### PR TITLE
Neighbor opt cuda

### DIFF
--- a/include/sph/IAD.hpp
+++ b/include/sph/IAD.hpp
@@ -75,7 +75,8 @@ void computeIADImpl(const Task& t, Dataset& d, const cstone::Box<T>& box)
 #endif
     for (size_t pi = 0; pi < n; ++pi)
     {
-        kernels::IADJLoop(pi, sincIndex, K, ngmax, box, clist, neighbors, neighborsCount,
+        int i = clist[pi];
+        kernels::IADJLoop(i, sincIndex, K, box, neighbors + ngmax * pi, neighborsCount[pi],
                           x, y, z, h, m, ro, wh, whd, c11, c12, c13, c22, c23, c33);
     }
 }

--- a/include/sph/cuda/cudaDensity.cu
+++ b/include/sph/cuda/cudaDensity.cu
@@ -112,3 +112,4 @@ template void computeDensity(std::vector<Task>&, ParticlesData<double, uint64_t>
 } // namespace cuda
 } // namespace sph
 } // namespace sphexa
+

--- a/include/sph/cuda/cudaDensity.cu
+++ b/include/sph/cuda/cudaDensity.cu
@@ -22,9 +22,9 @@ __global__ void density(int n, T sincIndex, T K, int ngmax, cstone::Box<T> box, 
     unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid >= n) return;
 
-    // computes ro[clist[tid]]
-    sph::kernels::densityJLoop(tid, sincIndex, K, ngmax, box, clist, neighbors, neighborsCount,
-                               x, y, z, h, m, wh, whd, ro);
+    int i = clist[tid];
+    ro[i] = sph::kernels::densityJLoop(
+        i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid], x, y, z, h, m, wh, whd);
 }
 
 template<class Dataset>

--- a/include/sph/cuda/cudaDensity.cu
+++ b/include/sph/cuda/cudaDensity.cu
@@ -14,25 +14,30 @@ namespace sph
 namespace cuda
 {
 
-template<class T/*, class KeyType*/>
-__global__ void density(int n, T sincIndex, T K, int ngmax, cstone::Box<T> box, const int* clist,
-                        const int* neighbors, const int* neighborsCount,
-                        //const KeyType* particleKeys, int numKeys,
+template<class T, class KeyType>
+__global__ void density(T sincIndex, T K, int ngmax, cstone::Box<T> box,
+                        int firstParticle, int lastParticle, int numParticles, const KeyType* particleKeys,
+                        int* neighborsCount,
                         const T* x, const T* y, const T* z, const T* h, const T* m, const T* wh, const T* whd, T* ro)
 {
     unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
-    if (tid >= n) return;
+    unsigned i = tid + firstParticle;
+    if (i >= lastParticle) return;
 
-    //int nLoc[150];
-    //int nCount;
+    // need to hard-code ngmax stack allocation for now
+    assert(ngmax <= NGMAX && "ngmax too big, please increase NGMAX to desired value");
+    int neighbors[NGMAX];
+    int neighborsCount_;
 
-    int i = clist[tid];
+    // starting from CUDA 11.3, dynamic stack allocation is available with the following command
+    // int* neighbors = (int*)alloca(ngmax * sizeof(int));
 
-    //cstone::findNeighbors(i, x, y ,z, h, box, cstone::sfcKindPointer(particleKeys), nLoc, &nCount, numKeys, ngmax);
+    cstone::findNeighbors(
+        i, x, y, z, h, box, cstone::sfcKindPointer(particleKeys), neighbors, &neighborsCount_, numParticles, ngmax);
 
-    //ro[i] = sph::kernels::densityJLoop(i, sincIndex, K, box, nLoc, nCount, x, y, z, h, m, wh, whd);
-    ro[i] = sph::kernels::densityJLoop(
-        i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid], x, y, z, h, m, wh, whd);
+    ro[i] = sph::kernels::densityJLoop(i, sincIndex, K, box, neighbors, neighborsCount_, x, y, z, h, m, wh, whd);
+
+    neighborsCount[tid] = neighborsCount_;
 }
 
 template<class Dataset>
@@ -40,9 +45,10 @@ void computeDensity(std::vector<Task>& taskList, Dataset& d, const cstone::Box<d
 {
     using T = typename Dataset::RealType;
 
-    size_t np = d.x.size();
-    size_t size_np_T = np * sizeof(T);
-    size_t size_np_CodeType = np * sizeof(typename Dataset::KeyType);
+    size_t numParticles = d.x.size();
+
+    size_t size_np_T = numParticles * sizeof(T);
+    size_t size_np_CodeType = numParticles * sizeof(typename Dataset::KeyType);
     T ngmax = taskList.empty() ? 0 : taskList.front().ngmax;
 
     auto largestChunkSize =
@@ -57,14 +63,14 @@ void computeDensity(std::vector<Task>& taskList, Dataset& d, const cstone::Box<d
 
     size_t ltsize = d.wh.size();
     size_t size_lt_T = ltsize * sizeof(T);
+    CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_wh, d.wh.data(), size_lt_T, cudaMemcpyHostToDevice));
+    CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_whd, d.whd.data(), size_lt_T, cudaMemcpyHostToDevice));
 
     CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_x, d.x.data(), size_np_T, cudaMemcpyHostToDevice));
     CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_y, d.y.data(), size_np_T, cudaMemcpyHostToDevice));
     CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_z, d.z.data(), size_np_T, cudaMemcpyHostToDevice));
     CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_h, d.h.data(), size_np_T, cudaMemcpyHostToDevice));
     CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_m, d.m.data(), size_np_T, cudaMemcpyHostToDevice));
