### PR TITLE
Fast octree count

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: '-openmp-use-default-none'
+InheritParentConfig: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,13 @@ find_package(OpenMP REQUIRED)
 
 include(CTest)
 
-add_subdirectory(domain)
-
 if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
+    set(CMAKE_CUDA_ARCHITECTURES OFF)
     add_subdirectory(include)
 else()
     message(STATUS "No CUDA support")
 endif()
 
+add_subdirectory(domain)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,6 @@ find_package(MPI)
 find_package(CUDAToolkit)
 find_package(OpenMP REQUIRED)
 
-if(OpenMP_FOUND)
-    #set_property(TARGET OpenMP::OpenMP_CXX PROPERTY INTERFACE_LINK_LIBRARIES "${OpenMP_CXX_FLAGS}")
-    # CMake fails to properly link to OpenMP for cray-clang, see
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/21818#note_903985
-    #message(STATUS "setting openmp link library to " ${OpenMP_CXX_FLAGS})
-endif()
-
 include(CTest)
 
 set(default_build_type "Release")
@@ -26,13 +19,12 @@ endif()
 if(CUDAToolkit_FOUND)
     enable_language(CUDA)
 
-    # does nothing
     set(CMAKE_CUDA_STANDARD 17)
-    # workaround for CMAKE_CUDA_STANDARD not setting the required flag
-    add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-std=c++17>)
+    # use default nvcc cuda architectures
+    set(CMAKE_CUDA_ARCHITECTURES OFF)
 
     if(OpenMP_FOUND)
-        # another OpenMP workaround
+        # workaround for openmp+cuda objects
         #set(CMAKE_CUDA_FLAGS "-Xcompiler ${OpenMP_CXX_FLAGS} ${CMAKE_CUDA_FLAGS}")
     endif()
 

--- a/include/cstone/tree/octree.hpp
+++ b/include/cstone/tree/octree.hpp
@@ -100,7 +100,7 @@ unsigned calculateNodeCount(const I* tree, TreeNodeIndex nodeIdx, const I* codes
 /*! @brief determine search bound for @p targetCode in an array of sorted particle SFC codes
  *
  * @tparam I          32- or 64-bit unsigned integer type
- * @param firstIdx    first (of two) search boundary, permissible range: [0:codesEnd-codesStart-1]
+ * @param firstIdx    first (of two) search boundary, must be non-negative, but can exceed the codes range
  *                    (the guess for the location of @p targetCode in [codesStart:codesEnd]
  * @param targetCode  code in [codesStart:codesEnd] to look for
  * @param codesStart  particle SFC code array start
@@ -114,6 +114,9 @@ pair<const I*> findSearchBounds(std::make_signed_t<I> firstIdx, I targetCode,
 {
     using SI = std::make_signed_t<I>;
     SI nCodes = codesEnd - codesStart;
+
+    // firstIdx must be an accessible index
+    firstIdx = stl::min(nCodes-1, firstIdx);
 
     I firstCode = codesStart[firstIdx];
     if (firstCode == targetCode)

--- a/include/cstone/tree/octree.hpp
+++ b/include/cstone/tree/octree.hpp
@@ -216,11 +216,18 @@ void computeNodeCounts(const I* tree, unsigned* counts, TreeNodeIndex nNodes, co
     {
         exclusiveScan(counts + firstNode, nNonZeroNodes);
         #pragma omp parallel for schedule(static)
-        for (TreeNodeIndex i = 0; i < nNonZeroNodes; ++i)
+        for (TreeNodeIndex i = 0; i < nNonZeroNodes-1; ++i)
         {
-            counts[i + firstNode] = updateNodeCount(i, populatedTree, counts[i + firstNode], counts[std::min(i+1, nNonZeroNodes-1)],
+            unsigned firstGuess  = counts[i + firstNode];
+            unsigned secondGuess = counts[i + firstNode + 1];
+            counts[i + firstNode] = updateNodeCount(i, populatedTree, firstGuess, secondGuess,
                                                     codesStart, codesEnd, maxCount);
         }
+
+        TreeNodeIndex lastIdx = nNonZeroNodes-1;
+        unsigned lastGuess    = counts[lastIdx + firstNode];
+        counts[lastIdx + firstNode] = updateNodeCount(lastIdx, populatedTree, lastGuess, lastGuess,
+                                                      codesStart, codesEnd, maxCount);
     }
     else
     {

--- a/include/cstone/tree/octree.hpp
+++ b/include/cstone/tree/octree.hpp
@@ -218,14 +218,14 @@ void computeNodeCounts(const I* tree, unsigned* counts, TreeNodeIndex nNodes, co
         #pragma omp parallel for schedule(static)
         for (TreeNodeIndex i = 0; i < nNonZeroNodes-1; ++i)
         {
-            unsigned firstGuess  = counts[i + firstNode];
-            unsigned secondGuess = counts[i + firstNode + 1];
+            unsigned firstGuess   = counts[i + firstNode];
+            unsigned secondGuess  = counts[i + firstNode + 1];
             counts[i + firstNode] = updateNodeCount(i, populatedTree, firstGuess, secondGuess,
                                                     codesStart, codesEnd, maxCount);
         }
 
-        TreeNodeIndex lastIdx = nNonZeroNodes-1;
-        unsigned lastGuess    = counts[lastIdx + firstNode];
+        TreeNodeIndex lastIdx       = nNonZeroNodes-1;
+        unsigned lastGuess          = counts[lastIdx + firstNode];
         counts[lastIdx + firstNode] = updateNodeCount(lastIdx, populatedTree, lastGuess, lastGuess,
                                                       codesStart, codesEnd, maxCount);
     }

--- a/include/cstone/util.hpp
+++ b/include/cstone/util.hpp
@@ -105,6 +105,7 @@ template<class T>
 class pair
 {
 public:
+    pair() = default;
 
     CUDA_HOST_DEVICE_FUN
     pair(T first, T second) : data{first, second} {}

--- a/test/coord_samples/plummer.hpp
+++ b/test/coord_samples/plummer.hpp
@@ -1,8 +1,74 @@
-//
-// Created by sebkelle on 27.03.21.
-//
+/*! @file plummer distribution
 
-#ifndef CORNERSTONE_OCTREE_PLUMMER_HPP
-#define CORNERSTONE_OCTREE_PLUMMER_HPP
+    Adapted from: https://github.com/treecode/Bonsai/blob/master/runtime/include/plummer.h
+*/
 
-#endif // CORNERSTONE_OCTREE_PLUMMER_HPP
+#pragma once
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+#include <fstream>
+
+//! @brief returns a vector of @p n Plummer distributed 3D coordinates
+template<class T>
+std::array<std::vector<T>, 3> plummer(size_t n)
+{
+    srand48(42);
+
+    std::array<std::vector<T>, 3> pos;
+    pos[0].resize(n);
+    pos[1].resize(n);
+    pos[2].resize(n);
+
+    T conv = 3.0 * M_PI / 16.0;
+
+    size_t i = 0;
+    while(i < n)
+    {
+        T R = 1.0 / sqrt((pow(drand48(), -2.0 / 3.0) - 1.0));
+
+        if(R < 100.0)
+        {
+            T Z = (1.0 - 2.0 * drand48()) * R;
+            T theta = 2 * M_PI * drand48();
+            T X = sqrt(R*R - Z*Z) * cos(theta);
+            T Y = sqrt(R*R - Z*Z) * sin(theta);
+
+            X *= conv;
+            Y *= conv;
+            Z *= conv;
+
+            pos[0][i]= X;
+            pos[1][i]= Y;
+            pos[2][i]= Z;
+
+            i++;
+        }
+    }
+
+    T mcm  = 0.0;
+    T mass = T(1) / n;
+    T xcm[3] = {0,0,0};
+
+    for(i = 0; i < n; i++) {
+        mcm += mass;
+        for(int k = 0; k < 3; k++) {
+            xcm[k] += mass * pos[k][i];
+        }
+    }
+
+    for(int k = 0; k < 3; k++) {
+        xcm[k] /= mcm;
+    }
+
+    for(i = 0; i < n; i++) {
+        for(int k = 0; k < 3; k++) {
+            pos[k][i] -= xcm[k];
+        }
+    }
+
+    return pos;
+}

--- a/test/performance/octree.cpp
+++ b/test/performance/octree.cpp
@@ -59,9 +59,7 @@ build_tree(const I* firstCode, const I* lastCode, unsigned bucketSize)
               << " count: " << std::accumulate(begin(counts), end(counts), 0lu) << std::endl;
 
     tp0  = std::chrono::high_resolution_clock::now();
-    std::tie(tree, counts) = computeOctree(firstCode, lastCode, bucketSize,
-                                           std::numeric_limits<unsigned>::max(),
-                                           std::move(tree));
+    updateOctree(firstCode, lastCode, bucketSize, tree, counts, std::numeric_limits<unsigned>::max());
     tp1  = std::chrono::high_resolution_clock::now();
 
     double t1 = std::chrono::duration<double>(tp1 - tp0).count();
@@ -71,7 +69,7 @@ build_tree(const I* firstCode, const I* lastCode, unsigned bucketSize)
               << " count: " << std::accumulate(begin(counts), end(counts), 0lu)
               << " empty nodes: " << nEmptyNodes << std::endl;
 
-    return std::make_tuple(tree, counts);
+    return std::make_tuple(std::move(tree), std::move(counts));
 }
 
 template<class I>