-    CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_wh, d.wh.data(), size_lt_T, cudaMemcpyHostToDevice));
-    CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_whd, d.whd.data(), size_lt_T, cudaMemcpyHostToDevice));
 
     CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_codes, d.codes.data(), size_np_CodeType, cudaMemcpyHostToDevice));
 
@@ -75,32 +81,24 @@ void computeDensity(std::vector<Task>& taskList, Dataset& d, const cstone::Box<d
         int sIdx = i % NST;
         cudaStream_t stream = d.devPtrs.d_stream[sIdx].stream;
 
-        int* d_clist_use = d.devPtrs.d_stream[sIdx].d_clist;
-        int* d_neighbors_use = d.devPtrs.d_stream[sIdx].d_neighbors;
         int* d_neighborsCount_use = d.devPtrs.d_stream[sIdx].d_neighborsCount;
 
-        size_t n = t.clist.size();
-        size_t size_n_int = n * sizeof(int);
-
-        CHECK_CUDA_ERR(cudaMemcpyAsync(d_clist_use, t.clist.data(), size_n_int, cudaMemcpyHostToDevice, stream));
-
-        findNeighborsHilbertGpu(d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h,
-                                t.clist[0], t.clist[n - 1] + 1, np, box, d.devPtrs.d_codes,
-                                d_neighbors_use, d_neighborsCount_use, ngmax, stream);
-        CHECK_CUDA_ERR(cudaGetLastError());
+        unsigned firstParticle = t.clist.front();
+        unsigned lastParticle  = t.clist.back() + 1;
+        unsigned numParticlesCompute = lastParticle - firstParticle;
 
         unsigned numThreads = 256;
-        unsigned numBlocks  = (n + numThreads - 1) / numThreads;
+        unsigned numBlocks  = (numParticlesCompute + numThreads - 1) / numThreads;
 
         density<<<numBlocks, numThreads, 0, stream>>>(
-            n, d.sincIndex, d.K, t.ngmax, box, d_clist_use, d_neighbors_use, d_neighborsCount_use,
-            //d.devPtrs.d_codes, np,
+            d.sincIndex, d.K, t.ngmax, box,
+            firstParticle, lastParticle, numParticles, d.devPtrs.d_codes, d_neighborsCount_use,
             d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h, d.devPtrs.d_m, d.devPtrs.d_wh, d.devPtrs.d_whd,
             d.devPtrs.d_ro);
         CHECK_CUDA_ERR(cudaGetLastError());
 
         CHECK_CUDA_ERR(cudaMemcpyAsync(t.neighborsCount.data(), d_neighborsCount_use,
-                                       size_n_int, cudaMemcpyDeviceToHost, stream));
+                                       numParticlesCompute * sizeof(int), cudaMemcpyDeviceToHost, stream));
     }
 
     // Memcpy in default stream synchronizes all other streams

--- a/include/sph/cuda/cudaDensity.cu
+++ b/include/sph/cuda/cudaDensity.cu
@@ -14,17 +14,25 @@ namespace sph
 namespace cuda
 {
 
-template<class T>
+template<class T, class KeyType>
 __global__ void density(int n, T sincIndex, T K, int ngmax, cstone::Box<T> box, const int* clist,
                         const int* neighbors, const int* neighborsCount,
+                        const KeyType* particleKeys, int numKeys,
                         const T* x, const T* y, const T* z, const T* h, const T* m, const T* wh, const T* whd, T* ro)
 {
     unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid >= n) return;
 
+    int nLoc[150];
+    int nCount;
+
     int i = clist[tid];
-    ro[i] = sph::kernels::densityJLoop(
-        i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid], x, y, z, h, m, wh, whd);
+
+    cstone::findNeighbors(i, x, y ,z, h, box, cstone::sfcKindPointer(particleKeys), nLoc, &nCount, numKeys, ngmax);
+
+    ro[i] = sph::kernels::densityJLoop(i, sincIndex, K, box, nLoc, nCount, x, y, z, h, m, wh, whd);
+    //ro[i] = sph::kernels::densityJLoop(
+    //    i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid], x, y, z, h, m, wh, whd);
 }
 
 template<class Dataset>
@@ -76,16 +84,17 @@ void computeDensity(std::vector<Task>& taskList, Dataset& d, const cstone::Box<d
 
         CHECK_CUDA_ERR(cudaMemcpyAsync(d_clist_use, t.clist.data(), size_n_int, cudaMemcpyHostToDevice, stream));
 
-        findNeighborsHilbertGpu(d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h,
-                                t.clist[0], t.clist[n - 1] + 1, np, box, d.devPtrs.d_codes,
-                                d_neighbors_use, d_neighborsCount_use, ngmax, stream);
-        CHECK_CUDA_ERR(cudaGetLastError());
+        //findNeighborsHilbertGpu(d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h,
+        //                        t.clist[0], t.clist[n - 1] + 1, np, box, d.devPtrs.d_codes,
+        //                        d_neighbors_use, d_neighborsCount_use, ngmax, stream);
+        //CHECK_CUDA_ERR(cudaGetLastError());
 
         unsigned numThreads = 256;
         unsigned numBlocks  = (n + numThreads - 1) / numThreads;
 
         density<<<numBlocks, numThreads, 0, stream>>>(
             n, d.sincIndex, d.K, t.ngmax, box, d_clist_use, d_neighbors_use, d_neighborsCount_use,
+            d.devPtrs.d_codes, np,
             d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h, d.devPtrs.d_m, d.devPtrs.d_wh, d.devPtrs.d_whd,
             d.devPtrs.d_ro);
         CHECK_CUDA_ERR(cudaGetLastError());

--- a/include/sph/cuda/cudaIAD.cu
+++ b/include/sph/cuda/cudaIAD.cu
@@ -14,18 +14,35 @@ namespace sph
 namespace cuda
 {
 
-template<class T>
+template<class T, class KeyType>
 __global__ void computeIAD(int n, T sincIndex, T K, int ngmax, cstone::Box<T> box, const int* clist,
-                           const int* neighbors, const int* neighborsCount,
+                           //const int* neighbors, const int* neighborsCount,
+                           const KeyType* particleKeys, int numKeys,
                            const T* x, const T* y, const T* z, const T* h, const T* m, const T* ro,
                            const T* wh, const T* whd, T* c11, T* c12, T* c13, T* c22, T* c23, T* c33)
 {
     const unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid >= n) return;
 
+    // need to hard-code ngmax stack allocation for now
+    assert(ngmax <= NGMAX && "ngmax too big, please adjust allocation size here to desired value of ngmax");
+    int neighbors[NGMAX];
+
+    // starting from CUDA 11.3, dynamic stack allocation is available with the following command
+    // int* neighbors = (int*)alloca(ngmax * sizeof(int));
+
+    int neighborsCount;
+
     int i = clist[tid];
-    sph::kernels::IADJLoop(i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid],
-                           x, y, z, h, m, ro, wh, whd, c11, c12, c13, c22, c23, c33);
+
+    cstone::findNeighbors(
+        i, x, y, z, h, box, cstone::sfcKindPointer(particleKeys), neighbors, &neighborsCount, numKeys, ngmax);
+
+    sph::kernels::IADJLoop(
+        i, sincIndex, K, box, neighbors, neighborsCount, x, y, z, h, m, ro, wh, whd, c11, c12, c13, c22, c23, c33);
+
+    // sph::kernels::IADJLoop(i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid],
+    //                        x, y, z, h, m, ro, wh, whd, c11, c12, c13, c22, c23, c33);
 }
 
 template <class Dataset>