@@ -94,7 +92,7 @@ void halo_discovery(Box<double> box, const std::vector<I>& tree, const std::vect
 
 int main()
 {
-    using CodeType = unsigned;
+    using CodeType = uint64_t;
     Box<double> box{-1, 1};
 
     int nParticles = 2000000;

--- a/test/performance/octree.cu
+++ b/test/performance/octree.cu
@@ -45,8 +45,8 @@ int main()
     using CodeType = unsigned;
     Box<double> box{-1, 1};
 
-    int nParticles = 8000000;
-    int bucketSize = 10;
+    int nParticles = 2000000;
+    int bucketSize = 16;
 
     RandomGaussianCoordinates<double, CodeType> randomBox(nParticles, box);
 
@@ -71,10 +71,9 @@ int main()
 
     tp0  = std::chrono::high_resolution_clock::now();
 
-    computeOctreeGpu(thrust::raw_pointer_cast(particleCodes.data()),
-                     thrust::raw_pointer_cast(particleCodes.data() + nParticles),
-                     bucketSize,
-                     tree, counts);
+    updateOctreeGpu(thrust::raw_pointer_cast(particleCodes.data()),
+                    thrust::raw_pointer_cast(particleCodes.data() + nParticles),
+                    bucketSize, tree, counts);
 
     tp1  = std::chrono::high_resolution_clock::now();
 

--- a/test/performance/octree.cu
+++ b/test/performance/octree.cu
@@ -29,13 +29,11 @@
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
-#include <chrono>
 #include <iostream>
 
 #include <thrust/reduce.h>
 
 #include "cstone/tree/octree.cuh"
-
 #include "coord_samples/random.hpp"
 
 using namespace cstone;
@@ -75,11 +73,14 @@ int main()
     std::cout << "build time from scratch " << t0/1000 << " nNodes(tree): " << nNodes(tree)
               << " count: " << thrust::reduce(counts.begin(), counts.end(), 0) << std::endl;
 
+    thrust::device_vector<CodeType>      tmpTree(tree.size());
+    thrust::device_vector<TreeNodeIndex> workArray(tree.size());
+
     cudaEventRecord(start, cudaStreamDefault);
 
     updateOctreeGpu(thrust::raw_pointer_cast(particleCodes.data()),
                     thrust::raw_pointer_cast(particleCodes.data() + nParticles),
-                    bucketSize, tree, counts);
+                    bucketSize, tree, counts, tmpTree, workArray);
 
     cudaEventRecord(stop, cudaStreamDefault);
     cudaEventSynchronize(stop);

--- a/test/performance/octree.cu
+++ b/test/performance/octree.cu
@@ -48,6 +48,10 @@ int main()
     int nParticles = 2000000;
     int bucketSize = 16;
 
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
     RandomGaussianCoordinates<double, CodeType> randomBox(nParticles, box);
 
     thrust::device_vector<CodeType> tree;
@@ -56,29 +60,35 @@ int main()
     thrust::device_vector<CodeType> particleCodes(randomBox.mortonCodes().begin(),
                                                   randomBox.mortonCodes().end());
 
-    auto tp0 = std::chrono::high_resolution_clock::now();
+    cudaEventRecord(start, cudaStreamDefault);
 
     computeOctreeGpu(thrust::raw_pointer_cast(particleCodes.data()),
                      thrust::raw_pointer_cast(particleCodes.data() + nParticles),
                      bucketSize,
                      tree, counts);
 
-    auto tp1  = std::chrono::high_resolution_clock::now();
+    cudaEventRecord(stop, cudaStreamDefault);
+    cudaEventSynchronize(stop);
 
-    double t0 = std::chrono::duration<double>(tp1 - tp0).count();
-    std::cout << "build time from scratch " << t0 << " nNodes(tree): " << nNodes(tree)
+    float t0;
+    cudaEventElapsedTime(&t0, start, stop);
+    std::cout << "build time from scratch " << t0/1000 << " nNodes(tree): " << nNodes(tree)
               << " count: " << thrust::reduce(counts.begin(), counts.end(), 0) << std::endl;
 
-    tp0  = std::chrono::high_resolution_clock::now();
+    cudaEventRecord(start, cudaStreamDefault);
 
     updateOctreeGpu(thrust::raw_pointer_cast(particleCodes.data()),
                     thrust::raw_pointer_cast(particleCodes.data() + nParticles),
                     bucketSize, tree, counts);
 
-    tp1  = std::chrono::high_resolution_clock::now();
+    cudaEventRecord(stop, cudaStreamDefault);
+    cudaEventSynchronize(stop);
 
-    double t1 = std::chrono::duration<double>(tp1 - tp0).count();
-
-    std::cout << "build time with guess " << t1 << " nNodes(tree): " << nNodes(tree)
+    float t1;
+    cudaEventElapsedTime(&t1, start, stop);
+    std::cout << "build time with guess " << t1/1000 << " nNodes(tree): " << nNodes(tree)
               << " count: " << thrust::reduce(counts.begin(), counts.end(), 0) << std::endl;
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
 }

--- a/test/unit/tree/octree.cpp
+++ b/test/unit/tree/octree.cpp
@@ -149,7 +149,8 @@ void checkCountTreeNodes()
 
     std::vector<unsigned> counts(nNodes(tree));
     computeNodeCounts(tree.data(), counts.data(), nNodes(tree),
-                      codes.data(), codes.data() + codes.size());
+                      codes.data(), codes.data() + codes.size(),
+                      std::numeric_limits<unsigned>::max());
 
     EXPECT_EQ(counts, reference);
 }
@@ -162,43 +163,6 @@ TEST(CornerstoneOctree, countTreeNodes32)
 TEST(CornerstoneOctree, countTreeNodes64)
 {
     checkCountTreeNodes<uint64_t>();
-}
-
-//! @brief Regression test case: make sure that the 2nd guess is not out of bounds
-template<class CodeType>
-void checkCountTreeNodesRangeEnd()
-{
-    std::vector<CodeType> tree = OctreeMaker<CodeType>{}.divide().makeTree();
-
-    std::vector<CodeType> codes;
-    codes.push_back(0);
-    for (int i = 0; i < 16; ++i)
-    {
-        codes.push_back(tree[6] + i);
-    }
-    codes.push_back(tree[7]);
-
-    //  nodeIdx                     0  1  2  3  4  5   6   7
-    std::vector<unsigned> reference{1, 0, 0, 0, 0, 0, 16,  1};
-    // code start location          0, 1, 1, 1, 1, 1,  1, 17
-    // guess start location         0  2  4  6  8 10  12  14
-    // Ntot: 18, nNonZeroNodes: 8, avgNodeCount: 18/8 = 2
-
-    std::vector<unsigned> counts(nNodes(tree));
-    computeNodeCounts(tree.data(), counts.data(), nNodes(tree),
-                      codes.data(), codes.data() + codes.size());
-
-    EXPECT_EQ(counts, reference);
-}
-
-TEST(CornerstoneOctree, countTreeNodesRangeEnd32)
-{
-    checkCountTreeNodesRangeEnd<unsigned>();
-}
-
-TEST(CornerstoneOctree, countTreeNodesRangeEnd64)
-{
-    checkCountTreeNodesRangeEnd<uint64_t>();
 }
 
 template<class CodeType, class LocalIndex>