@@ -35,8 +52,6 @@ void computeIAD(const std::vector<Task>& taskList, Dataset& d, const cstone::Box
     size_t np = d.x.size();
     size_t size_np_T = np * sizeof(T);
     T ngmax = taskList.empty() ? 0 : taskList.front().ngmax;
-
-    size_t ltsize = d.wh.size();
 
     auto largestChunkSize =
         std::max_element(taskList.cbegin(), taskList.cend(),
@@ -58,24 +73,26 @@ void computeIAD(const std::vector<Task>& taskList, Dataset& d, const cstone::Box
         cudaStream_t stream = d.devPtrs.d_stream[sIdx].stream;
 
         int *d_clist_use = d.devPtrs.d_stream[sIdx].d_clist;
-        int *d_neighbors_use = d.devPtrs.d_stream[sIdx].d_neighbors;
-        int *d_neighborsCount_use = d.devPtrs.d_stream[sIdx].d_neighborsCount;
+        //int *d_neighbors_use = d.devPtrs.d_stream[sIdx].d_neighbors;
+        //int *d_neighborsCount_use = d.devPtrs.d_stream[sIdx].d_neighborsCount;
 
         size_t n = t.clist.size();
         size_t size_n_int = n * sizeof(int);
 
         CHECK_CUDA_ERR(cudaMemcpyAsync(d_clist_use, t.clist.data(), size_n_int, cudaMemcpyHostToDevice, stream));
 
-        findNeighborsHilbertGpu(d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h, t.clist[0],
-                                t.clist[n - 1] + 1, np, box, d.devPtrs.d_codes, d_neighbors_use,
-                                d_neighborsCount_use, ngmax, stream);
-        CHECK_CUDA_ERR(cudaGetLastError());
+        //findNeighborsHilbertGpu(d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h, t.clist[0],
+        //                        t.clist[n - 1] + 1, np, box, d.devPtrs.d_codes, d_neighbors_use,
+        //                        d_neighborsCount_use, ngmax, stream);
+        //CHECK_CUDA_ERR(cudaGetLastError());
 
         unsigned numThreads = 256;
         unsigned numBlocks  = (n + numThreads - 1) / numThreads;
 
         computeIAD<<<numBlocks, numThreads, 0, stream>>>(
-            n, d.sincIndex, d.K, ngmax, box, d_clist_use, d_neighbors_use, d_neighborsCount_use,
+            n, d.sincIndex, d.K, ngmax, box, d_clist_use,
+            //d_neighbors_use, d_neighborsCount_use,
+            d.devPtrs.d_codes, np,
             d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h, d.devPtrs.d_m, d.devPtrs.d_ro,
             d.devPtrs.d_wh, d.devPtrs.d_whd,
             d.devPtrs.d_c11, d.devPtrs.d_c12, d.devPtrs.d_c13, d.devPtrs.d_c22, d.devPtrs.d_c23, d.devPtrs.d_c33);

--- a/include/sph/cuda/cudaIAD.cu
+++ b/include/sph/cuda/cudaIAD.cu
@@ -110,3 +110,4 @@ template void computeIAD(const std::vector<Task>& taskList, ParticlesData<double
 } // namespace cuda
 } // namespace sph
 } // namespace sphexa
+

--- a/include/sph/cuda/cudaIAD.cu
+++ b/include/sph/cuda/cudaIAD.cu
@@ -23,7 +23,8 @@ __global__ void computeIAD(int n, T sincIndex, T K, int ngmax, cstone::Box<T> bo
     const unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid >= n) return;
 
-    sph::kernels::IADJLoop(tid, sincIndex, K, ngmax, box, clist, neighbors, neighborsCount,
+    int i = clist[tid];
+    sph::kernels::IADJLoop(i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid],
                            x, y, z, h, m, ro, wh, whd, c11, c12, c13, c22, c23, c33);
 }
 