@@ -555,7 +519,8 @@ TEST(CornerstoneOctree, nodeMaxRegression)
 
     {
         std::vector<unsigned> countsProbe(nNodes(tree));
-        computeNodeCounts(tree.data(), countsProbe.data(), nNodes(tree), codes.data(), codes.data() + codes.size());
+        computeNodeCounts(tree.data(), countsProbe.data(), nNodes(tree), codes.data(), codes.data() + codes.size(),
+                          std::numeric_limits<unsigned>::max());
         EXPECT_EQ(nodeCounts, countsProbe);
     }
 

--- a/test/unit/tree/octree.cpp
+++ b/test/unit/tree/octree.cpp
@@ -38,51 +38,95 @@
 
 using namespace cstone;
 
-template<class CodeType>
-void findSearchBounds()
+TEST(CornerstoneOctree, findSearchBounds)
 {
-    std::vector<CodeType> tree = OctreeMaker<CodeType>{}.divide().divide(0).makeTree();
+    using CodeType = unsigned;
 
-    std::vector<CodeType> codes{tree[1], tree[1], tree[1] + 10, tree[1] + 100, tree[2] - 1,
-                                tree[2] + 1,
-                                tree[11], tree[11] + 2,
-                                tree[12], tree[12] + 1000, tree[12] + 2000, tree[13] - 10,
-                                tree[13], tree[13] + 1};
-
+    //                          0   1   2   3   4   5   6   7   8   9
+    std::vector<CodeType> codes{3, 10, 11, 14, 16, 16, 16, 18, 19, 21};
     const CodeType* c = codes.data();
-    std::vector<pair<const CodeType*>> reference{
-        {c+0,c+2}, {c+1,c+5}, {c+2,c+6}, {c+3,c+7}, {c+4,c+6}, {c+5,c+7}, {c+4,c+6}, {c+5,c+7},
-        {c+4,c+8}, {c+5,c+9}, {c+6,c+10}, {c+7,c+11}, {c+12,c+14}
-    };
 
-    //  nodeIdx                    0  1  2  3  4  5  6  7  8  9 10 11 12 13 14
-    //  counts                     0  5  1  0  0  0  0  0  0  0  0  2  4  2  0};
-    // code start location            0  5  6  6  6  6  6  6  6  6  6  8 12
-    // guess start location           0  1  2  3  4  5  6  7  8  9 10 11 12
-    // Ntot: 14, nNonZeroNodes: 13, avgNodeCount: 14/13 = 1
-
-    // first and last nodes are empty, effective number of nodes is nNodes(tree) - 2
-    // nNodes(tree) - 2  corresponds to nNonZeroNodes = lastNode - firstNode in computeNodeCounts
-    unsigned avgNodeCount = codes.size() / (nNodes(tree) - 2);
-    std::vector<pair<const CodeType*>> searchBounds(nNodes(tree) - 2);
-
-    for (int i = 0; i < nNodes(tree)-2; ++i)
     {
-        TreeNodeIndex guess  = i * avgNodeCount;
-        searchBounds[i] = findSearchBounds(guess, tree[i+1], codes.data(), codes.data() + codes.size());
+        // upward search direction, guess distance from target: 0
+        int guess = 3;
+        auto probe = findSearchBounds(guess, CodeType(14), c, c + codes.size());
+        pair<const CodeType*> reference{c+2, c+4};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // upward search direction, guess distance from target: 1
+        int guess = 3;
+        auto probe = findSearchBounds(guess, CodeType(15), c, c + codes.size());
+        pair<const CodeType*> reference{c+3, c+4};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // upward search direction, guess distance from target: 1
+        int guess = 3;
+        auto probe = findSearchBounds(guess, CodeType(16), c, c + codes.size());
+        pair<const CodeType*> reference{c+3, c+7};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // upward search direction, guess distance from target: 6
+        int guess = 0;
+        auto probe = findSearchBounds(guess, CodeType(17), c, c + codes.size());
+        pair<const CodeType*> reference{c+0, c+8};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // downward search direction
+        int guess = 4;
+        auto probe = findSearchBounds(guess, CodeType(12), c, c + codes.size());
+        pair<const CodeType*> reference{c+2, c+4};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // downward search direction
+        int guess = 4;
+        auto probe = findSearchBounds(guess, CodeType(11), c, c + codes.size());
+        pair<const CodeType*> reference{c+0, c+4};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // downward search direction
+        int guess = 4;
+        auto probe = findSearchBounds(guess, CodeType(10), c, c + codes.size());
+        pair<const CodeType*> reference{c+0, c+4};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // downward search direction
+        int guess = 8;
+        auto probe = findSearchBounds(guess, CodeType(16), c, c + codes.size());
+        pair<const CodeType*> reference{c+0, c+8};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // downward search direction
+        int guess = 6;
+        auto probe = findSearchBounds(guess, CodeType(16), c, c + codes.size());
+        pair<const CodeType*> reference{c+3, c+7};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
+    {
+        // direct hit on the last element
+        int guess = 9;
+        auto probe = findSearchBounds(guess, CodeType(21), c, c + codes.size());
+        pair<const CodeType*> reference{c+8, c+10};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
     }
 
-    EXPECT_EQ(searchBounds, reference);
-}
-
-TEST(CornerstoneOctree, findSearchBounds32)
-{
-    findSearchBounds<unsigned>();
-}
-
-TEST(CornerstoneOctree, findSearchBounds64)
-{
-    findSearchBounds<uint64_t>();
 }
 
 //! @brief test that computeNodeCounts correctly counts the number of codes for each node

--- a/test/unit/tree/octree.cpp
+++ b/test/unit/tree/octree.cpp
@@ -38,6 +38,53 @@
 
 using namespace cstone;
 
+template<class CodeType>
+void findSearchBounds()
+{
+    std::vector<CodeType> tree = OctreeMaker<CodeType>{}.divide().divide(0).makeTree();
+
+    std::vector<CodeType> codes{tree[1], tree[1], tree[1] + 10, tree[1] + 100, tree[2] - 1,
+                                tree[2] + 1,
+                                tree[11], tree[11] + 2,
+                                tree[12], tree[12] + 1000, tree[12] + 2000, tree[13] - 10,
+                                tree[13], tree[13] + 1};
+
+    const CodeType* c = codes.data();
+    std::vector<pair<const CodeType*>> reference{
+        {c+0,c+2}, {c+1,c+5}, {c+2,c+6}, {c+3,c+7}, {c+4,c+6}, {c+5,c+7}, {c+4,c+6}, {c+5,c+7},
+        {c+4,c+8}, {c+5,c+9}, {c+6,c+10}, {c+7,c+11}, {c+12,c+14}
+    };
+
+    //  nodeIdx                    0  1  2  3  4  5  6  7  8  9 10 11 12 13 14
+    //  counts                     0  5  1  0  0  0  0  0  0  0  0  2  4  2  0};
+    // code start location            0  5  6  6  6  6  6  6  6  6  6  8 12
+    // guess start location           0  1  2  3  4  5  6  7  8  9 10 11 12
+    // Ntot: 14, nNonZeroNodes: 13, avgNodeCount: 14/13 = 1
+
+    // first and last nodes are empty, effective number of nodes is nNodes(tree) - 2
+    // nNodes(tree) - 2  corresponds to nNonZeroNodes = lastNode - firstNode in computeNodeCounts
+    unsigned avgNodeCount = codes.size() / (nNodes(tree) - 2);
+    std::vector<pair<const CodeType*>> searchBounds(nNodes(tree) - 2);
+
+    for (int i = 0; i < nNodes(tree)-2; ++i)
+    {
+        TreeNodeIndex guess  = i * avgNodeCount;
+        searchBounds[i] = findSearchBounds(guess, tree[i+1], codes.data(), codes.data() + codes.size());
+    }
+
+    EXPECT_EQ(searchBounds, reference);
+}
+
+TEST(CornerstoneOctree, findSearchBounds32)
+{
+    findSearchBounds<unsigned>();
+}
+
+TEST(CornerstoneOctree, findSearchBounds64)
+{
+    findSearchBounds<uint64_t>();
+}
+
 //! @brief test that computeNodeCounts correctly counts the number of codes for each node
 template<class CodeType>
 void checkCountTreeNodes()
@@ -71,6 +118,43 @@ TEST(CornerstoneOctree, countTreeNodes32)
 TEST(CornerstoneOctree, countTreeNodes64)
 {
     checkCountTreeNodes<uint64_t>();
+}
+
+//! @brief Regression test case: make sure that the 2nd guess is not out of bounds
+template<class CodeType>
+void checkCountTreeNodesRangeEnd()
+{
+    std::vector<CodeType> tree = OctreeMaker<CodeType>{}.divide().makeTree();
+
+    std::vector<CodeType> codes;
+    codes.push_back(0);
+    for (int i = 0; i < 16; ++i)
+    {
+        codes.push_back(tree[6] + i);
+    }
+    codes.push_back(tree[7]);
+
+    //  nodeIdx                     0  1  2  3  4  5   6   7
+    std::vector<unsigned> reference{1, 0, 0, 0, 0, 0, 16,  1};
+    // code start location          0, 1, 1, 1, 1, 1,  1, 17
+    // guess start location         0  2  4  6  8 10  12  14
+    // Ntot: 18, nNonZeroNodes: 8, avgNodeCount: 18/8 = 2
+
+    std::vector<unsigned> counts(nNodes(tree));
+    computeNodeCounts(tree.data(), counts.data(), nNodes(tree),
+                      codes.data(), codes.data() + codes.size());
+
+    EXPECT_EQ(counts, reference);
+}
+
+TEST(CornerstoneOctree, countTreeNodesRangeEnd32)
+{
+    checkCountTreeNodesRangeEnd<unsigned>();
+}
+
+TEST(CornerstoneOctree, countTreeNodesRangeEnd64)
+{
+    checkCountTreeNodesRangeEnd<uint64_t>();
 }
 
 template<class CodeType, class LocalIndex>

--- a/test/unit/tree/octree.cpp
+++ b/test/unit/tree/octree.cpp
@@ -457,12 +457,7 @@ public:
         CoordinateType<double, CodeType> randomBox(nParticles, box);
         std::vector<CodeType> codes = randomBox.mortonCodes();
 
-        // compute octree starting from default uniform octree
-        auto [tree, counts] = computeOctree(codes.data(),
-                                            codes.data() + nParticles,
-                                            bucketSize);
-
-        std::cout << "number of nodes: " << nNodes(tree) << std::endl;
+        auto [tree, counts] = computeOctree(codes.data(), codes.data() + nParticles, bucketSize);
 
         checkOctreeWithCounts(tree, counts, bucketSize, codes, false);
 

--- a/test/unit/tree/octree.cpp
+++ b/test/unit/tree/octree.cpp
@@ -126,6 +126,14 @@ TEST(CornerstoneOctree, findSearchBounds)
         EXPECT_EQ(probe[0]-c, reference[0]-c);
         EXPECT_EQ(probe[1]-c, reference[1]-c);
     }