--- a/include/sph/cuda/cudaIAD.cu
+++ b/include/sph/cuda/cudaIAD.cu
@@ -53,13 +53,12 @@ __global__ void computeIAD(T sincIndex, T K, int ngmax, cstone::Box<T> box,
     if (i >= lastParticle) return;
 
     // need to hard-code ngmax stack allocation for now
-    assert(ngmax <= NGMAX && "ngmax too big, please adjust allocation size here to desired value of ngmax");
+    assert(ngmax <= NGMAX && "ngmax too big, please increase NGMAX to desired size");
     int neighbors[NGMAX];
+    int neighborsCount;
 
     // starting from CUDA 11.3, dynamic stack allocation is available with the following command
     // int* neighbors = (int*)alloca(ngmax * sizeof(int));
-
-    int neighborsCount;
 
     cstone::findNeighbors(
         i, x, y, z, h, box, cstone::sfcKindPointer(particleKeys), neighbors, &neighborsCount, numParticles, ngmax);

--- a/include/sph/cuda/cudaIAD.cu
+++ b/include/sph/cuda/cudaIAD.cu
@@ -14,15 +14,43 @@ namespace sph
 namespace cuda
 {
 
+/*! @brief
+ *
+ * @tparam     T               float or double
+ * @tparam     KeyType         32- or 64-bit unsigned integer
+ * @param[in]  sincIndex
+ * @param[in]  K
+ * @param[in]  ngmax           maximum number of neighbors per particle to use
+ * @param[in]  box             global coordinate bounding box
+ * @param[in]  firstParticle   first particle to compute
+ * @param[in]  lastParticle    last particle to compute
+ * @param[in]  numParticles    number of local particles + halos
+ * @param[in]  particleKeys    SFC keys of particles, sorted in ascending order
+ * @param[in]  x               x coords, length @p numParticles, SFC sorted
+ * @param[in]  y               y coords, length @p numParticles, SFC sorted
+ * @param[in]  z               z coords, length @p numParticles, SFC sorted
+ * @param[in]  h               smoothing lengths, length @p numParticles
+ * @param[in]  m               masses, length @p numParticles
+ * @param[in]  ro              densities, length @p numParticles
+ * @param[in]  wh              sinc lookup table
+ * @param[in]  whd             sinc derivative lookup table
+ * @param[out] c11             output iad components, length @p numParticles
+ * @param[out] c12
+ * @param[out] c13
+ * @param[out] c22
+ * @param[out] c23
+ * @param[out] c33
+ */
 template<class T, class KeyType>
-__global__ void computeIAD(int n, T sincIndex, T K, int ngmax, cstone::Box<T> box, const int* clist,
-                           //const int* neighbors, const int* neighborsCount,
-                           const KeyType* particleKeys, int numKeys,
+__global__ void computeIAD(T sincIndex, T K, int ngmax, cstone::Box<T> box,
+                           int firstParticle, int lastParticle, int numParticles, const KeyType* particleKeys,
                            const T* x, const T* y, const T* z, const T* h, const T* m, const T* ro,
                            const T* wh, const T* whd, T* c11, T* c12, T* c13, T* c22, T* c23, T* c33)
 {
-    const unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
-    if (tid >= n) return;
+    unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
+    unsigned i = tid + firstParticle;
+
+    if (i >= lastParticle) return;
 
     // need to hard-code ngmax stack allocation for now
     assert(ngmax <= NGMAX && "ngmax too big, please adjust allocation size here to desired value of ngmax");
@@ -33,71 +61,39 @@ __global__ void computeIAD(int n, T sincIndex, T K, int ngmax, cstone::Box<T> bo
 
     int neighborsCount;
 
-    int i = clist[tid];
-
     cstone::findNeighbors(
-        i, x, y, z, h, box, cstone::sfcKindPointer(particleKeys), neighbors, &neighborsCount, numKeys, ngmax);
+        i, x, y, z, h, box, cstone::sfcKindPointer(particleKeys), neighbors, &neighborsCount, numParticles, ngmax);
 
     sph::kernels::IADJLoop(
         i, sincIndex, K, box, neighbors, neighborsCount, x, y, z, h, m, ro, wh, whd, c11, c12, c13, c22, c23, c33);
-
-    // sph::kernels::IADJLoop(i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid],
-    //                        x, y, z, h, m, ro, wh, whd, c11, c12, c13, c22, c23, c33);
 }
 
 template <class Dataset>
 void computeIAD(const std::vector<Task>& taskList, Dataset& d, const cstone::Box<double>& box)
 {
     using T = typename Dataset::RealType;
-    size_t np = d.x.size();
-    size_t size_np_T = np * sizeof(T);
+
+    // number of locally present particles, including halos
+    size_t numParticles = d.x.size();
+
+    size_t size_np_T = numParticles * sizeof(T);
     T ngmax = taskList.empty() ? 0 : taskList.front().ngmax;
-
-    auto largestChunkSize =
-        std::max_element(taskList.cbegin(), taskList.cend(),
-                         [](const Task &lhs, const Task &rhs) { return lhs.clist.size() < rhs.clist.size(); })
-            ->clist.size();
-
-    d.devPtrs.resize_streams(largestChunkSize, ngmax);
-
-    // number of CUDA streams to use
-    constexpr int NST = DeviceParticlesData<T, Dataset>::NST;
 
     CHECK_CUDA_ERR(cudaMemcpy(d.devPtrs.d_ro, d.ro.data(), size_np_T, cudaMemcpyHostToDevice));
 
-    for (int i = 0; i < taskList.size(); ++i)
-    {
-        const auto &t = taskList[i];
+    unsigned firstParticle = taskList.front().clist.front();
+    unsigned lastParticle  = taskList.back().clist.back() + 1;
+    unsigned numParticlesCompute = lastParticle - firstParticle;
 
-        int sIdx = i % NST;
-        cudaStream_t stream = d.devPtrs.d_stream[sIdx].stream;
+    unsigned numThreads = 128;
+    unsigned numBlocks  = (numParticlesCompute + numThreads - 1) / numThreads;
 
-        int *d_clist_use = d.devPtrs.d_stream[sIdx].d_clist;
-        //int *d_neighbors_use = d.devPtrs.d_stream[sIdx].d_neighbors;
-        //int *d_neighborsCount_use = d.devPtrs.d_stream[sIdx].d_neighborsCount;
-
-        size_t n = t.clist.size();
-        size_t size_n_int = n * sizeof(int);
-
-        CHECK_CUDA_ERR(cudaMemcpyAsync(d_clist_use, t.clist.data(), size_n_int, cudaMemcpyHostToDevice, stream));
-
-        //findNeighborsHilbertGpu(d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h, t.clist[0],
-        //                        t.clist[n - 1] + 1, np, box, d.devPtrs.d_codes, d_neighbors_use,
-        //                        d_neighborsCount_use, ngmax, stream);
-        //CHECK_CUDA_ERR(cudaGetLastError());
-
-        unsigned numThreads = 256;
-        unsigned numBlocks  = (n + numThreads - 1) / numThreads;
-
-        computeIAD<<<numBlocks, numThreads, 0, stream>>>(
-            n, d.sincIndex, d.K, ngmax, box, d_clist_use,
-            //d_neighbors_use, d_neighborsCount_use,
-            d.devPtrs.d_codes, np,
-            d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h, d.devPtrs.d_m, d.devPtrs.d_ro,
-            d.devPtrs.d_wh, d.devPtrs.d_whd,
-            d.devPtrs.d_c11, d.devPtrs.d_c12, d.devPtrs.d_c13, d.devPtrs.d_c22, d.devPtrs.d_c23, d.devPtrs.d_c33);
-        CHECK_CUDA_ERR(cudaGetLastError());
-    }
+    computeIAD<<<numBlocks, numThreads>>>(
+        d.sincIndex, d.K, ngmax, box, firstParticle, lastParticle, numParticles, d.devPtrs.d_codes,
+        d.devPtrs.d_x, d.devPtrs.d_y, d.devPtrs.d_z, d.devPtrs.d_h, d.devPtrs.d_m, d.devPtrs.d_ro,
+        d.devPtrs.d_wh, d.devPtrs.d_whd,
+        d.devPtrs.d_c11, d.devPtrs.d_c12, d.devPtrs.d_c13, d.devPtrs.d_c22, d.devPtrs.d_c23, d.devPtrs.d_c33);
+    CHECK_CUDA_ERR(cudaGetLastError());
 
     CHECK_CUDA_ERR(cudaMemcpy(d.c11.data(), d.devPtrs.d_c11, size_np_T, cudaMemcpyDeviceToHost));
     CHECK_CUDA_ERR(cudaMemcpy(d.c12.data(), d.devPtrs.d_c12, size_np_T, cudaMemcpyDeviceToHost));

--- a/include/sph/cuda/cudaMomentumAndEnergyIAD.cu
+++ b/include/sph/cuda/cudaMomentumAndEnergyIAD.cu
@@ -120,3 +120,4 @@ template void computeMomentumAndEnergyIAD(const std::vector<Task>& taskList, Par
 } // namespace cuda
 } // namespace sph
 } // namespace sphexa
+

--- a/include/sph/cuda/cudaMomentumAndEnergyIAD.cu
+++ b/include/sph/cuda/cudaMomentumAndEnergyIAD.cu
@@ -26,7 +26,8 @@ __global__ void computeMomentumAndEnergyIAD(int n, T sincIndex, T K, int ngmax, 
     unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid >= n) return;
 
-    sph::kernels::momentumAndEnergyJLoop(tid, sincIndex, K, ngmax, box, clist, neighbors, neighborsCount,
+    int i = clist[tid];
+    sph::kernels::momentumAndEnergyJLoop(i, sincIndex, K, box, neighbors + ngmax * tid, neighborsCount[tid],
                                          x, y, z, vx, vy, vz, h, m, ro, p, c, c11, c12, c13, c22, c23, c33,
                                          wh, whd, grad_P_x, grad_P_y, grad_P_z, du, maxvsignal);
 }

--- a/include/sph/cuda/sph.cuh
+++ b/include/sph/cuda/sph.cuh
@@ -28,3 +28,4 @@ extern void computeMomentumAndEnergyIAD(const std::vector<Task>& taskList, Datas
 } // namespace cuda
 } // namespace sph
 } // namespace sphexa