+    {
+        // must be able to handle out-of-bounds guess
+        int guess = 12;
+        auto probe = findSearchBounds(guess, CodeType(16), c, c + codes.size());
+        pair<const CodeType*> reference{c+1, c+9};
+        EXPECT_EQ(probe[0]-c, reference[0]-c);
+        EXPECT_EQ(probe[1]-c, reference[1]-c);
+    }
 
 }
 

--- a/test/unit_cuda/octree.cu
+++ b/test/unit_cuda/octree.cu
@@ -66,7 +66,8 @@ TEST(OctreeGpu, computeNodeCountsKernel)
     constexpr unsigned nThreads = 512;
     computeNodeCountsKernel<<<iceil(nNodes(d_cstree), nThreads), nThreads>>>(
         thrust::raw_pointer_cast(d_cstree.data()), thrust::raw_pointer_cast(d_counts.data()), nNodes(d_cstree),
-        thrust::raw_pointer_cast(d_codes.data()), thrust::raw_pointer_cast(d_codes.data() + d_codes.size()));
+        thrust::raw_pointer_cast(d_codes.data()), thrust::raw_pointer_cast(d_codes.data() + d_codes.size()),
+        std::numeric_limits<unsigned>::max());
 
     // download counts from device
     thrust::host_vector<unsigned> h_counts = d_counts;