+

--- a/include/sph/cuda/sph.cuh
+++ b/include/sph/cuda/sph.cuh
@@ -6,6 +6,9 @@
 #include "cudaParticlesData.cuh"
 #include "cstone/sfc/box.hpp"
 
+//! @brief maximum number of neighbors supported in GPU kernels
+#define NGMAX 150
+
 namespace sphexa
 {
 namespace sph

--- a/include/sph/density.hpp
+++ b/include/sph/density.hpp
@@ -70,14 +70,12 @@ void computeDensityImpl(const Task& t, Dataset& d, const cstone::Box<T>& box)
         //cstone::findNeighbors(
         //    pi, x, y, z, h, box, cstone::sfcKindPointer(d.codes.data()), neighLoc, &count, d.codes.size(), ngmax);
 
-        //kernels::densityJLoop(
-        //    pi, sincIndex, K, ngmax, box, clist, neighbors, neighborsCount, x, y, z, h, m, wh, whd, ro);
-
-        // computes ro[i]
-        kernels::densityJLoop(
-            pi, sincIndex, K, ngmax, box, clist, neighbors, neighborsCount, x, y, z, h, m, wh, whd, ro);
+        int i = clist[pi];
+        ro[i] = kernels::densityJLoop(
+            i, sincIndex, K, box, neighbors + ngmax * pi, neighborsCount[pi], x, y, z, h, m, wh, whd);
 #ifndef NDEBUG
-        if (std::isnan(ro[pi])) printf("ERROR::Density(%zu) density %f, position: (%f %f %f), h: %f\n", pi, ro[pi], x[pi], y[pi], z[pi], h[pi]);
+        if (std::isnan(ro[i]))
+            printf("ERROR::Density(%zu) density %f, position: (%f %f %f), h: %f\n", pi, ro[i], x[i], y[i], z[i], h[i]);
 #endif
     }
 }