@@ -120,7 +121,8 @@ TEST(OctreeGpu, computeNodeCountsGpu)
     }
 
     computeNodeCountsGpu(thrust::raw_pointer_cast(d_cstree.data()), thrust::raw_pointer_cast(d_counts.data()), nNodes(d_cstree),
-                         thrust::raw_pointer_cast(d_codes.data()), thrust::raw_pointer_cast(d_codes.data() + d_codes.size()));
+                         thrust::raw_pointer_cast(d_codes.data()), thrust::raw_pointer_cast(d_codes.data() + d_codes.size()),
+                         std::numeric_limits<unsigned>::max());
 
     // download counts from device
     thrust::host_vector<unsigned> h_counts = d_counts;
@@ -150,7 +152,6 @@ TEST(OctreeGpu, rebalanceDecision)
     d_counts[9] = 2;
 
     unsigned bucketSize = 1;
-    thrust::device_vector<int> convergenceFlag(1, 0);
 
     thrust::device_vector<TreeNodeIndex> d_nodeOps(d_counts.size());
     constexpr unsigned nThreads = 512;
@@ -160,8 +161,7 @@ TEST(OctreeGpu, rebalanceDecision)
             thrust::raw_pointer_cast(d_counts.data()),
             nNodes(d_cstree),
             bucketSize,