--- a/include/sph/kernel/computeDensity.hpp
+++ b/include/sph/kernel/computeDensity.hpp
@@ -12,14 +12,10 @@ namespace kernels
 {
 
 template<typename T>
-CUDA_DEVICE_HOST_FUN inline void densityJLoop(int pi, T sincIndex, T K, int ngmax, const cstone::Box<T>& box,
-                                              const int* clist, const int* neighbors, const int* neighborsCount,
-                                              const T* x, const T* y, const T* z, const T* h, const T* m, const T* wh,
-                                              const T* whd, T* ro)
+CUDA_DEVICE_HOST_FUN inline T densityJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const int* neighbors,
+                                           int neighborsCount, const T* x, const T* y, const T* z, const T* h,
+                                           const T* m, const T* wh, const T* whd)
 {
-    const int i  = clist[pi];
-    const int nn = neighborsCount[pi];
-
     T xi = x[i];
     T yi = y[i];
     T zi = z[i];
@@ -28,12 +24,10 @@ CUDA_DEVICE_HOST_FUN inline void densityJLoop(int pi, T sincIndex, T K, int ngma
     T hInv  = 1.0 / hi;
     T h3Inv = hInv * hInv * hInv;
 
-    const int* neighborsOfI = neighbors + pi * ngmax;
-
     T roloc = 0.0;
-    for (int pj = 0; pj < nn; ++pj)
+    for (int pj = 0; pj < neighborsCount; ++pj)
     {
-        int j  = neighborsOfI[pj];
+        int j  = neighbors[pj];
         T dist = distancePBC(box, hi, xi, yi, zi, x[j], y[j], z[j]);
         T vloc = dist * hInv;
         T w    = ::sphexa::math::pow(lt::wharmonic_lt_with_derivative(wh, whd, vloc), (int)sincIndex);
@@ -41,7 +35,7 @@ CUDA_DEVICE_HOST_FUN inline void densityJLoop(int pi, T sincIndex, T K, int ngma
         roloc += w * m[j];
     }
 
-    ro[i] = K * (roloc + m[i]) * h3Inv;
+    return K * (roloc + m[i]) * h3Inv;
 }
 
 } // namespace kernels

--- a/include/sph/kernel/computeIAD.hpp
+++ b/include/sph/kernel/computeIAD.hpp
@@ -12,14 +12,11 @@ namespace kernels
 {
 
 template<typename T>
-CUDA_DEVICE_HOST_FUN inline void IADJLoop(int pi, T sincIndex, T K, int ngmax, const cstone::Box<T>& box,
-                                          const int* clist, const int* neighbors, const int* neighborsCount, const T* x,
-                                          const T* y, const T* z, const T* h, const T* m, const T* ro, const T* wh,
-                                          const T* whd, T* c11, T* c12, T* c13, T* c22, T* c23, T* c33)
+CUDA_DEVICE_HOST_FUN inline void IADJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const int* neighbors,
+                                          int neighborsCount, const T* x, const T* y, const T* z, const T* h,
+                                          const T* m, const T* ro, const T* wh, const T* whd, T* c11, T* c12, T* c13,
+                                          T* c22, T* c23, T* c33)
 {
-    int i  = clist[pi];
-    int nn = neighborsCount[pi];
-
     T tau11 = 0.0, tau12 = 0.0, tau13 = 0.0, tau22 = 0.0, tau23 = 0.0, tau33 = 0.0;
 
     T xi = x[i];
@@ -29,9 +26,9 @@ CUDA_DEVICE_HOST_FUN inline void IADJLoop(int pi, T sincIndex, T K, int ngmax, c
     T hi    = h[i];
     T hiInv = 1.0 / hi;
 
-    for (int pj = 0; pj < nn; ++pj)
+    for (int pj = 0; pj < neighborsCount; ++pj)
     {
-        int j = neighbors[pi * ngmax + pj];
+        int j = neighbors[pj];
 
         T rx = (xi - x[j]);
         T ry = (yi - y[j]);

--- a/include/sph/kernel/computeMomentumAndEnergy.hpp
+++ b/include/sph/kernel/computeMomentumAndEnergy.hpp
@@ -13,17 +13,14 @@ namespace kernels
 
 template<typename T>
 CUDA_DEVICE_HOST_FUN inline void
-momentumAndEnergyJLoop(int pi, T sincIndex, T K, int ngmax, const cstone::Box<T>& box, const int* clist,
-                       const int* neighbors, const int* neighborsCount, const T* x, const T* y, const T* z, const T* vx,
-                       const T* vy, const T* vz, const T* h, const T* m, const T* ro, const T* p, const T* c,
-                       const T* c11, const T* c12, const T* c13, const T* c22, const T* c23, const T* c33, const T* wh,
-                       const T* whd, T* grad_P_x, T* grad_P_y, T* grad_P_z, T* du, T* maxvsignal)
+momentumAndEnergyJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const int* neighbors, int neighborsCount,
+                       const T* x, const T* y, const T* z, const T* vx, const T* vy, const T* vz, const T* h,
+                       const T* m, const T* ro, const T* p, const T* c, const T* c11, const T* c12, const T* c13,
+                       const T* c22, const T* c23, const T* c33, const T* wh, const T* whd, T* grad_P_x, T* grad_P_y,
+                       T* grad_P_z, T* du, T* maxvsignal)
 {
     constexpr T gradh_i = 1.0;
     constexpr T gradh_j = 1.0;
-
-    int i = clist[pi];
-    int nn = neighborsCount[pi];
 
     T xi = x[i];
     T yi = y[i];
@@ -52,9 +49,9 @@ momentumAndEnergyJLoop(int pi, T sincIndex, T K, int ngmax, const cstone::Box<T>
     T c23i = c23[i];
     T c33i = c33[i];
 
-    for (int pj = 0; pj < nn; ++pj)
+    for (int pj = 0; pj < neighborsCount; ++pj)
     {
-        int j = neighbors[pi * ngmax + pj];
+        int j = neighbors[pj];
 
         T rx    = xi - x[j];
         T ry    = yi - y[j];

--- a/include/sph/momentumAndEnergyIAD.hpp
+++ b/include/sph/momentumAndEnergyIAD.hpp
@@ -85,7 +85,8 @@ void computeMomentumAndEnergyIADImpl(const Task& t, Dataset& d, const cstone::Bo
 #endif
     for (size_t pi = 0; pi < n; ++pi)
     {
-        kernels::momentumAndEnergyJLoop(pi, sincIndex, K, ngmax, box, clist, neighbors, neighborsCount,
+        int i = clist[pi];
+        kernels::momentumAndEnergyJLoop(i, sincIndex, K, box, neighbors + ngmax * pi, neighborsCount[pi],
                                         x, y, z, vx, vy, vz, h, m, ro, p, c,
                                         c11, c12, c13, c22, c23, c33,
                                         wh, whd, grad_P_x, grad_P_y, grad_P_z, du, maxvsignal);

--- a/include/sph/test/kernel/density.cpp
+++ b/include/sph/test/kernel/density.cpp
@@ -44,7 +44,6 @@ TEST(Density, JLoop)
 
     T sincIndex = 6.0;
     T K = compute_3d_k(sincIndex);
-    int ngmax = 10;
 
     std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>();
     std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>();
@@ -54,7 +53,7 @@ TEST(Density, JLoop)
     // particle 0 has 4 neighbors
     std::vector<int> clist{0};
     std::vector<int> neighbors{1, 2, 3, 4};
-    std::vector<int> neighborsCount{4};
+    int neighborsCount = 4;
 
     std::vector<T> x{1.0, 2.1, 3.2, 4.3, 5.4};
     std::vector<T> y{1.1, 2.2, 3.3, 4.4, 5.5};
@@ -70,15 +69,21 @@ TEST(Density, JLoop)
      * j = 4   7.62102
      */
 
-    std::vector<T> rho(1);
+    T rho = sph::kernels::densityJLoop(0,
+                                       sincIndex,
+                                       K,
+                                       box,
+                                       neighbors.data(),
+                                       neighborsCount,
+                                       x.data(),
+                                       y.data(),
+                                       z.data(),
+                                       h.data(),
+                                       m.data(),
+                                       wh.data(),
+                                       whd.data());
 
-    // fill with invalid result to make sure that the kernel overwrites it instead of add to it
-    rho[0] = -1;
-
-    sph::kernels::densityJLoop(0, sincIndex, K, ngmax, box, clist.data(), neighbors.data(), neighborsCount.data(),
-                               x.data(), y.data(), z.data(), h.data(), m.data(), wh.data(), whd.data(), rho.data());
-
-    EXPECT_NEAR(rho[0], 0.014286303130604867, 1e-10);
+    EXPECT_NEAR(rho, 0.014286303130604867, 1e-10);
 }
 
 TEST(Density, JLoopPBC)
@@ -87,7 +92,6 @@ TEST(Density, JLoopPBC)
 
     T sincIndex = 6.0;
     T K = compute_3d_k(sincIndex);
-    int ngmax = 10;
 
     std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>();
     std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>();
@@ -99,7 +103,7 @@ TEST(Density, JLoopPBC)
     // particle 0 has 4 neighbors
     std::vector<int> clist{0};
     std::vector<int> neighbors{1, 2, 3, 4};
-    std::vector<int> neighborsCount{4};
+    int neighborsCount = 4;
 
     std::vector<T> x{1.0, 1.1, 1.4, 9.9, 10.4};
     std::vector<T> y{1.1, 1.2, 1.5, 9.8, 10.2};
@@ -116,14 +120,20 @@ TEST(Density, JLoopPBC)
      * j = 4  15.9367    2.26495
      */
 
-    std::vector<T> rho(1);
+    T rho = sph::kernels::densityJLoop(0,
+                                       sincIndex,
+                                       K,
+                                       box,
+                                       neighbors.data(),
+                                       neighborsCount,
+                                       x.data(),
+                                       y.data(),
+                                       z.data(),
+                                       h.data(),
+                                       m.data(),
+                                       wh.data(),
+                                       whd.data());
 
-    // fill with invalid result to make sure that the kernel overwrites it instead of add to it
-    rho[0] = -1;
-
-    sph::kernels::densityJLoop(0, sincIndex, K, ngmax, box, clist.data(), neighbors.data(), neighborsCount.data(),
-                               x.data(), y.data(), z.data(), h.data(), m.data(), wh.data(), whd.data(), rho.data());
-
-    EXPECT_NEAR(rho[0], 0.17929212293724384, 1e-10);
+    EXPECT_NEAR(rho, 0.17929212293724384, 1e-10);
 }
 

--- a/include/sph/test/kernel/iad.cpp
+++ b/include/sph/test/kernel/iad.cpp
@@ -44,7 +44,6 @@ TEST(IAD, JLoop)
 
     T sincIndex = 6.0;
     T K = compute_3d_k(sincIndex);
-    int ngmax = 10;
 
     std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>();
     std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>();
@@ -52,9 +51,8 @@ TEST(IAD, JLoop)
     cstone::Box<T> box(0, 6, 0, 6, 0, 6, false, false, false);
 
     // particle 0 has 4 neighbors
-    std::vector<int> clist{0};
     std::vector<int> neighbors{1, 2, 3, 4};
-    std::vector<int> neighborsCount{4};
+    int neighborsCount = 4;
 
     std::vector<T> x{1.0, 1.1, 3.2, 1.3, 2.4};
     std::vector<T> y{1.1, 1.2, 1.3, 4.4, 5.5};
@@ -75,7 +73,7 @@ TEST(IAD, JLoop)
     std::vector<T> iad(6, -1);
 
     // compute the 6 tensor components for particle 0
-    sph::kernels::IADJLoop(0, sincIndex, K, ngmax, box, clist.data(), neighbors.data(), neighborsCount.data(),
+    sph::kernels::IADJLoop(0, sincIndex, K, box, neighbors.data(), neighborsCount,
                            x.data(), y.data(), z.data(), h.data(), m.data(), rho.data(), wh.data(), whd.data(),
                            &iad[0], &iad[1], &iad[2], &iad[3], &iad[4], &iad[5]);
 
@@ -93,7 +91,6 @@ TEST(IAD, JLoopPBC)
 
     T sincIndex = 6.0;
     T K = compute_3d_k(sincIndex);
-    int ngmax = 10;
 
     std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>();
     std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>();
@@ -103,9 +100,8 @@ TEST(IAD, JLoopPBC)
     cstone::Box<T> box(0, 10.5, 0, 10.5, 0, 10.5, true, true, true);
 
     // particle 0 has 4 neighbors
-    std::vector<int> clist{0};
     std::vector<int> neighbors{1, 2, 3, 4};
-    std::vector<int> neighborsCount{4};
+    int neighborsCount = 4;
 
     std::vector<T> x{1.0, 1.1, 3.2, 1.3, 9.4};
     std::vector<T> y{1.1, 1.2, 1.3, 8.4, 9.5};
@@ -126,7 +122,7 @@ TEST(IAD, JLoopPBC)
     // fill with invalid initial value to make sure that the kernel overwrites it instead of add to it
     std::vector<T> iad(6, -1);
 
-    sph::kernels::IADJLoop(0, sincIndex, K, ngmax, box, clist.data(), neighbors.data(), neighborsCount.data(),
+    sph::kernels::IADJLoop(0, sincIndex, K, box, neighbors.data(), neighborsCount,
                            x.data(), y.data(), z.data(), h.data(), m.data(), rho.data(), wh.data(), whd.data(),
                            &iad[0], &iad[1], &iad[2], &iad[3], &iad[4], &iad[5]);
 

--- a/include/sph/test/kernel/momentum_energy.cpp
+++ b/include/sph/test/kernel/momentum_energy.cpp
@@ -44,7 +44,6 @@ TEST(MomentumEnergy, JLoop)
 
     T sincIndex = 6.0;
     T K         = compute_3d_k(sincIndex);
-    int ngmax   = 10;
 
     std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>();
     std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>();
@@ -52,9 +51,8 @@ TEST(MomentumEnergy, JLoop)
     cstone::Box<T> box(0, 6, 0, 6, 0, 6, false, false, false);
 
     // particle 0 has 4 neighbors
-    std::vector<int> clist{0};
     std::vector<int> neighbors{1, 2, 3, 4};
-    std::vector<int> neighborsCount{4};
+    int neighborsCount = 4;
 
     std::vector<T> x{1.0, 1.1, 3.2, 1.3, 2.4};
     std::vector<T> y{1.1, 1.2, 1.3, 4.4, 5.5};
@@ -96,11 +94,9 @@ TEST(MomentumEnergy, JLoop)
     sph::kernels::momentumAndEnergyJLoop(0,
                                          sincIndex,
                                          K,
-                                         ngmax,
                                          box,
-                                         clist.data(),
                                          neighbors.data(),
-                                         neighborsCount.data(),
+                                         neighborsCount,
                                          x.data(),
                                          y.data(),
                                          z.data(),
@@ -139,7 +135,6 @@ TEST(MomentumEnergy, JLoopPBC)
 
     T sincIndex = 6.0;
     T K         = compute_3d_k(sincIndex);
-    int ngmax   = 10;
 
     std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>();
     std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>();
@@ -149,9 +144,8 @@ TEST(MomentumEnergy, JLoopPBC)
     cstone::Box<T> box(0, 10.5, 0, 10.5, 0, 10.5, true, true, true);
 
     // particle 0 has 4 neighbors
-    std::vector<int> clist{0};
     std::vector<int> neighbors{1, 2, 3, 4};
-    std::vector<int> neighborsCount{4};
+    int neighborsCount = 4;
 
     std::vector<T> x{1.0, 1.1, 3.2, 1.3, 9.4};
     std::vector<T> y{1.1, 1.2, 1.3, 8.4, 9.5};
@@ -194,11 +188,9 @@ TEST(MomentumEnergy, JLoopPBC)
     sph::kernels::momentumAndEnergyJLoop(0,
                                          sincIndex,
                                          K,
-                                         ngmax,
                                          box,
-                                         clist.data(),
                                          neighbors.data(),
-                                         neighborsCount.data(),
+                                         neighborsCount,
                                          x.data(),
                                          y.data(),
                                          z.data(),


### PR DESCRIPTION
This fuses the GPU SPH and neighbor search kernels, removes the need for pre-allocated neighbor lists
and replaces the local particles list with a particle range.