-            thrust::raw_pointer_cast(d_nodeOps.data()),
-            thrust::raw_pointer_cast(convergenceFlag.data())
+            thrust::raw_pointer_cast(d_nodeOps.data())
     );
 
     // download result from device
@@ -172,8 +172,10 @@ TEST(OctreeGpu, rebalanceDecision)
         reference[i] = 0; // merge
     reference[9] = 8; // fuse
 
+    int changeCounter = 0;
+    cudaMemcpyFromSymbol(&changeCounter, rebalanceChangeCounter, sizeof(int));
     EXPECT_EQ(h_nodeOps, reference);
-    EXPECT_NE(0, convergenceFlag[0]);
+    EXPECT_NE(0, changeCounter);
 }
 
 TEST(OctreeGpu, rebalanceTree)

--- a/test/unit_cuda/octree.cu
+++ b/test/unit_cuda/octree.cu
@@ -185,12 +185,15 @@ TEST(OctreeGpu, rebalanceTree)
 
     thrust::device_vector<CodeType> tree = OctreeMaker<CodeType>{}.divide().divide(7).makeTree();
 
+    thrust::device_vector<CodeType>      tmpTree;
+    thrust::device_vector<TreeNodeIndex> workArray;
+
     // nodes {7,i} will need to be fused
     thrust::device_vector<unsigned> counts(nNodes(tree), 1);
     // node {1} will need to be split
     counts[1] = bucketSize+1;
 
-    rebalanceTreeGpu(tree, thrust::raw_pointer_cast(counts.data()), nNodes(tree), bucketSize);
+    rebalanceTreeGpu(tree, thrust::raw_pointer_cast(counts.data()), bucketSize, tmpTree, workArray);
 
     // download tree from host
     thrust::host_vector<CodeType> h_tree = tree;


### PR DESCRIPTION
Uses a prefix scan of the previous counts as start guess for the binary search.
Reduces formal scaling from NlogN to N.