### PR TITLE
Add simple H5part support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,12 @@ else()
     message(STATUS "No CUDA support")
 endif()
 
+option(SPH_EXA_WITH_H5PART "Enable HDF5 IO using H5Part library" OFF)
+if (SPH_EXA_WITH_H5PART)
+    find_package(HDF5)
+    add_subdirectory(./extern/h5part)
+endif()
+
 add_subdirectory(include)
 add_subdirectory(domain)
 

--- a/extern/h5part/AUTHORS
+++ b/extern/h5part/AUTHORS
@@ -1,0 +1,11 @@
+
+Andreas Adelmann (PSI)
+Achim Gsell (PSI)
+Benedikt Oswald (PSI)
+
+Wes Bethel (NERSC/LBNL)
+John Shalf (NERSC/LBNL)
+Cristina Siegerist (NERSC/LBNL)
+Mark Howison (NERSC/LBNL)
+
+Please use h5part@lists.psi.ch for communicaion.

--- a/extern/h5part/CMakeLists.txt
+++ b/extern/h5part/CMakeLists.txt
@@ -1,0 +1,78 @@
+project(H5Part C)
+
+#--------------------------------------------------------
+# Parallel compilation flag
+#--------------------------------------------------------
+IF(HDF5_IS_PARALLEL)
+  ADD_DEFINITIONS(-DH5PART_PARALLEL_IO -DH5PART_HAS_MPI)
+ELSE()
+  MESSAGE("HDF5_IS_PARALLEL not found, Parallel HDF5 IO will not be enabled")
+ENDIF()
+
+IF(WIN32)
+  ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS)
+ENDIF(WIN32)
+
+#--------------------------------------------------------
+# Source files
+#--------------------------------------------------------
+SET(H5Part_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/H5Part.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/h5tools_type.c
+)
+
+#
+# Make sure msvc builds as cxx not C
+# This resolves some struct typedef issues
+#
+IF(WIN32)
+  SET_SOURCE_FILES_PROPERTIES(
+    ${CMAKE_CURRENT_SOURCE_DIR}/H5Part.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/H5Block.c
+    PROPERTIES LANGUAGE CXX
+  )
+ENDIF (WIN32)
+
+#--------------------------------------------------------
+# List the libraries used
+#--------------------------------------------------------
+SET(H5Part_LIBS
+  ${PARAVIEW_HDF5_LIBRARIES}
+)
+
+IF (PARAVIEW_USE_MPI)
+  SET(H5Part_LIBS
+    ${H5Part_LIBS}
+    hdf5
+    ${MPI_C_LIBRARIES}
+  )
+ENDIF (PARAVIEW_USE_MPI)
+
+#--------------------------------------------------------
+# Include class, configuration headers
+#--------------------------------------------------------
+SET(H5PART_INCLUDE_DIRS
+  ${PROJECT_SOURCE_DIR}
+  ${PROJECT_BINARY_DIR}
+  ${HDF5_INCLUDE_DIR}
+)
+
+INCLUDE_DIRECTORIES(${H5PART_INCLUDE_DIRS})
+
+#--------------------------------------------------------
+# Create the Library
+#--------------------------------------------------------
+ADD_LIBRARY(H5Part STATIC
+  ${H5Part_SRCS}
+)
+
+TARGET_LINK_LIBRARIES(H5Part
+  PUBLIC
+    ${H5Part_LIBS}
+)
+
+# Make sure static lib can be linked into dynamic one
+IF(BUILD_SHARED_LIBS AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCC)
+  SET_TARGET_PROPERTIES( H5Part PROPERTIES COMPILE_FLAGS -fPIC)
+ENDIF(BUILD_SHARED_LIBS AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCC)
+

--- a/extern/h5part/COPYING
+++ b/extern/h5part/COPYING
@@ -1,0 +1,71 @@
+*** Copyright Notice ***
+
+H5Part  Copyright (c) 2006-2009, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy) and the Paul Scherrer
+Institut (Switzerland).  All rights reserved.
+
+If you have questions about your rights to use or distribute this
+software, please contact Berkeley Lab's Technology Transfer Department
+at  TTD@lbl.gov referring to "H5Part (LBNL Ref CR-2255)"
+
+NOTICE.  This software was developed under partial funding from the U.S.
+Department of Energy.  As such, the U.S. Government has been granted for
+itself and others acting on its behalf a paid-up, nonexclusive,
+irrevocable, worldwide license in the Software to reproduce, prepare
+derivative works, and perform publicly and display publicly.  Beginning
+five (5) years after the date permission to assert copyright is obtained
+from the U.S. Department of Energy, and subject to any subsequent five
+(5) year renewals, the U.S. Government is granted for itself and others
+acting on its behalf a paid-up, nonexclusive, irrevocable, worldwide
+license in the Software to reproduce, prepare derivative works,
+distribute copies to the public, perform publicly and display publicly,
+and to permit others to do so.
+
+
+*** License agreement ***
+
+H5Part  Copyright (c) 2006-2009, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy) and the Paul Scherrer
+Institut (Switzerland).  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+(1) Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+(2) Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+(3) Neither the name of the University of California, Lawrence Berkeley
+National Laboratory, U.S. Dept. of Energy, Paul Scherrer Institut
+(Switzerland) nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+You are under no obligation whatsoever to provide any bug fixes,
+patches, or upgrades to the features, functionality or performance of
+the source code ("Enhancements") to anyone; however, if you choose to
+make your Enhancements available either publicly, or directly to
+Lawrence Berkeley National Laboratory, without imposing a separate
+written license agreement for such Enhancements, then you hereby grant
+the following license: a  non-exclusive, royalty-free perpetual license
+to install, use, modify, prepare derivative works, incorporate into
+other computer software, distribute, and sublicense such enhancements or
+derivative works thereof, in binary and source code form.
+

--- a/extern/h5part/H5Part.c
+++ b/extern/h5part/H5Part.c
@@ -1,0 +1,3713 @@
+/*! \mainpage H5Part: A Portable High Performance Parallel Data Interface to HDF5
+
+Particle based simulations of accelerator beam-lines, especially in
+six dimensional phase space, generate vast amounts of data. Even
+though a subset of statistical information regarding phase space or
+analysis needs to be preserved, reading and writing such enormous
+restart files on massively parallel supercomputing systems remains
+challenging.
+
+H5Part consists of Particles and Block structured Fields.
+
+Developed by:
+
+<UL>
+<LI> Andreas Adelmann (PSI) </LI>
+<LI> Achim Gsell (PSI) </LI>
+<LI> Benedikt Oswald (PSI) </LI>
+
+<LI> Wes Bethel (NERSC/LBNL)</LI>
+<LI> John Shalf (NERSC/LBNL)</LI>
+<LI> Cristina Siegerist (NERSC/LBNL)</LI>
+<LI> Mark Howison (NERSC/LBNL)</LI>
+</UL>
+
+
+Papers:
+
+<UL>
+<LI> A. Adelmann, R.D. Ryne, C. Siegerist, J. Shalf,"From Visualization to Data Mining with Large Data Sets," <i>
+<a href="http://www.sns.gov/pac05">Particle Accelerator Conference (PAC05)</a></i>, Knoxville TN., May 16-20, 2005. (LBNL-57603)
+<a href="http://vis.lbl.gov/Publications/2005/FPAT082.pdf">FPAT082.pdf</a>
+</LI>
+
+
+<LI> A. Adelmann, R.D. Ryne, J. Shalf, C. Siegerist, "H5Part: A Portable High Performance Parallel Data Interface for Particle Simulations," <i>
+<a href="http://www.sns.gov/pac05">Particle Accelerator Conference (PAC05)</a></i>, Knoxville TN., May 16-20, 2005.
+<a href="http://vis.lbl.gov/Publications/2005/FPAT083.pdf">FPAT083.pdf</a>
+</LI>
+</UL>
+
+For further information contact: <a href="mailto:h5part@lists.psi.ch">h5part</a>
+
+ */
+
+
+/*!
+  \defgroup h5part_c_api H5Part C API
+
+ */
+/*!
+  \ingroup h5part_c_api
+  \defgroup h5part_open 	File Opening and Closing
+ */
+/*!
+  \ingroup h5part_c_api
+  \defgroup h5part_model	Setting up the Data Model
+ */
+/*!
+  \ingroup h5part_c_api
+  \defgroup h5part_data		Readind and Writing Datasets
+ */
+/*!
+  \ingroup h5part_c_api
+  \defgroup h5part_attrib	Reading and Writing Attributes
+ */
+/*!
+  \ingroup h5part_c_api
+  \defgroup h5part_errhandle	Error Handling
+ */
+/*!
+  \internal
+  \defgroup h5partkernel H5Part private functions
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>	/* va_arg - System dependent ?! */
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <hdf5.h>
+
+#ifndef WIN32
+#include <unistd.h>
+#else /* WIN32 */
+#include <io.h>
+#define open  _open
+#define close _close
+#endif /* WIN32 */
+
+#include "H5Part.h"
+#include "H5PartPrivate.h"
+#include "H5PartErrors.h"
+
+char H5PART_GROUPNAME_STEP[256] = "Step";
+
+/********* Global Variable Declarations *************/
+h5part_error_handler	_err_handler = H5PartReportErrorHandler;
+
+/********* Private Variable Declarations *************/
+
+static unsigned			_debug = H5PART_VERB_ERROR;
+static h5part_int64_t		_h5part_errno = H5PART_SUCCESS;
+static char *__funcname;
+
+/********** Declaration of private functions ******/
+
+static h5part_int64_t
+_init(
+    void
+);
+
+static h5part_int64_t
+_reset_view (
+    H5PartFile *f
+);
+
+/*
+  error handler for hdf5
+ */
+static herr_t
+_h5_error_handler (
+#ifndef H5_USE_16_API
+    hid_t,
+#endif
+    void *
+);
+
+/*========== File Opening/Closing ===============*/
+
+static H5PartFile*
+_H5Part_open_file (
+    const char *filename,	/*!< [in] The name of the data file to open. */
+    const char flags,	/*!< [in] The access mode for the file. */
+    MPI_Comm comm,		/*!< [in] MPI communicator */
+    int f_parallel,		/*!< [in] 0 for serial io otherwise parallel */
+    h5part_int64_t align	/*!< [in] Number of bytes for setting alignment,
+                      metadata block size, etc.
+                      Set to 0 to disable. */
+) {
+
+    _h5part_errno = H5PART_SUCCESS;
+    H5PartFile *f = NULL;
+
+    f = (H5PartFile*) malloc( sizeof (H5PartFile) );
+    if( f == NULL ) {
+        HANDLE_H5PART_NOMEM_ERR;
+        goto error_cleanup;
+    }
+    memset (f, 0, sizeof (H5PartFile));
+
+    f->flags = flags;
+
+    /* set default step name */
+    strncpy ( f->groupname_step, H5PART_GROUPNAME_STEP, H5PART_STEPNAME_LEN );
+    f->stepno_width = 0;
+
+    f->xfer_prop = f->create_prop = H5P_DEFAULT;
+
+    f->access_prop = H5Pcreate (H5P_FILE_ACCESS);
+    if (f->access_prop < 0) {
+        HANDLE_H5P_CREATE_ERR;
+        goto error_cleanup;
+    }
+
+    if ( f_parallel ) {
+#ifdef H5PART_PARALLEL_IO
+        MPI_Info info = MPI_INFO_NULL;
+
+        if (MPI_Comm_size (comm, &f->nprocs) != MPI_SUCCESS) {
+            HANDLE_MPI_COMM_SIZE_ERR;
+            goto error_cleanup;
+        }
+        if (MPI_Comm_rank (comm, &f->myproc) != MPI_SUCCESS) {
+            HANDLE_MPI_COMM_RANK_ERR;
+            goto error_cleanup;
+        }
+
+        f->pnparticles =
+            (h5part_int64_t*) malloc (f->nprocs * sizeof (h5part_int64_t));
+        if (f->pnparticles == NULL) {
+            HANDLE_H5PART_NOMEM_ERR;
+            goto error_cleanup;
+        }
+
+        /* select the HDF5 VFD */
+        if (flags & H5PART_VFD_MPIPOSIX) {
+            if (f->myproc == 0) {
+                _H5Part_print_info ( "Selecting MPI-POSIX VFD" );
+            }
+            //			if (H5Pset_fapl_mpiposix ( f->access_prop, comm, 0 ) < 0) {
+            //				HANDLE_H5P_SET_FAPL_ERR;
+            //				goto error_cleanup;
+            //			}
+        }
+        else {
+            if (f->myproc == 0) {
+                _H5Part_print_info ( "Selecting MPI-IO VFD" );
+            }
+            if (H5Pset_fapl_mpio ( f->access_prop, comm, info ) < 0) {
+                HANDLE_H5P_SET_FAPL_ERR;
+                goto error_cleanup;
+            }
+            if (flags & H5PART_VFD_MPIIO_IND) {
+                if (f->myproc == 0) {
+                    _H5Part_print_info ( "Using independent mode" );
+                }
+            } else {
+                if (f->myproc == 0) {
+                    _H5Part_print_info ( "Using collective mode" );
+                }
+                f->xfer_prop = H5Pcreate (H5P_DATASET_XFER);
+                if (f->xfer_prop < 0) {
+                    HANDLE_H5P_CREATE_ERR;
+                    goto error_cleanup;
+                }
+                if (H5Pset_dxpl_mpio ( f->xfer_prop, H5FD_MPIO_COLLECTIVE ) < 0) {
+                    HANDLE_H5P_SET_DXPL_MPIO_ERR;
+                    goto error_cleanup;
+                }
+            }
+        }
+
+        if ( flags & H5PART_FS_LUSTRE )
+        {
+            /* extend the btree size so that metadata pieces are
+             * close to the alignment value */
+            unsigned int btree_ik = (align - 256) / 96;
+            unsigned int btree_bytes = 64 + 96*btree_ik;
+            if ( btree_bytes > align ) {
+                HANDLE_H5PART_INVALID_ERR(
+                    "btree_ik", btree_ik );
+                goto error_cleanup;
+            }
+
+            if (f->myproc == 0) {
+                _H5Part_print_info (
+                    "Setting HDF5 btree parameter to %u",
+                    btree_ik );
+                _H5Part_print_info (
+                    "Extending HDF5 btree size to %u bytes at rank 3",
+                    btree_bytes );
+            }
+
+            f->create_prop = H5Pcreate(H5P_FILE_CREATE);
+            H5Pset_istore_k (f->create_prop, H5PART_BTREE_IK);
+
+#ifndef H5_USE_16_API
+            /* defer metadata cache flushing until file close */
+            H5AC_cache_config_t cache_config;
+            cache_config.version = H5AC__CURR_CACHE_CONFIG_VERSION;
+            H5Pget_mdc_config (f->access_prop, &cache_config);
+            cache_config.set_initial_size = 1;
+            cache_config.initial_size = 16 * 1024 * 1024;
+            cache_config.evictions_enabled = 0;
+            cache_config.incr_mode = H5C_incr__off;
+            cache_config.flash_incr_mode = H5C_flash_incr__off;
+            cache_config.decr_mode = H5C_decr__off;
+            H5Pset_mdc_config (f->access_prop, &cache_config);
+#else // H5_USE_16_API
+            _H5Part_print_info (
+                "Unable to defer metadata write: need HDF5 1.8");
+#endif // H5_USE_16_API
+        }
+
+        f->comm = comm;
+#endif // H5PART_PARALLEL_IO
+    } else {
+        f->comm = 0;
+        f->nprocs = 1;
+        f->myproc = 0;
+        f->pnparticles =
+            (h5part_int64_t*) malloc (f->nprocs * sizeof (h5part_int64_t));
+    }
+
+    if ( align != 0 ) {
+        if (f->myproc == 0) {
+            _H5Part_print_info ( "Setting HDF5 alignment to %ld bytes", align );
+        }
+        if (H5Pset_alignment ( f->access_prop, 0, align ) < 0) {
+            HANDLE_H5P_SET_FAPL_ERR;
+            goto error_cleanup;
+        }
+        if (f->myproc == 0) {
+            _H5Part_print_info ( "Setting HDF5 meta block to %ld bytes", align );
+        }
+        if (H5Pset_meta_block_size ( f->access_prop, align ) < 0) {
+            HANDLE_H5P_SET_FAPL_ERR;
+            goto error_cleanup;
+        }
+        /*if (f->myproc == 0) {
+            _H5Part_print_info ( "Setting HDF5 sieve buffer to %ld bytes", align );
+        }
+        if (H5Pset_sieve_buf_size ( f->access_prop, align ) < 0) {
+            HANDLE_H5P_SET_FAPL_ERR;
+            goto error_cleanup;
+        }*/
+    }
+
+    if ( flags & H5PART_READ ) {
+        f->file = H5Fopen(filename, H5F_ACC_RDONLY, f->access_prop);
+    }
+    else if ( flags & H5PART_WRITE ){
+        f->file = H5Fcreate (filename, H5F_ACC_TRUNC, f->create_prop,
+            f->access_prop);
+        f->empty = 1;
+    }
+    else if ( flags & H5PART_APPEND ) {
+        int fd = open(filename, O_RDONLY, 0);
+        if ( (fd == -1) && (errno == ENOENT) ) {
+            f->file = H5Fcreate(filename, H5F_ACC_TRUNC,
+                f->create_prop, f->access_prop);
+            f->empty = 1;
+        }
+        else if (fd != -1) {
+            close (fd);
+            f->file = H5Fopen(
+                filename, H5F_ACC_RDWR, f->access_prop);
+            /*
+              The following function call returns an error,
+              if f->file < 0. But we can safely ignore this.
+             */
+            f->timestep = _H5Part_get_num_objects_matching_pattern(
+                f->file, "/", H5G_GROUP, f->groupname_step );
+            if ( f->timestep < 0 ) goto error_cleanup;
+        }
+    }
+    else {
+        HANDLE_H5PART_FILE_ACCESS_TYPE_ERR ( flags );
+        goto error_cleanup;
+    }
+
+    if (f->file < 0) {
+        HANDLE_H5F_OPEN_ERR ( filename, flags );
+        goto error_cleanup;
+    }
+    f->nparticles = 0;
+    f->timegroup = -1;
+    f->shape = H5S_ALL;
+    f->diskshape = H5S_ALL;
+    f->memshape = H5S_ALL;
+    f->viewstart = -1;
+    f->viewend = -1;
+    f->viewindexed = 0;
+    f->throttle = 0;
+
+    _H5Part_print_debug (
+        "Proc[%d]: Opened file \"%s\" val=%lld",
+        f->myproc,
+        filename,
+        (long long)(size_t)f );
+
+    return f;
+
+    error_cleanup:
+    if (f != NULL ) {
+        if (f->pnparticles != NULL) {
+            free (f->pnparticles);
+        }
+        free (f);
+    }
+    return NULL;
+}
+
+#ifdef H5PART_PARALLEL_IO
+/*!
+  \ingroup h5part_open
+
+  Opens file with specified filename.
+
+  If you open with flag \c H5PART_WRITE, it will truncate any
+  file with the specified filename and start writing to it. If
+  you open with \c H5PART_APPEND, then you can append new timesteps.
+  If you open with \c H5PART_READ, then it will open the file
+  readonly.
+
+  The typical extension for these files is \c .h5.
+
+  H5PartFile should be treated as an essentially opaque
+  datastructure.  It acts as the file handle, but internally
+  it maintains several key state variables associated with
+  the file.
+
+  \return	File handle or \c NULL
+ */
+H5PartFile*
+H5PartOpenFileParallel (
+    const char *filename,	/*!< [in] The name of the data file to open. */
+    const char flags,	/*!< [in] The access mode for the file. */
+    MPI_Comm comm		/*!< [in] MPI communicator */
+) {
+    INIT
+    SET_FNAME ( "H5PartOpenFileParallel" );
+
+    int f_parallel = 1;	/* parallel i/o */
+    h5part_int64_t align = 0; /* no alignment tuning */
+
+    return _H5Part_open_file ( filename, flags, comm, f_parallel, align );
+}
+
+/*!
+  \ingroup h5part_open
+
+  Opens file with specified filename, and also specifices an alignment
+  value used for HDF5 tuning parameters.
+
+  \return	File handle or \c NULL
+ */
+H5PartFile*
+H5PartOpenFileParallelAlign (
+    const char *filename,	/*!< [in] The name of the data file to open. */
+    const char flags,	/*!< [in] The access mode for the file. */
+    MPI_Comm comm,		/*!< [in] MPI communicator */
+    h5part_int64_t align	/*!< [in] Alignment size in bytes. */
+) {
+    INIT
+    SET_FNAME ( "H5PartOpenFileParallelAlign" );
+
+    int f_parallel = 1;	/* parallel i/o */
+
+    return _H5Part_open_file ( filename, flags, comm, f_parallel, align );
+}
+#endif
+
+/*!
+  \ingroup  h5part_open
+
+  Opens file with specified filename.
+
+  If you open with flag \c H5PART_WRITE, it will truncate any
+  file with the specified filename and start writing to it. If
+  you open with \c H5PART_APPEND, then you can append new timesteps.
+  If you open with \c H5PART_READ, then it will open the file
+  readonly.
+
+  The typical extension for these files is \c .h5.
+
+  H5PartFile should be treated as an essentially opaque
+  datastructure.  It acts as the file handle, but internally
+  it maintains several key state variables associated with
+  the file.
+
+  \return	File handle or \c NULL
+ */
+H5PartFile*
+H5PartOpenFile (
+    const char *filename,	/*!< [in] The name of the data file to open. */
+    const char flags	/*!< [in] The access mode for the file. */
+) {
+    INIT
+    SET_FNAME ( "H5PartOpenFile" );
+
+    MPI_Comm comm = 0;	/* dummy */
+    int f_parallel = 0;	/* serial open */
+    int align = 0;		/* no tuning parameters */
+
+    return _H5Part_open_file ( filename, flags, comm, f_parallel, align );
+}
+
+/*!
+  \ingroup h5part_open
+
+  Opens file with specified filename, and also specifices an alignment
+  value used for HDF5 tuning parameters.
+
+  \return	File handle or \c NULL
+ */
+H5PartFile*
+H5PartOpenFileAlign (
+    const char *filename,	/*!< [in] The name of the data file to open. */
+    const char flags,	/*!< [in] The access mode for the file. */
+    h5part_int64_t align	/*!< [in] Alignment size in bytes. */
+) {
+    INIT
+    SET_FNAME ( "H5PartOpenFileAlign" );
+
+    MPI_Comm comm = 0;	/* dummy */
+    int f_parallel = 0;	/* serial open */
+
+    return _H5Part_open_file ( filename, flags, comm, f_parallel, align );
+}
+
+/*!
+  Checks if a file was successfully opened.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+_H5Part_file_is_valid (
+    const H5PartFile *f	/*!< filehandle  to check validity of */
+) {
+
+    if( f == NULL )
+        return H5PART_ERR_BADFD;
+    else if(f->file > 0)
+        return H5PART_SUCCESS;
+    else
+        return H5PART_ERR_BADFD;
+}
+
+h5part_int64_t
+_H5Part_close_hdf_ids (
+    H5PartFile *f		/*!< [in] filehandle of the file to close */
+) {
+
+    herr_t r = 0;
+
+    if ( f->block && f->close_block ) {
+        (*f->close_block) ( f );
+        f->block = NULL;
+        f->close_block = NULL;
+    }
+
+#ifdef H5PART_PARALLEL_IO
+    if ( f->multiblock && f->close_multiblock ) {
+        (*f->close_multiblock) ( f );
+        f->multiblock = NULL;
+        f->close_multiblock = NULL;
+    }
+#endif
+
+    if( f->shape != H5S_ALL ) {
+        r = H5Sclose( f->shape );
+        if ( r < 0 ) HANDLE_H5S_CLOSE_ERR;
+        f->shape = 0;
+    }
+    if( f->timegroup >= 0 ) {
+        r = H5Gclose( f->timegroup );
+        if ( r < 0 ) HANDLE_H5G_CLOSE_ERR;
+        f->timegroup = -1;
+    }
+    if( f->diskshape != H5S_ALL ) {
+        r = H5Sclose( f->diskshape );
+        if ( r < 0 ) HANDLE_H5S_CLOSE_ERR;
+        f->diskshape = 0;
+    }
+    if( f->memshape != H5S_ALL ) {
+        r = H5Sclose( f->memshape );
+        if ( r < 0 ) HANDLE_H5S_CLOSE_ERR;
+        f->memshape = 0;
+    }
+    if( f->xfer_prop != H5P_DEFAULT ) {
+        r = H5Pclose( f->xfer_prop );
+        if ( r < 0 ) HANDLE_H5P_CLOSE_ERR ( "f->xfer_prop" );
+        f->xfer_prop = H5P_DEFAULT;
+    }
+    if( f->access_prop != H5P_DEFAULT ) {
+        r = H5Pclose( f->access_prop );
+        if ( r < 0 ) HANDLE_H5P_CLOSE_ERR ( "f->access_prop" );
+        f->access_prop = H5P_DEFAULT;
+    }
+    if( f->create_prop != H5P_DEFAULT ) {
+        r = H5Pclose( f->create_prop );
+        if ( r < 0 ) HANDLE_H5P_CLOSE_ERR ( "f->create_prop" );
+        f->create_prop = H5P_DEFAULT;
+    }
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_open
+
+  Closes an open file.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartCloseFile (
+    H5PartFile *f		/*!< [in] filehandle of the file to close */
+) {
+
+    SET_FNAME ( "H5PartCloseFile" );
+    herr_t r = 0;
+    _h5part_errno = H5PART_SUCCESS;
+
+    CHECK_FILEHANDLE ( f );
+
+    r = _H5Part_close_hdf_ids ( f );
+    if ( r < 0 ) return r;
+
+    if ( f->file ) {
+        r = H5Fclose( f->file );
+        if ( r < 0 ) HANDLE_H5F_CLOSE_ERR;
+        f->file = 0;
+    }
+
+    /* free memory from H5PartFile struct */
+    if( f->pnparticles ) {
+        free( f->pnparticles );
+    }
+    free( f );
+
+    return _h5part_errno;
+}
+
+h5part_int64_t
+H5PartFileIsValid (
+    H5PartFile *f
+) {
+    return _H5Part_file_is_valid(f);
+}
+
+/*============== File Writing Functions ==================== */
+
+h5part_int64_t
+_H5Part_get_step_name(
+    H5PartFile *f,
+    const h5part_int64_t step,
+    char *name
+) {
+
+    /* Work around sprintf bug on older systems */
+    if (f->stepno_width == 0 && step == 0) {
+        sprintf (
+            name,
+            "%s#%0*lld",
+            f->groupname_step, 1, (long long) step );
+    }
+    else {
+        sprintf (
+            name,
+            "%s#%0*lld",
+            f->groupname_step, f->stepno_width, (long long) step );
+    }
+
+    return H5PART_SUCCESS;
+}
+
+h5part_int64_t
+H5PartDefineStepName (
+    H5PartFile *f,
+    const char *name,
+    const h5part_int64_t width
+) {
+
+    CHECK_FILEHANDLE ( f );
+
+    h5part_int64_t len = H5PART_STEPNAME_LEN - width - 2;
+    if ( strlen(name) > len ) {
+        _H5Part_print_warn (
+            "Step name has been truncated to fit within %d chars.",
+            H5PART_STEPNAME_LEN );
+    }
+
+    strncpy ( f->groupname_step, name, len );
+    f->stepno_width = (int)width;
+
+    _H5Part_print_debug ( "Step name defined as '%s'", f->groupname_step );
+
+    return H5PART_SUCCESS;
+}
+
+static h5part_int64_t
+_set_num_particles (
+    H5PartFile *f,				/*!< [in] Handle to open file */
+    const h5part_int64_t nparticles,	/*!< [in] Number of particles */
+    const h5part_int64_t _stride
+) {
+
+    int ret;
+    h5part_int64_t herr;
+
+    hsize_t count;
+#ifdef HDF5V160
+    hssize_t start;
+#else
+    hsize_t start;
+#endif
+    hsize_t stride;
+    hsize_t dmax = H5S_UNLIMITED;
+
+#ifdef H5PART_PARALLEL_IO
+    hsize_t total;
+    register int i;
+#endif
+
+    if ( nparticles <= 0 )
+        return HANDLE_H5PART_INVALID_ERR ( "nparticles", nparticles );
+
+    /* prevent invalid stride value */
+    if (_stride < 1)
+    {
+        _H5Part_print_warn (
+            "Stride < 1 was specified: changing to 1." );
+        stride = 1;
+    } else {
+        stride = (hsize_t) _stride;
+    }
+
+#ifndef H5PART_PARALLEL_IO
+    /*
+      if we are not using parallel-IO, there is enough information
+       to know that we can short circuit this routine.  However,
+       for parallel IO, this is going to cause problems because
+       we don't know if things have changed globally
+     */
+    if ( f->nparticles == nparticles && stride == 1 ) {
+        _H5Part_print_debug (
+            "Serial mode: skipping unnecessary view creation" );
+        return H5PART_SUCCESS;
+    }
+#endif
+
+    herr = _reset_view ( f );
+    if ( herr < 0 ) return herr;
+
+    if ( f->shape != H5S_ALL ) {
+        herr = H5Sclose ( f->shape );
+        if ( herr < 0 ) return HANDLE_H5S_CLOSE_ERR;
+        f->shape = H5S_ALL;
+    }
+
+    f->nparticles = (hsize_t) nparticles;
+
+    /* declare local memory datasize with striding */
+    count = f->nparticles * stride;
+    f->memshape = H5Screate_simple ( 1, &count, &dmax );
+    if ( f->memshape < 0 )
+        return HANDLE_H5S_CREATE_SIMPLE_ERR ( f->nparticles );
+
+    /* we need a hyperslab selection if there is striding
+     * (otherwise, the default H5S_ALL selection is ok)
+     */
+    if ( stride > 1 )
+    {
+        start = 0;
+        count = f->nparticles;
+        herr = H5Sselect_hyperslab (
+            f->memshape,
+            H5S_SELECT_SET,
+            &start,
+            &stride,
+            &count, NULL );
+        if ( herr < 0 ) return HANDLE_H5S_SELECT_HYPERSLAB_ERR;
+    }
+
+#ifndef H5PART_PARALLEL_IO
+    count = f->nparticles;
+    f->shape = H5Screate_simple ( 1, &count, NULL );
+    if ( f->shape < 0 ) HANDLE_H5S_CREATE_SIMPLE_ERR ( count );
+    f->viewstart = 0;
+    f->viewend   = nparticles - 1; // view range is *inclusive*
+#else /* H5PART_PARALLEL_IO */
+    /*
+      The Gameplan here is to declare the overall size of the on-disk
+      data structure the same way we do for the serial case.  But
+      then we must have additional "DataSpace" structures to define
+      our in-memory layout of our domain-decomposed portion of the particle
+      list as well as a "selection" of a subset of the on-disk
+      data layout that will be written in parallel to mutually exclusive
+      regions by all of the processors during a parallel I/O operation.
+      These are f->shape, f->memshape and f->diskshape respectively.
+     */
+
+    /*
+      acquire the number of particles to be written from each MPI process
+     */
+
+    if (f->comm) {
+        ret = MPI_Allgather (
+            (void*)&nparticles, 1, MPI_LONG_LONG,
+            f->pnparticles, 1, MPI_LONG_LONG,
+            f->comm );
+        if ( ret != MPI_SUCCESS) return HANDLE_MPI_ALLGATHER_ERR;
+    }
+    else {
+        f->pnparticles[0] = nparticles;
+    }
+
+    if ( f->myproc == 0 ) {
+        _H5Part_print_debug ( "Particle offsets:" );
+        for ( i=0; i<f->nprocs; i++ )
+            _H5Part_print_debug ( "\t[%d] np=%lld", i,
+                (long long) f->pnparticles[i] );
+    }
+
+    /* compute start offsets */
+    start = 0;
+    for (i=0; i<f->myproc; i++) {
+        start += f->pnparticles[i];
+    }
+    f->viewstart = start;
+    f->viewend   = start + f->nparticles - 1; // view range is *inclusive*
+
+    /* compute total nparticles */
+    total = 0;
+    for (i=0; i < f->nprocs; i++) {
+        total += f->pnparticles[i];
+    }
+
+    /* declare overall datasize */
+    count = total;
+    f->shape = H5Screate_simple (1, &count, NULL);
+    if ( f->shape < 0 ) return HANDLE_H5S_CREATE_SIMPLE_ERR ( count );
+
+    /* declare overall data size  but then will select a subset */
+    f->diskshape = H5Screate_simple (1, &count, NULL);
+    if ( f->diskshape < 0 ) return HANDLE_H5S_CREATE_SIMPLE_ERR ( count );
+
+    count = nparticles;
+    stride = 1;
+    herr = H5Sselect_hyperslab (
+        f->diskshape,
+        H5S_SELECT_SET,
+        &start,
+        &stride,
+        &count, NULL );
+    if ( herr < 0 ) return HANDLE_H5S_SELECT_HYPERSLAB_ERR;
+#endif
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_model
+
+  Set the number of particles for the current time-step.
+  After you call this subroutine, all subsequent
+  operations will assume this number of particles will be written.
+
+  For the parallel library, the \c nparticles value is the number of
+  particles that the \e individual task will write. You can use
+  a different value on different tasks.
+  This function uses an \c MPI_Allgather
+  call to aggregate each tasks number of particles and determine
+  the appropiate offsets. Because of the use of this MPI collective,
+  it is advisable to call this function as
+  few times as possible when running at large concurrency.
+
+  This function assumes that your particles' data fields are in stored in
+  contiguous 1D arrays.
+  For instance, the fields \e x and \e y for your particles are stored
+  in separate arrays \c x[] and \c y[].
+
+  If instead you store your particles as tuples, so that the values
+  are arranged \f$ x_1,y_1,x_2,y_2\f$... than you need to setup striding
+  (in this case with value 2) using \ref H5PartSetNumParticlesStrided.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartSetNumParticles (
+    H5PartFile *f,			/*!< [in] Handle to open file */
+    const h5part_int64_t nparticles	/*!< [in] Number of particles */
+) {
+
+    SET_FNAME ( "H5PartSetNumParticles" );
+    CHECK_FILEHANDLE( f );
+
+    h5part_int64_t herr;
+    h5part_int64_t stride = 1;
+
+    herr = _set_num_particles ( f, nparticles, stride );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_model
+
+  Set the number of particles for the current time-step.
+  After you call this subroutine, all subsequent
+  operations will assume this number of particles will be written.
+
+  For the parallel library, the \c nparticles value is the number of
+  particles that the \e individual task will write. You can use
+  a different value on different tasks.
+  This function uses an \c MPI_Allgather
+  call to aggregate each tasks number of particles and determine
+  the appropiate offsets. Because of the use of this MPI collective,
+  it is advisable to call this function as
+  few times as possible when running at large concurrency.
+
+  This function assumes that your particles' data fields are
+  stored tuples. For instance, the fields \e x and \e y of your
+  particles are arranged \f$x_1,y_1,x_2,y_2\f$... in a single data
+  array. In this example, the stride value would be 2.
+
+  If you instead have a separate array for each fields,
+  such as \c x[] and \c y[],
+  use \ref H5PartSetNumParticles.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartSetNumParticlesStrided (
+    H5PartFile *f,				/*!< [in] Handle to open file */
+    const h5part_int64_t nparticles,	/*!< [in] Number of particles */
+    const h5part_int64_t stride		/*!< [in] Stride value (e.g. number of fields in the particle array) */
+) {
+
+    SET_FNAME ( "H5PartSetNumParticlesStrided" );
+    CHECK_FILEHANDLE( f );
+
+    h5part_int64_t herr;
+
+    herr = _set_num_particles ( f, nparticles, stride );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+static void
+_normalize_dataset_name (
+    const char *name,
+    char *name2
+) {
+
+    if ( strlen(name) > H5PART_DATANAME_LEN ) {
+        strncpy ( name2, name, H5PART_DATANAME_LEN - 1 );
+        name2[H5PART_DATANAME_LEN-1] = '\0';
+        _H5Part_print_warn (
+            "Dataset name '%s' is longer than maximum %d chars. "
+            "Truncated to: '%s'",
+            name, H5PART_DATANAME_LEN, name2 );
+    } else {
+        strcpy ( name2, name );
+    }
+}
+
+static h5part_int64_t
+_write_data (
+    H5PartFile *f,		/*!< IN: Handle to open file */
+    const char *name,	/*!< IN: Name to associate array with */
+    const void *array,	/*!< IN: Array to commit to disk */
+    const hid_t type	/*!< IN: Type of data */
+) {
+
+    herr_t herr;
+    hid_t dataset_id;
+
+    char name2[H5PART_DATANAME_LEN];
+    _normalize_dataset_name ( name, name2 );
+
+    _H5Part_print_debug (
+        "Create a dataset[%s] mounted on "
+        "timestep %lld",
+        name2, (long long)f->timestep );
+
+    if ( f->shape == H5S_ALL ) {
+        _H5Part_print_warn (
+            "The view is unset or invalid: please "
+            "set the view or specify a number of particles." );
+        return HANDLE_H5PART_BAD_VIEW_ERR ( f->viewstart, f->viewend );
+    }
+
+    H5E_BEGIN_TRY
+    dataset_id = H5Dopen ( f->timegroup, name2
+#ifndef H5_USE_16_API
+        , H5P_DEFAULT
+#endif
+    );
+    H5E_END_TRY
+
+    if ( dataset_id > 0 ) {
+        _H5Part_print_warn (
+            "Dataset[%s] at timestep %lld "
+            "already exists", name2, (long long)f->timestep );
+    } else {
+#ifndef H5_USE_16_API
+        dataset_id = H5Dcreate2 (
+            f->timegroup,
+            name2,
+            type,
+            f->shape,
+            H5P_DEFAULT,
+            H5P_DEFAULT,
+            H5P_DEFAULT );
+#else
+        dataset_id = H5Dcreate (
+            f->timegroup,
+            name2,
+            type,
+            f->shape,
+            H5P_DEFAULT );
+#endif
+        if ( dataset_id < 0 )
+            return HANDLE_H5D_CREATE_ERR ( name2, f->timestep );
+    }
+
+#ifdef H5PART_PARALLEL_IO
+    herr = _H5Part_start_throttle ( f );
+    if ( herr < 0 ) return herr;
+#endif
+
+    herr = H5Dwrite (
+        dataset_id,
+        type,
+        f->memshape,
+        f->diskshape,
+        f->xfer_prop,
+        array );
+
+#ifdef H5PART_PARALLEL_IO
+    herr = _H5Part_end_throttle ( f );
+    if ( herr < 0 ) return herr;
+#endif
+
+    if ( herr < 0 ) return HANDLE_H5D_WRITE_ERR ( name2, f->timestep );
+
+    herr = H5Dclose ( dataset_id );
+    if ( herr < 0 ) return HANDLE_H5D_CLOSE_ERR;
+
+    f->empty = 0;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  Write array of 64 bit floating point data to file.
+
+  After setting the number of particles with \c H5PartSetNumParticles() and
+  the current timestep using \c H5PartSetStep(), you can start writing datasets
+  into the file. Each dataset has a name associated with it (chosen by the
+  user) in order to facilitate later retrieval. The name of the dataset is
+  specified in the parameter \c name, which must be a null-terminated string.
+
+  There are no restrictions on naming of datasets, but it is useful to arrive
+  at some common naming convention when sharing data with other groups.
+
+  The writing routines also implicitly store the datatype of the array so that
+  the array can be reconstructed properly on other systems with incompatible
+  type representations.
+
+  All data that is written after setting the timestep is associated with that
+  timestep. While the number of particles can change for each timestep, you
+  cannot change the number of particles in the middle of a given timestep.
+
+  The data is committed to disk before the routine returns.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartWriteDataFloat64 (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate array with */
+    const h5part_float64_t *array	/*!< [in] Array to commit to disk */
+) {
+
+    SET_FNAME ( "H5PartWriteDataFloat64" );
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_WRITABLE_MODE( f );
+    CHECK_TIMEGROUP( f );
+
+    herr = _write_data ( f, name, (void*)array, H5T_NATIVE_DOUBLE );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  Write array of 32 bit floating point data to file.
+
+  After setting the number of particles with \c H5PartSetNumParticles() and
+  the current timestep using \c H5PartSetStep(), you can start writing datasets
+  into the file. Each dataset has a name associated with it (chosen by the
+  user) in order to facilitate later retrieval. The name of the dataset is
+  specified in the parameter \c name, which must be a null-terminated string.
+
+  There are no restrictions on naming of datasets, but it is useful to arrive
+  at some common naming convention when sharing data with other groups.
+
+  The writing routines also implicitly store the datatype of the array so that
+  the array can be reconstructed properly on other systems with incompatible
+  type representations.
+
+  All data that is written after setting the timestep is associated with that
+  timestep. While the number of particles can change for each timestep, you
+  cannot change the number of particles in the middle of a given timestep.
+
+  The data is committed to disk before the routine returns.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartWriteDataFloat32 (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate array with */
+    const h5part_float32_t *array	/*!< [in] Array to commit to disk */
+) {
+
+    SET_FNAME ( "H5PartWriteDataFloat32" );
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_WRITABLE_MODE( f );
+    CHECK_TIMEGROUP( f );
+
+    herr = _write_data ( f, name, (void*)array, H5T_NATIVE_FLOAT );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  Write array of 64 bit integer data to file.
+
+  After setting the number of particles with \c H5PartSetNumParticles() and
+  the current timestep using \c H5PartSetStep(), you can start writing datasets
+  into the file. Each dataset has a name associated with it (chosen by the
+  user) in order to facilitate later retrieval. The name of the dataset is
+  specified in the parameter \c name, which must be a null-terminated string.
+
+  There are no restrictions on naming of datasets, but it is useful to arrive
+  at some common naming convention when sharing data with other groups.
+
+  The writing routines also implicitly store the datatype of the array so that
+  the array can be reconstructed properly on other systems with incompatible
+  type representations.
+
+  All data that is written after setting the timestep is associated with that
+  timestep. While the number of particles can change for each timestep, you
+  cannot change the number of particles in the middle of a given timestep.
+
+  The data is committed to disk before the routine returns.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartWriteDataInt64 (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate array with */
+    const h5part_int64_t *array	/*!< [in] Array to commit to disk */
+) {
+
+    SET_FNAME ( "H5PartWriteDataInt64" );
+
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_WRITABLE_MODE( f );
+    CHECK_TIMEGROUP( f );
+
+    herr = _write_data ( f, name, (void*)array, H5T_NATIVE_INT64 );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  Write array of 32 bit integer data to file.
+
+  After setting the number of particles with \c H5PartSetNumParticles() and
+  the current timestep using \c H5PartSetStep(), you can start writing datasets
+  into the file. Each dataset has a name associated with it (chosen by the
+  user) in order to facilitate later retrieval. The name of the dataset is
+  specified in the parameter \c name, which must be a null-terminated string.
+
+  There are no restrictions on naming of datasets, but it is useful to arrive
+  at some common naming convention when sharing data with other groups.
+
+  The writing routines also implicitly store the datatype of the array so that
+  the array can be reconstructed properly on other systems with incompatible
+  type representations.
+
+  All data that is written after setting the timestep is associated with that
+  timestep. While the number of particles can change for each timestep, you
+  cannot change the number of particles in the middle of a given timestep.
+
+  The data is committed to disk before the routine returns.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartWriteDataInt32 (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate array with */
+    const h5part_int32_t *array	/*!< [in] Array to commit to disk */
+) {
+
+    SET_FNAME ( "H5PartWriteDataInt32" );
+
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_WRITABLE_MODE( f );
+    CHECK_TIMEGROUP( f );
+
+    herr = _write_data ( f, name, (void*)array, H5T_NATIVE_INT32 );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/********************** reading and writing attribute ************************/
+
+/********************** private functions to handle attributes ***************/
+
+/*!
+  \ingroup h5partkernel
+  @{
+ */
+
+h5part_int64_t
+_H5Part_make_string_type(
+    hid_t *stype,
+    int size
+) {
+    *stype = H5Tcopy ( H5T_C_S1 );
+    if ( *stype < 0 ) return HANDLE_H5T_STRING_ERR;
+    herr_t herr = H5Tset_size ( *stype, size );
+    if ( herr < 0 ) return HANDLE_H5T_STRING_ERR;
+    return H5PART_SUCCESS;
+}
+
+/*!
+   Normalize HDF5 type
+ */
+h5part_int64_t
+_H5Part_normalize_h5_type (
+    hid_t type
+) {
+
+    H5T_class_t tclass = H5Tget_class ( type );
+    int size = H5Tget_size ( type );
+
+    switch ( tclass ) {
+    case H5T_INTEGER:
+        if ( size==8 ) {
+            return H5PART_INT64;
+        }
+        else if ( size==1 ) {
+            return H5PART_CHAR;
+        }
+        break;
+    case H5T_FLOAT:
+        if ( size==8 ) {
+            return H5PART_FLOAT64;
+        }
+        else if ( size==4 ) {
+            return H5PART_FLOAT32;
+        }
+        break;
+    case H5T_STRING:
+        return H5PART_STRING;
+    default:
+        ;/* NOP */
+    }
+
+    return HANDLE_H5PART_TYPE_ERR;
+}
+
+h5part_int64_t
+_H5Part_read_attrib (
+    hid_t id,
+    const char *attrib_name,
+    void *attrib_value
+) {
+
+    herr_t herr;
+    h5part_int64_t h5err;
+    hid_t attrib_id;
+    hid_t space_id;
+    hid_t type_id;
+
+#ifndef H5_USE_16_API
+    if (! H5Aexists ( id, attrib_name )) {
+        _H5Part_print_warn ( "Attribute '%s' does not exist!", attrib_name );
+    }
+    attrib_id = H5Aopen ( id, attrib_name, H5P_DEFAULT );
+#else
+    attrib_id = H5Aopen_name ( id, attrib_name );
+#endif
+    if ( attrib_id <= 0 ) return HANDLE_H5A_OPEN_NAME_ERR( attrib_name );
+
+    type_id = H5Aget_type ( attrib_id );
+    if ( type_id < 0 ) return HANDLE_H5A_GET_TYPE_ERR;
+
+    space_id = H5Aget_space ( attrib_id );
+    if ( space_id < 0 ) return HANDLE_H5A_GET_SPACE_ERR;
+
+    herr = H5Aread ( attrib_id, type_id, attrib_value );
+    if ( herr < 0 ) return HANDLE_H5A_READ_ERR;
+
+    herr = H5Sclose ( space_id );
+    if ( herr < 0 ) return HANDLE_H5S_CLOSE_ERR;
+
+    herr = H5Tclose ( type_id );
+    if ( herr < 0 ) return HANDLE_H5T_CLOSE_ERR;
+
+    herr = H5Aclose ( attrib_id );
+    if ( herr < 0 ) return HANDLE_H5A_CLOSE_ERR;
+
+    return H5PART_SUCCESS;
+}
+
+h5part_int64_t
+_H5Part_write_attrib (
+    hid_t id,
+    const char *attrib_name,
+    const hid_t attrib_type,
+    const void *attrib_value,
+    const hsize_t attrib_nelem
+) {
+
+    h5part_int64_t herr;
+    hid_t space_id;
+    hid_t attrib_id;
+    hid_t type = attrib_type;
+
+    if ( attrib_type == H5PART_STRING )
+    {
+        herr = _H5Part_make_string_type ( &type, attrib_nelem );
+        if ( herr < 0 ) return herr;
+
+        space_id = H5Screate (H5S_SCALAR);
+        if ( space_id < 0 )
+            return HANDLE_H5S_CREATE_SCALAR_ERR;
+    }
+    else {
+        space_id = H5Screate_simple ( 1, &attrib_nelem, NULL );
+        if ( space_id < 0 )
+            return HANDLE_H5S_CREATE_SIMPLE_ERR ( attrib_nelem );
+    }
+
+    attrib_id = H5Acreate(
+        id,
+        attrib_name,
+        type,
+        space_id,
+        H5P_DEFAULT
+#ifndef H5_USE_16_API
+        , H5P_DEFAULT
+#endif
+    );
+
+    if ( attrib_id < 0 ) return HANDLE_H5A_CREATE_ERR ( attrib_name );
+
+    herr = H5Awrite ( attrib_id, type, attrib_value);
+    if ( herr < 0 ) return HANDLE_H5A_WRITE_ERR ( attrib_name );
+
+    herr = H5Aclose ( attrib_id );
+    if ( herr < 0 ) return HANDLE_H5A_CLOSE_ERR;
+
+    herr = H5Sclose ( space_id );
+    if ( herr < 0 ) return HANDLE_H5S_CLOSE_ERR;
+
+    if ( attrib_type == H5PART_STRING ) {
+        herr = H5Tclose ( type );
+        if ( herr < 0 ) return HANDLE_H5T_CLOSE_ERR;
+    }
+
+    return H5PART_SUCCESS;
+}
+
+h5part_int64_t
+_H5Part_write_file_attrib (
+    H5PartFile *f,
+    const char *name,
+    const hid_t type,
+    const void *value,
+    const hsize_t nelem
+) {
+
+    hid_t group_id = H5Gopen ( f->file, "/"
+#ifndef H5_USE_16_API
+        , H5P_DEFAULT
+#endif
+    );
+
+    if ( group_id < 0 ) return HANDLE_H5G_OPEN_ERR( "/" );
+
+    h5part_int64_t herr = _H5Part_write_attrib (
+        group_id,
+        name,
+        type,
+        value,
+        nelem );
+    if ( herr < 0 ) return herr;
+
+    herr = H5Gclose ( group_id );
+    if ( herr < 0 ) return HANDLE_H5G_CLOSE_ERR;
+
+    return H5PART_SUCCESS;
+}
+
+h5part_int64_t
+_H5Part_write_step_attrib (
+    H5PartFile *f,
+    const char *name,
+    const hid_t type,
+    const void *value,
+    const hsize_t nelem
+) {
+
+    CHECK_TIMEGROUP( f );
+
+    h5part_int64_t herr = _H5Part_write_attrib (
+        f->timegroup,
+        name,
+        type,
+        value,
+        nelem );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+h5part_int64_t
+_H5Part_get_attrib_info (
+    hid_t id,
+    const h5part_int64_t attrib_idx,
+    char *attrib_name,
+    const h5part_int64_t len_attrib_name,
+    h5part_int64_t *attrib_type,
+    h5part_int64_t *attrib_nelem
+) {
+
+    herr_t herr;
+    hid_t attrib_id;
+    hid_t mytype;
+    hid_t space_id;
+
+    attrib_id = H5Aopen_idx ( id, (unsigned int)attrib_idx );
+    if ( attrib_id < 0 ) return HANDLE_H5A_OPEN_IDX_ERR ( attrib_idx );
+
+    if ( attrib_nelem ) {
+        space_id =  H5Aget_space ( attrib_id );
+        if ( space_id < 0 ) return HANDLE_H5A_GET_SPACE_ERR;
+
+        *attrib_nelem = H5Sget_simple_extent_npoints ( space_id );
+        if ( *attrib_nelem < 0 )
+            return HANDLE_H5S_GET_SIMPLE_EXTENT_NPOINTS_ERR;
+
+        herr = H5Sclose ( space_id );
+        if ( herr < 0 ) return HANDLE_H5S_CLOSE_ERR;
+    }
+    if ( attrib_name ) {
+        herr = H5Aget_name (
+            attrib_id,
+            (size_t)len_attrib_name,
+            attrib_name );
+        if ( herr < 0 ) return HANDLE_H5A_GET_NAME_ERR;
+    }
+    if ( attrib_type ) {
+        mytype = H5Aget_type ( attrib_id );
+        if ( mytype < 0 ) return HANDLE_H5A_GET_TYPE_ERR;
+
+        *attrib_type = _H5Part_normalize_h5_type ( mytype );
+        if ( *attrib_type < 0 ) return *attrib_type;
+
+        herr = H5Tclose ( mytype );
+        if ( herr < 0 ) return HANDLE_H5T_CLOSE_ERR;
+    }
+    herr = H5Aclose ( attrib_id);
+    if ( herr < 0 ) return HANDLE_H5A_CLOSE_ERR;
+
+    return H5PART_SUCCESS;
+}
+/*!
+  }@
+ */
+
+/********************** attribute API ****************************************/
+
+/*!
+  \ingroup h5part_attrib
+
+  Writes an attribute \c name with the string \c value to
+  the file root ("/").
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartWriteFileAttribString (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name of attribute to create */
+    const char *value	/*!< [in] Value of attribute */
+) {
+
+    SET_FNAME ( "H5PartWriteFileAttribString" );
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_WRITABLE_MODE( f );
+
+    h5part_int64_t herr = _H5Part_write_file_attrib (
+        f,
+        name,
+        H5PART_STRING,
+        value,
+        strlen ( value ) + 1 );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Writes an attribute \c name with the string \c value to
+  the current timestep.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartWriteStepAttribString (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name of attribute to create */
+    const char *value	/*!< [in] Value of attribute */
+) {
+
+    SET_FNAME ( "H5PartWriteStepAttribString" );
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_WRITABLE_MODE( f );
+
+    h5part_int64_t herr = _H5Part_write_step_attrib (
+        f,
+        name,
+        H5PART_STRING,
+        value,
+        strlen ( value ) + 1 );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Writes an attribute \c name with values in the array \c data
+  of \c nelem elements to
+  the current timestep.
+
+  The type of \c data must ve specified using one of the folowing
+  macros:
+
+  - \c H5PART_FLOAT64 (for \c h5part_float64_t)
+  - \c H5PART_FLOAT32 (for \c h5part_float32_t)
+  - \c H5PART_INT64 (for \c h5part_int64_t)
+  - \c H5PART_INT32 (for \c h5part_int32_t)
+  - \c H5PART_CHAR (for \c char)
+  - \c H5PART_STRING (for \c char*)
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartWriteStepAttrib (
+    H5PartFile *f,			/*!< [in] Handle to open file */
+    const char *name,		/*!< [in] Name of attribute */
+    const h5part_int64_t type,	/*!< [in] Type of values */
+    const void *data,		/*!< [in] Array of attribute values */
+    const h5part_int64_t nelem	/*!< [in] Number of array elements */
+){
+
+    SET_FNAME ( "H5PartWriteStepAttrib" );
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_WRITABLE_MODE( f );
+    CHECK_TIMEGROUP( f );
+
+    h5part_int64_t herr = _H5Part_write_step_attrib (
+        f,
+        name,
+        (const hid_t)type,
+        data,
+        nelem );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Writes an attribute \c name with values in the array \c data
+  of \c nelem elements to
+  the file root ("/").
+
+  The type of \c data must ve specified using one of the folowing
+  macros:
+
+  - \c H5PART_FLOAT64 (for \c h5part_float64_t)
+  - \c H5PART_FLOAT32 (for \c h5part_float32_t)
+  - \c H5PART_INT64 (for \c h5part_int64_t)
+  - \c H5PART_INT32 (for \c h5part_int32_t)
+  - \c H5PART_CHAR (for \c char)
+  - \c H5PART_STRING (for \c char*)
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartWriteFileAttrib (
+    H5PartFile *f,			/*!< [in] Handle to open file */
+    const char *name,		/*!< [in] Name of attribute */
+    const h5part_int64_t type,	/*!< [in] Type of values */
+    const void *data,		/*!< [in] Array of attribute values */
+    const h5part_int64_t nelem	/*!< [in] Number of array elements */
+) {
+
+    SET_FNAME ( "H5PartWriteFileAttrib" );
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_WRITABLE_MODE ( f );
+
+    h5part_int64_t herr = _H5Part_write_file_attrib (
+        f,
+        name,
+        (const hid_t)type,
+        data,
+        nelem );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Gets the number of attributes bound to the current step.
+
+  \return	Number of attributes bound to current time step or error code.
+ */
+h5part_int64_t
+H5PartGetNumStepAttribs (
+    H5PartFile *f			/*!< [in] Handle to open file */
+) {
+
+    SET_FNAME ( "H5PartGetNumStepAttribs" );
+    CHECK_FILEHANDLE ( f );
+
+    h5part_int64_t nattribs;
+
+    nattribs = H5Aget_num_attrs(f->timegroup);
+    if ( nattribs < 0 ) HANDLE_H5A_GET_NUM_ATTRS_ERR;
+
+    return nattribs;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Gets the number of attributes bound to the file.
+
+  \return	Number of attributes bound to file \c f or error code.
+ */
+h5part_int64_t
+H5PartGetNumFileAttribs (
+    H5PartFile *f			/*!< [in] Handle to open file */
+) {
+
+    SET_FNAME ( "H5PartGetNumFileAttribs" );
+    herr_t herr;
+    h5part_int64_t nattribs;
+
+    CHECK_FILEHANDLE ( f );
+
+
+    hid_t group_id = H5Gopen ( f->file, "/"
+#ifndef H5_USE_16_API
+        , H5P_DEFAULT
+#endif
+    );
+
+    if ( group_id < 0 ) HANDLE_H5G_OPEN_ERR ( "/" );
+
+    nattribs = H5Aget_num_attrs ( group_id );
+    if ( nattribs < 0 ) HANDLE_H5A_GET_NUM_ATTRS_ERR;
+
+    herr = H5Gclose ( group_id );
+    if ( herr < 0 ) HANDLE_H5G_CLOSE_ERR;
+    return nattribs;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Gets the name, type and number of elements of the step attribute
+  specified by its index.
+
+  This function can be used to retrieve all attributes bound to the
+  current time-step by looping from \c 0 to the number of attribute
+  minus one.  The number of attributes bound to the current
+  time-step can be queried by calling the function
+  \c H5PartGetNumStepAttribs().
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartGetStepAttribInfo (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t attrib_idx,/*!< [in]  Index of attribute to
+                           get infos about */
+    char *attrib_name,		/*!< [out] Name of attribute */
+    const h5part_int64_t len_of_attrib_name,
+    /*!< [in]  length of buffer \c name */
+    h5part_int64_t *attrib_type,	/*!< [out] Type of value. */
+    h5part_int64_t *attrib_nelem	/*!< [out] Number of elements */
+) {
+
+    SET_FNAME ( "H5PartGetStepAttribInfo" );
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    herr = _H5Part_get_attrib_info (
+        f->timegroup,
+        attrib_idx,
+        attrib_name,
+        len_of_attrib_name,
+        attrib_type,
+        attrib_nelem );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Gets the name, type and number of elements of the file attribute
+  specified by its index.
+
+  This function can be used to retrieve all attributes bound to the
+  file \c f by looping from \c 0 to the number of attribute minus
+  one.  The number of attributes bound to file \c f can be queried
+  by calling the function \c H5PartGetNumFileAttribs().
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+
+h5part_int64_t
+H5PartGetFileAttribInfo (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t attrib_idx,/*!< [in]  Index of attribute to get
+                           infos about */
+    char *attrib_name,		/*!< [out] Name of attribute */
+    const h5part_int64_t len_of_attrib_name,
+    /*!< [in]  length of buffer \c name */
+    h5part_int64_t *attrib_type,	/*!< [out] Type of value. */
+    h5part_int64_t *attrib_nelem	/*!< [out] Number of elements */
+) {
+
+    SET_FNAME ( "H5PartGetFileAttribInfo" );
+    hid_t group_id;
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    group_id = H5Gopen(f->file,"/"
+#ifndef H5_USE_16_API
+        , H5P_DEFAULT
+#endif
+    );
+
+    if ( group_id < 0 ) return HANDLE_H5G_OPEN_ERR( "/" );
+
+    herr = _H5Part_get_attrib_info (
+        group_id,
+        attrib_idx,
+        attrib_name,
+        len_of_attrib_name,
+        attrib_type,
+        attrib_nelem );
+    if ( herr < 0 ) return herr;
+
+    herr = H5Gclose ( group_id );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Reads an attribute bound to current time-step.
+
+  \return \c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartReadStepAttrib (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const char *attrib_name,	/*!< [in] Name of attribute to read */
+    void *attrib_value		/*!< [out] Value of attribute */
+) {
+
+    SET_FNAME ( "H5PartReadStepAttrib" );
+    CHECK_FILEHANDLE( f );
+
+    h5part_int64_t herr;
+
+    herr = _H5Part_read_attrib ( f->timegroup, attrib_name, attrib_value );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_attrib
+
+  Reads an attribute bound to file \c f.
+
+  \return \c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartReadFileAttrib (
+    H5PartFile *f,
+    const char *attrib_name,
+    void *attrib_value
+) {
+
+    SET_FNAME ( "H5PartReadFileAttrib" );
+
+    hid_t group_id;
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    group_id = H5Gopen(f->file,"/"
+#ifndef H5_USE_16_API
+        , H5P_DEFAULT
+#endif
+    );
+
+    if ( group_id < 0 ) return HANDLE_H5G_OPEN_ERR( "/" );
+
+    herr = _H5Part_read_attrib ( group_id, attrib_name, attrib_value );
+    if ( herr < 0 ) return herr;
+
+    herr = H5Gclose ( group_id );
+    if ( herr < 0 ) return HANDLE_H5G_CLOSE_ERR;
+
+    return H5PART_SUCCESS;
+}
+
+
+/*================== File Reading Routines =================*/
+/*
+  H5PartSetStep:
+
+
+  So you use this to random-access the file for a particular timestep.
+  Failure to explicitly set the timestep on each read will leave you
+  stuck on the same timestep for *all* of your reads.  That is to say
+  the writes auto-advance the file pointer, but the reads do not
+  (they require explicit advancing by selecting a particular timestep).
+ */
+
+h5part_int64_t
+_H5Part_set_step (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t step	/*!< [in]  Time-step to set. */
+) {
+
+    char stepname[H5PART_STEPNAME_LEN];
+    _H5Part_get_step_name(f, step, stepname);
+
+    if ( (!(f->flags & H5PART_READ)) && _H5Part_have_group ( f->file, stepname ) ) {
+        return HANDLE_H5PART_STEP_EXISTS_ERR ( step );
+    }
+
+    if ( f->timegroup >= 0 ) {
+        herr_t herr = H5Gclose ( f->timegroup );
+        if ( herr < 0 ) return HANDLE_H5G_CLOSE_ERR;
+    }
+    f->timegroup = -1;
+    f->timestep = step;
+
+    if ( f->flags & H5PART_READ ) {
+        _H5Part_print_debug (
+            "Proc[%d]: Set step to #%lld for file %lld",
+            f->myproc,
+            (long long)step,
+            (long long)(size_t) f );
+
+        f->timegroup = H5Gopen ( f->file, stepname
+#ifndef H5_USE_16_API
+            , H5P_DEFAULT
+#endif
+        );
+        if ( f->timegroup < 0 )
+            return HANDLE_H5G_OPEN_ERR ( stepname );
+    }
+    else {
+        _H5Part_print_debug (
+            "Proc[%d]: Create step #%lld for file %lld",
+            f->myproc,
+            (long long)step,
+            (long long)(size_t) f );
+
+        f->timegroup = H5Gcreate( f->file, stepname, 0
+#ifndef H5_USE_16_API
+            , H5P_DEFAULT, H5P_DEFAULT
+#endif
+        );
+        if ( f->timegroup < 0 )
+            return HANDLE_H5G_CREATE_ERR ( stepname );
+    }
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_model
+
+  Set the current time-step.
+
+  When writing data to a file the current time step must be set first
+  (even if there is only one). In write-mode this function creates a new
+  time-step! You are not allowed to step to an already existing time-step.
+  This prevents you from overwriting existing data. Another consequence is,
+  that you \b must write all data before going to the next time-step.
+
+  In read-mode you can use this function to random-access the file for a
+  particular timestep.
+
+  \return \c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartSetStep (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t step	/*!< [in]  Time-step to set. */
+) {
+
+    SET_FNAME ( "H5PartSetStep" );
+
+    CHECK_FILEHANDLE ( f );
+
+    return _H5Part_set_step ( f, step );
+}
+
+/********************** query file structure *********************************/
+
+/*!
+  \ingroup h5part_kernel
+
+  Test whether a group named \c name exists at location \c id.
+ */
+h5part_int64_t
+_H5Part_have_group (
+    const hid_t id,
+    const char *name
+) {
+#ifndef H5_USE_16_API
+    return (H5Lexists( id, name, H5P_DEFAULT ) ? 1 : 0);
+#else
+    herr_t exists = 0;
+    H5E_BEGIN_TRY
+    H5Gget_objinfo( id, name, 1, NULL );
+    H5E_END_TRY
+    return (exists >= 0 ? 1 : 0);
+#endif
+}
+
+
+/********************** query file structure *********************************/
+
+/*!
+  \ingroup h5part_kernel
+
+  Iterator for \c H5Giterate().
+ */
+#ifndef H5_USE_16_API
+herr_t
+_H5Part_iteration_operator2 (
+    hid_t group_id,			/*!< [in] parent object id */
+    const char *member_name,	/*!< [in] child object name */
+    const H5L_info_t *linfo,	/*!< link info */
+    void *operator_data		/*!< [in,out] data passed to the iterator */
+) {
+
+    struct _iter_op_data *data = (struct _iter_op_data*)operator_data;
+    herr_t herr = 0;
+
+    switch (linfo->type) {
+    case H5L_TYPE_HARD: {
+
+        H5O_info_t objinfo;
+        if( H5Oget_info_by_name( group_id, member_name, &objinfo, H5P_DEFAULT ) < 0 ) {
+            return (herr_t)HANDLE_H5G_GET_OBJINFO_ERR ( member_name );
+        }
+
+        switch(objinfo.type)
+        {
+        case H5O_TYPE_GROUP:
+        case H5O_TYPE_DATASET:
+            return _H5Part_iteration_operator( group_id,
+                member_name,
+                operator_data );
+            break;
+
+        default:
+            return (herr_t)HANDLE_H5G_GET_OBJINFO_ERR ( member_name );
+            break;
+        }
+
+        break;
+    }
+
+    case H5L_TYPE_EXTERNAL: {
+        char *targbuf = (char*) malloc( linfo->u.val_size );
+        if ( targbuf == NULL ) return (herr_t)HANDLE_H5PART_NOMEM_ERR;
+
+        if(H5Lget_val(group_id, member_name, targbuf, linfo->u.val_size,
+            H5P_DEFAULT) < 0) {
+
+            // DO TO - THROW AN ERROR
+        } else {
+            const char *filename;
+            const char *targname;
+
+            if(H5Lunpack_elink_val(targbuf, linfo->u.val_size, 0,
+                &filename, &targname) < 0) {
+                // DO TO - THROW AN ERROR
+            } else {
+
+                /* 	  std::cout << "VsFilter::visitLinks: node '" << member_name << "' is an external link." << std::endl; */
+
+                /* 	  std::cout << "VsFilter::visitLinks: node '" << targname << "' the is an external target group." << std::endl; */
+
+                free(targbuf);
+
+                // Open the linked object.
+                H5O_info_t objinfo;
+                hid_t obj_id = H5Oopen(group_id, member_name, H5P_DEFAULT);
+                if ( obj_id < 0 ) {
+                    return (herr_t)HANDLE_H5G_OPEN_ERR ( member_name );
+                }
+                else if ( H5Oget_info ( obj_id, &objinfo ) < 0 ) {
+                    return (herr_t)HANDLE_H5G_GET_OBJINFO_ERR ( member_name );
+                }
+                else {
+
+                    H5Oclose( obj_id );
+
+                    switch(objinfo.type)
+                    {
+                    case H5O_TYPE_GROUP:
+                    case H5O_TYPE_DATASET:
+                        return _H5Part_iteration_operator( group_id,
+                            member_name,
+                            operator_data );
+                        break;
+
+                    default:
+                        return (herr_t)HANDLE_H5G_GET_OBJINFO_ERR ( member_name );
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    break;
+
+
+    default:
+        return (herr_t)HANDLE_H5G_GET_OBJINFO_ERR ( member_name );
+        break;
+    }
+
+    return 0;
+}
+#endif // H5_USE_16_API
+
+
+/********************** query file structure *********************************/
+
+/*!
+  \ingroup h5part_kernel
+
+  Iterator for \c H5Giterate().
+ */
+herr_t
+_H5Part_iteration_operator (
+    hid_t group_id,		/*!< [in] parent object id */
+    const char *member_name,/*!< [in] child object name */
+    void *operator_data	/*!< [in,out] data passed to the iterator */
+) {
+
+    struct _iter_op_data *data = (struct _iter_op_data*)operator_data;
+    herr_t herr;
+
+    /*   printf( "%d GROUP ITERATOR %s %d\n", __LINE__, member_name, data->type ); */
+
+    if ( data->type != H5G_UNKNOWN )
+    {
+#ifndef H5_USE_16_API
+        H5O_info_t objinfo;
+
+        hid_t obj_id = H5Oopen(group_id, member_name, H5P_DEFAULT);
+        if ( obj_id < 0 )
+            return (herr_t)HANDLE_H5G_OPEN_ERR ( member_name );
+
+        herr = H5Oget_info ( obj_id, &objinfo );
+        if ( herr < 0 )
+            return (herr_t)HANDLE_H5G_GET_OBJINFO_ERR ( member_name );
+
+        H5Oclose( obj_id );
+#else
+        H5G_stat_t objinfo;
+        herr = H5Gget_objinfo( group_id, member_name, 1, &objinfo );
+        if ( herr < 0 )
+            return (herr_t)HANDLE_H5G_GET_OBJINFO_ERR ( member_name );
+#endif
+        if ( objinfo.type != data->type )
+            return 0; /* don't count, continue iteration */
+    }
+
+    if ( data->name && (data->stop_idx == data->count) )
+    {
+        memset ( data->name, 0, data->len );
+        strncpy ( data->name, member_name, data->len-1 );
+
+        return 1;	/* stop iteration */
+    }
+
+    /* count only if pattern is NULL or member name matches */
+    if ( !data->pattern ||
+        (strncmp (member_name, data->pattern, strlen(data->pattern)) == 0)
+    ) {
+        data->count++;
+    }
+
+    return 0;		/* continue iteration */
+}
+
+/*!
+  \ingroup h5part_kernel
+
+  Iterator for \c H5Giterate().
+ */
+h5part_int64_t
+_H5Part_get_num_objects (
+    hid_t group_id,
+    const char *group_name,
+    const hid_t type
+) {
+
+    return _H5Part_get_num_objects_matching_pattern (
+        group_id,
+        group_name,
+        type,
+        NULL );
+}
+
+/*!
+  \ingroup h5part_kernel
+
+  Iterator for \c H5Giterate().
+ */
+h5part_int64_t
+_H5Part_get_num_objects_matching_pattern (
+    hid_t group_id,
+    const char *group_name,
+    const hid_t type,
+    char * const pattern
+) {
+
+    h5part_int64_t herr;
+    int idx = 0;
+    struct _iter_op_data data;
+
+    memset ( &data, 0, sizeof ( data ) );
+    data.type = type;
+    data.pattern = pattern;
+
+#ifndef H5_USE_16_API
+    hid_t child_id = H5Gopen( group_id, group_name, H5P_DEFAULT );
+    if ( child_id < 0 ) return child_id;
+    herr = H5Literate( child_id, H5_INDEX_NAME, H5_ITER_INC, 0,
+        _H5Part_iteration_operator2, &data );
+#else
+    herr = H5Giterate ( group_id, group_name, &idx,
+        _H5Part_iteration_operator, &data );
+#endif
+    if ( herr < 0 ) return herr;
+
+#ifndef H5_USE_16_API
+    herr = H5Gclose ( child_id );
+    if ( herr < 0 ) return HANDLE_H5G_CLOSE_ERR;
+#endif
+
+    return data.count;
+}
+
+/*!
+  \ingroup h5part_kernel
+
+  \return	1 on success
+        0 for no entry
+ */
+h5part_int64_t
+_H5Part_get_object_name (
+    hid_t group_id,
+    const char *group_name,
+    const hid_t type,
+    const h5part_int64_t idx,
+    char *obj_name,
+    const h5part_int64_t len_obj_name
+) {
+
+    herr_t herr;
+    struct _iter_op_data data;
+    int iterator_idx = 0;
+
+    memset ( &data, 0, sizeof ( data ) );
+    data.stop_idx = (hid_t)idx;
+    data.type = type;
+    data.name = obj_name;
+    data.len = (size_t)len_obj_name;
+
+#ifndef H5_USE_16_API
+    hid_t child_id = H5Gopen ( group_id, group_name, H5P_DEFAULT );
+    if ( child_id < 0 ) return child_id;
+    herr = H5Literate ( child_id, H5_INDEX_NAME, H5_ITER_INC, 0,
+        _H5Part_iteration_operator2, &data );
+#else
+    herr = H5Giterate ( group_id, group_name, &iterator_idx,
+        _H5Part_iteration_operator, &data );
+#endif
+    if ( herr < 0 ) {
+        return HANDLE_H5L_ITERATE_ERR;
+    }
+
+#ifndef H5_USE_16_API
+    herr_t herr2 = H5Gclose ( child_id );
+    if ( herr2 < 0 ) return HANDLE_H5G_CLOSE_ERR;
+#endif
+
+    if ( herr == 0 ) return 0;
+
+    return 1;
+}
+
+/*!
+  \ingroup h5part_model
+
+  Query whether a particular \a step already exists in
+  the file \a f.
+
+  \return	0 or 1
+ */
+h5part_int64_t
+H5PartHasStep (
+    H5PartFile *f,		/*!< [in]  Handle to open file */
+    h5part_int64_t step	/*!< [in]  Step number to query */
+) {
+
+    SET_FNAME ( "H5PartHasStep" );
+
+    CHECK_FILEHANDLE( f );
+
+    char stepname[H5PART_STEPNAME_LEN];
+    _H5Part_get_step_name(f, step, stepname);
+
+    return _H5Part_have_group ( f->file, stepname );
+}
+
+
+/*!
+  \ingroup h5part_model
+
+  Get the number of time-steps that are currently stored in the file
+  \c f.
+
+  It works for both reading and writing of files, but is probably
+  only typically used when you are reading.
+
+  \return	number of time-steps or error code
+ */
+h5part_int64_t
+H5PartGetNumSteps (
+    H5PartFile *f			/*!< [in]  Handle to open file */
+) {
+
+    SET_FNAME ( "H5PartGetNumSteps" );
+
+    CHECK_FILEHANDLE( f );
+
+    return _H5Part_get_num_objects_matching_pattern (
+        f->file,
+        "/",
+        H5G_UNKNOWN,
+        f->groupname_step );
+}
+
+/*!
+  \ingroup h5part_model
+
+  Get the number of datasets that are stored at the current time-step.
+
+  \return	number of datasets in current timestep or error code
+ */
+
+h5part_int64_t
+H5PartGetNumDatasets (
+    H5PartFile *f			/*!< [in]  Handle to open file */
+) {
+
+    SET_FNAME ( "H5PartGetNumDatasets" );
+
+    CHECK_FILEHANDLE( f );
+
+    char stepname[H5PART_STEPNAME_LEN];
+    _H5Part_get_step_name(f, f->timestep, stepname);
+
+    return _H5Part_get_num_objects ( f->file, stepname, H5G_DATASET );
+}
+
+/*!
+  \ingroup h5part_model
+
+  This reads the name of a dataset specified by it's index in the current
+  time-step.
+
+  If the number of datasets is \c n, the range of \c _index is \c 0 to \c n-1.
+
+  \result	\c H5PART_SUCCESS
+ */
+h5part_int64_t
+H5PartGetDatasetName (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t idx,	/*!< [in]  Index of the dataset */
+    char *name,			/*!< [out] Name of dataset */
+    const h5part_int64_t len_of_name/*!< [in]  Size of buffer \c name */
+) {
+
+    SET_FNAME ( "H5PartGetDatasetName" );
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_TIMEGROUP ( f );
+
+    char stepname[H5PART_STEPNAME_LEN];
+    _H5Part_get_step_name(f, f->timestep, stepname);
+
+    h5part_int64_t herr = _H5Part_get_object_name (
+        f->file,
+        stepname,
+        H5G_DATASET,
+        idx,
+        name,
+        len_of_name );
+    if ( herr == 0 ) HANDLE_H5PART_NOENTRY_ERR(
+        stepname, H5G_DATASET, idx );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_model
+
+  Gets the name, type and number of elements of a dataset based on its
+  index in the current timestep.
+
+  Type is one of the following macros:
+
+  - \c H5PART_FLOAT64 (for \c h5part_float64_t)
+  - \c H5PART_FLOAT32 (for \c h5part_float32_t)
+  - \c H5PART_INT64 (for \c h5part_int64_t)
+  - \c H5PART_INT32 (for \c h5part_int32_t)
+  - \c H5PART_CHAR (for \c char)
+  - \c H5PART_STRING (for \c char*)
+
+  \return	\c H5PART_SUCCESS
+ */
+h5part_int64_t
+H5PartGetDatasetInfo (
+    H5PartFile *f,		/*!< [in]  Handle to open file */
+    const h5part_int64_t idx,/*!< [in]  Index of the dataset */
+    char *dataset_name,	/*!< [out] Name of dataset */
+    const h5part_int64_t len_dataset_name,
+    /*!< [in]  Size of buffer \c dataset_name */
+    h5part_int64_t *type,	/*!< [out] Type of data in dataset */
+    h5part_int64_t *nelem	/*!< [out] Number of elements. */
+) {
+
+    SET_FNAME ( "H5PartGetDatasetInfo" );
+
+    h5part_int64_t herr;
+    hid_t dataset;
+    hid_t space;
+    hid_t h5type;
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_TIMEGROUP ( f );
+
+    char stepname[H5PART_STEPNAME_LEN];
+    _H5Part_get_step_name(f, f->timestep, stepname);
+
+    herr = _H5Part_get_object_name (
+        f->file,
+        stepname,
+        H5G_DATASET,
+        idx,
+        dataset_name,
+        len_dataset_name );
+    if ( herr == 0 ) {
+        return HANDLE_H5PART_NOENTRY_ERR( stepname, H5G_DATASET, idx );
+    }
+    else if ( herr < 0 ) return herr;
+
+    dataset = H5Dopen( f->timegroup, dataset_name
+#ifndef H5_USE_16_API
+        , H5P_DEFAULT
+#endif
+    );
+    if ( dataset < 0 ) return HANDLE_H5D_OPEN_ERR ( dataset_name );
+
+    h5type = H5Dget_type ( dataset );
+    if ( h5type < 0 ) return HANDLE_H5D_GET_TYPE_ERR;
+
+    if ( type ) {
+        *type = _H5Part_normalize_h5_type ( h5type );
+        if ( *type < 0 ) return *type;
+    }
+
+    if ( nelem )
+    {
+        space = H5Dget_space ( dataset );
+        if ( space < 0 ) return HANDLE_H5D_GET_SPACE_ERR;
+
+        *nelem = H5Sget_simple_extent_npoints ( space );
+        if ( *nelem < 0 )
+            return HANDLE_H5S_GET_SIMPLE_EXTENT_NPOINTS_ERR;
+
+        herr = H5Sclose ( space );
+        if ( herr <  0 ) return HANDLE_H5S_CLOSE_ERR;
+    }
+
+    herr = H5Tclose ( h5type );
+    if ( herr < 0 ) HANDLE_H5T_CLOSE_ERR;
+
+    herr = H5Dclose ( dataset );
+    if ( herr < 0 ) HANDLE_H5D_CLOSE_ERR;
+
+    return H5PART_SUCCESS;
+}
+
+static h5part_int64_t
+_H5Part_has_view (
+    H5PartFile *f
+) {
+
+    return  ( f->viewindexed || ( f->viewstart >= 0 && f->viewend >= 0 ));
+}
+
+h5part_int64_t
+_H5Part_get_num_particles (
+    H5PartFile *f			/*!< [in]  Handle to open file */
+) {
+
+    h5part_int64_t herr;
+    h5part_int64_t nparticles;
+    char dataset_name[H5PART_DATANAME_LEN];
+    char stepname[H5PART_STEPNAME_LEN];
+    _H5Part_get_step_name(f, f->timestep, stepname);
+
+    herr = _H5Part_get_object_name (
+        f->file,
+        stepname,
+        H5G_DATASET,
+        0,
+        dataset_name, H5PART_DATANAME_LEN );
+    if ( herr < 0 ) return herr;
+    /* returns 0 if there are no datasets on disk */
+    else if ( herr == 0 )
+    {
+        /* try to recover number of particles from a previous
+         * H5PartSetNumParticles call. */
+#ifdef H5PART_PARALLEL_IO
+        nparticles = 0;
+        int i;
+        for (i=0; i < f->nprocs; i++) {
+            nparticles += f->pnparticles[i];
+        }
+#else
+        nparticles = f->nparticles;
+#endif
+
+        if ( nparticles > 0 ) {
+            _H5Part_print_debug (
+                "Using existing view to report "
+                "nparticles = %lld", (long long)nparticles );
+            return nparticles;
+        }
+        else {
+            _H5Part_print_warn (
+                "There are no datasets in timestep %s "
+                "or existing views: "
+                "reporting 0 particles.", stepname );
+            return 0;
+        }
+    }
+
+    /* if a view exists, use its size as the number of particles */
+    if ( _H5Part_has_view ( f ) )
+    {
+        nparticles = H5Sget_select_npoints ( f->diskshape );
+        if ( nparticles < 0 ) return HANDLE_H5S_GET_SELECT_NPOINTS_ERR;
+
+        _H5Part_print_debug (
+            "Found %lld points with H5Sget_select_npoints",
+            (long long)nparticles );
+
+#if 0 // this does not work for indices
+        /* double check that the size of the diskshape agrees with
+         * the size of the view */
+        if ( nparticles != f->viewend - f->viewstart + 1 ) {
+            _H5Part_print_warn (
+                "Number of particles (%lld) does not agree "
+                "with view range.", (long long)nparticles );
+            return HANDLE_H5PART_BAD_VIEW_ERR (
+                f->viewstart, f->viewend);
+        }
+#endif
+    }
+    /* otherwise, report all particles on disk in the first dataset
+     * for this timestep */
+    else
+    {
+        hid_t space_id;
+        hid_t dataset_id;
+
+        dataset_id = H5Dopen ( f->timegroup, dataset_name
+#ifndef H5_USE_16_API
+            , H5P_DEFAULT
+#endif
+        );
+
+        if ( dataset_id < 0 )
+            return HANDLE_H5D_OPEN_ERR ( dataset_name );
+
+        space_id = H5Dget_space ( dataset_id );
+        if ( space_id < 0 ) return HANDLE_H5D_GET_SPACE_ERR;
+
+        nparticles = H5Sget_simple_extent_npoints ( space_id );
+        if ( nparticles < 0 )
+            return HANDLE_H5S_GET_SIMPLE_EXTENT_NPOINTS_ERR;
+
+        herr = H5Sclose ( space_id );
+        if ( herr < 0 ) return HANDLE_H5S_CLOSE_ERR;
+
+        herr = H5Dclose ( dataset_id );
+        if ( herr < 0 ) return HANDLE_H5D_CLOSE_ERR;
+    }
+
+    return nparticles;
+}
+
+/*!
+  \ingroup h5part_model
+
+  This function returns the number of particles in the first dataset of
+  the current timestep (or in the first timestep if none has been set).
+
+  If you have neither set the number of particles (read or write)
+  nor set a view (read-only), then this returns the total number of
+  elements on disk of the first dataset if is exists. Otherwise,
+  it returns 0.
+
+  If you have set a view, this return the number of particles
+  in the view.
+
+  \return	number of particles in current timestep or an error
+        code.
+ */
+h5part_int64_t
+H5PartGetNumParticles (
+    H5PartFile *f			/*!< [in]  Handle to open file */
+) {
+
+    SET_FNAME ( "H5PartGetNumParticles" );
+
+    CHECK_FILEHANDLE( f );
+
+    if ( f->timegroup < 0 ) {
+        h5part_int64_t herr = _H5Part_set_step ( f, 0 );
+        if ( herr < 0 ) return herr;
+    }
+
+    return _H5Part_get_num_particles ( f );
+}
+
+static h5part_int64_t
+_reset_view (
+    H5PartFile *f			/*!< [in]  Handle to open file */
+) {
+
+    herr_t herr = 0;
+
+    f->viewstart = -1;
+    f->viewend = -1;
+    f->viewindexed = 0;
+
+    if ( f->diskshape != H5S_ALL ) {
+        herr = H5Sclose ( f->diskshape );
+        if ( herr < 0 ) return HANDLE_H5S_CLOSE_ERR;
+        f->diskshape = H5S_ALL;
+    }
+
+    if ( f->memshape != H5S_ALL ){
+        herr = H5Sclose ( f->memshape );
+        if ( herr < 0 ) return HANDLE_H5S_CLOSE_ERR;
+        f->memshape = H5S_ALL;
+    }
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_model
+ */
+h5part_int64_t
+H5PartResetView (
+    H5PartFile *f			/*!< [in]  Handle to open file */
+) {
+    SET_FNAME ( "H5PartResetView" );
+
+    CHECK_FILEHANDLE( f );
+    CHECK_READONLY_MODE ( f );
+
+    return _reset_view ( f );
+}
+
+/*!
+  \ingroup h5part_model
+ */
+h5part_int64_t
+H5PartHasView (
+    H5PartFile *f			/*!< [in]  Handle to open file */
+) {
+    SET_FNAME ( "H5PartHasView" );
+
+    CHECK_FILEHANDLE ( f );
+    CHECK_READONLY_MODE ( f );
+
+    return _H5Part_has_view ( f );
+}
+
+static h5part_int64_t
+_set_view (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    h5part_int64_t start,		/*!< [in]  Start particle */
+    h5part_int64_t end		/*!< [in]  End particle */
+) {
+
+    h5part_int64_t herr = 0;
+    hsize_t total;
+    hsize_t stride = 1;
+    hsize_t hstart;
+    hsize_t dmax = H5S_UNLIMITED;
+
+    _H5Part_print_debug (
+        "Set view (%lld,%lld).",
+        (long long)start,(long long)end);
+
+    herr = _reset_view ( f );
+    if ( herr < 0 ) return herr;
+
+    if ( start == -1 && end == -1 ) return H5PART_SUCCESS;
+
+    /*
+      View has been reset so H5PartGetNumParticles will tell
+      us the total number of particles.
+
+      For now, we interpret start=-1 to mean 0 and
+      end==-1 to mean end of file
+     */
+    total = (hsize_t) _H5Part_get_num_particles ( f );
+    if ( total < 0 ) {
+        return HANDLE_H5PART_GET_NUM_PARTICLES_ERR ( total );
+    }
+    else if ( total == 0 ) {
+        /* No datasets have been created yet and no veiws are set.
+         * We have to leave the view empty because we don't know how
+         * many particles there should be! */
+        return H5PART_SUCCESS;
+    }
+
+    if ( start == -1 ) start = 0;
+    if ( end == -1 )   end = total - 1; // range is *inclusive*
+
+    /* so, is this selection inclusive or exclusive?
+       it appears to be inclusive for both ends of the range.
+     */
+    if ( end < start ) {
+        _H5Part_print_warn (
+            "Nonfatal error. "
+            "End of view (%lld) is less than start (%lld).",
+            (long long)end, (long long)start );
+        end = start; /* ensure that we don't have a range error */
+    }
+    /* setting up the new view */
+    f->viewstart =  start;
+    f->viewend =    end;
+    f->nparticles = end - start + 1;
+
+    _H5Part_print_debug ( "nparticles=%lld", (long long)f->nparticles );
+
+    /* declare overall data size but then select a subset */
+    f->diskshape = H5Screate_simple ( 1, &total, NULL );
+    if ( f->diskshape < 0 )
+        return HANDLE_H5S_CREATE_SIMPLE_ERR ( total );
+
+    total = (hsize_t)f->nparticles;
+    hstart = (size_t)start;
+    herr = H5Sselect_hyperslab (
+        f->diskshape,
+        H5S_SELECT_SET,
+        &hstart,
+        &stride,
+        &total,
+        NULL );
+    if ( herr < 0 ) return HANDLE_H5S_SELECT_HYPERSLAB_ERR;
+
+    /* declare local memory datasize */
+    f->memshape = H5Screate_simple ( 1, &total, &dmax );
+    if ( f->memshape < 0 )
+        return HANDLE_H5S_CREATE_SIMPLE_ERR ( f->nparticles );
+
+    return H5PART_SUCCESS;
+}
+
+static h5part_int64_t
+_set_view_indices (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t *indices,	/*!< [in]  List of indices */
+    h5part_int64_t nelems		/*!< [in]  Size of list */
+) {
+
+    h5part_int64_t herr = 0;
+    hsize_t total;
+    hsize_t dmax = H5S_UNLIMITED;
+
+    herr = _reset_view ( f );
+    if ( herr < 0 ) return herr;
+
+    if ( indices == NULL ) {
+        _H5Part_print_warn (
+            "View indices array is null: reseting view." );
+        return H5PART_SUCCESS;
+    }
+
+    /*
+      View has been reset so H5PartGetNumParticles will tell
+      us the total number of particles.
+
+      For now, we interpret start=-1 to mean 0 and
+      end==-1 to mean end of file
+     */
+    total = (hsize_t) _H5Part_get_num_particles ( f );
+    if ( total < 0 ) {
+        return HANDLE_H5PART_GET_NUM_PARTICLES_ERR ( total );
+    }
+    else if ( total == 0 ) {
+        /* No datasets have been created yet and no veiws are set.
+         * We have to leave the view empty because we don't know how
+         * many particles there should be! */
+        return H5PART_SUCCESS;
+    }
+
+    _H5Part_print_debug ( "Total nparticles=%lld", (long long)total );
+
+    if ( total == 0 ) return H5PART_SUCCESS;
+
+    /* check length of list */
+    if ( nelems < 0 ) {
+        _H5Part_print_warn (
+            "Array of view indices has length < 0: "
+            "resetting view.");
+        f->nparticles = 0;
+    } else {
+        f->nparticles = (hsize_t) nelems;
+    }
+
+    /* declare overall data size  but then will select a subset */
+    f->diskshape = H5Screate_simple ( 1, &total, NULL );
+    if ( f->diskshape < 0 )
+        return HANDLE_H5S_CREATE_SIMPLE_ERR ( total );
+
+    /* declare local memory datasize */
+    total = (size_t)f->nparticles;
+    f->memshape = H5Screate_simple (1, &total, &dmax );
+    if ( f->memshape < 0 )
+        return HANDLE_H5S_CREATE_SIMPLE_ERR ( f->nparticles );
+
+    if ( nelems > 0 ) {
+        herr = H5Sselect_elements (
+            f->diskshape,
+            H5S_SELECT_SET,
+            nelems,
+#if (H5_VERS_MAJOR>1)||((H5_VERS_MAJOR==1)&&(H5_VERS_MINOR>=8))
+            (hsize_t*)indices );
+#else
+        (const hsize_t**)&indices );
+#endif
+    } else {
+        herr = H5Sselect_none ( f->diskshape );
+    }
+    if ( herr < 0 ) return HANDLE_H5S_SELECT_ELEMENTS_ERR;
+
+    f->viewindexed = 1;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_model
+
+  For parallel I/O or for subsetting operations on the datafile, the
+  \c H5PartSetView() function allows you to define a subset of the total
+  particle dataset to operate on.
+  The concept of "view" works for both serial
+  and for parallel I/O.  The "view" will remain in effect until a new view
+  is set, or the number of particles in a dataset changes, or the view is
+  "unset" by calling \c H5PartSetView(file,-1,-1);
+
+  Before you set a view, the \c H5PartGetNumParticles() will return the
+  total number of particles in the current time-step (even for the parallel
+  reads).  However, after you set a view, it will return the number of
+  particles contained in the view.
+
+  The range is \e inclusive: the end value is the last index of the
+  data.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartSetView (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t start,	/*!< [in]  Start particle */
+    const h5part_int64_t end	/*!< [in]  End particle */
+) {
+
+    SET_FNAME ( "H5PartSetView" );
+
+    CHECK_FILEHANDLE( f );
+
+    if ( f->timegroup < 0 ) {
+        h5part_int64_t herr = _H5Part_set_step ( f, 0 );
+        if ( herr < 0 ) return herr;
+    }
+
+    return _set_view ( f, start, end );
+}
+
+/*!
+  \ingroup h5part_model
+
+  For parallel I/O or for subsetting operations on the datafile,
+  this function allows you to define a subset of the total
+  dataset to operate on by specifying a list of indices.
+  The concept of "view" works for both serial
+  and for parallel I/O.  The "view" will remain in effect until a new view
+  is set, or the number of particles in a dataset changes, or the view is
+  "unset" by calling \c H5PartSetViewIndices(NULL,0);
+
+  Before you set a view, the \c H5PartGetNumParticles() will return the
+  total number of particles in the current time-step (even for the parallel
+  reads).  However, after you set a view, it will return the number of
+  particles contained in the view.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartSetViewIndices (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t *indices,	/*!< [in]  List of indices */
+    h5part_int64_t nelems		/*!< [in]  Size of list */
+) {
+
+    SET_FNAME ( "H5PartSetViewIndices" );
+
+    CHECK_FILEHANDLE( f );
+
+    if ( f->timegroup < 0 ) {
+        h5part_int64_t herr = _H5Part_set_step ( f, 0 );
+        if ( herr < 0 ) return herr;
+    }
+
+    return _set_view_indices ( f, indices, nelems );
+}
+
+/*!
+  \ingroup h5part_model
+
+   Allows you to query the current view. Start and End
+   will be \c -1 if there is no current view established.
+   Use \c H5PartHasView() to see if the view is smaller than the
+   total dataset.
+
+   \return	number of elements in the view or error code
+ */
+h5part_int64_t
+H5PartGetView (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    h5part_int64_t *start,		/*!< [out]  Start particle */
+    h5part_int64_t *end		/*!< [out]  End particle */
+) {
+
+    SET_FNAME ( "H5PartGetView" );
+
+    CHECK_FILEHANDLE( f );
+
+    if ( f->viewindexed ) {
+        _H5Part_print_error (
+            "The current view has an index selection, but "
+            "this function only works for ranged views." );
+        return H5PART_ERR_INVAL;
+    }
+
+    if ( f->timegroup < 0 ) {
+        h5part_int64_t herr = _H5Part_set_step ( f, 0 );
+        if ( herr < 0 ) return herr;
+    }
+
+    h5part_int64_t viewstart = 0;
+    h5part_int64_t viewend = 0;
+
+    if ( f->viewstart >= 0 )
+        viewstart = f->viewstart;
+
+    if ( f->viewend >= 0 ) {
+        viewend = f->viewend;
+    }
+    else {
+        viewend = _H5Part_get_num_particles ( f );
+        if ( viewend < 0 )
+            return HANDLE_H5PART_GET_NUM_PARTICLES_ERR ( viewend );
+    }
+
+    if ( start ) *start = viewstart;
+    if ( end )   *end   = viewend;
+
+    return viewend - viewstart + 1; // view range is *inclusive*
+}
+
+/*!
+  \ingroup h5part_model
+
+  If it is too tedious to manually set the start and end coordinates
+  for a view, the \c H5SetCanonicalView() will automatically select an
+  appropriate domain decomposition of the data arrays for the degree
+  of parallelism and set the "view" accordingly.
+
+  \return		H5PART_SUCCESS or error code
+ */
+/*
+  \note
+  There is a bug in this function:
+  If (NumParticles % f->nprocs) != 0  then
+  the last  (NumParticles % f->nprocs) particles are not handled!
+ */
+
+h5part_int64_t
+H5PartSetCanonicalView (
+    H5PartFile *f			/*!< [in]  Handle to open file */
+) {
+
+    SET_FNAME ( "H5PartSetCanonicalView" );
+
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    herr = _reset_view ( f );
+    if ( herr < 0 ) return HANDLE_H5PART_SET_VIEW_ERR( herr, -1, -1 );
+
+#ifdef H5PART_PARALLEL_IO
+    h5part_int64_t start = 0;
+    h5part_int64_t end = 0;
+    h5part_int64_t total = 0;
+    h5part_int64_t pertask = 0;
+    int i = 0;
+
+    if ( f->timegroup < 0 ) {
+        herr = _H5Part_set_step ( f, 0 );
+        if ( herr < 0 ) return herr;
+    }
+
+    /* returns all particles (aggregated across all tasks) */
+    total = _H5Part_get_num_particles ( f );
+    if ( total < 0 )
+        return HANDLE_H5PART_GET_NUM_PARTICLES_ERR ( total );
+
+#if 0
+    /* now lets query the attributes for this group to see if there
+       is a 'pnparticles' group that contains the offsets for the
+       processors.
+     */
+    if ( _H5Part_read_attrib (
+        f->timegroup,
+        "pnparticles", f->pnparticles ) < 0) {
+        /*
+          Attribute "pnparticles" is not available.  So
+          subdivide the view into NP mostly equal pieces
+         */
+        n /= f->nprocs;
+        for ( i=0; i<f->nprocs; i++ ) {
+            f->pnparticles[i] = n;
+        }
+    }
+#endif
+
+    total /= f->nprocs;
+    for ( i=0; i<f->nprocs; i++ ) {
+        f->pnparticles[i] = total;
+    }
+
+    for ( i = 0; i < f->myproc; i++ ){
+        start += f->pnparticles[i];
+    }
+    end = start + f->pnparticles[f->myproc] - 1;
+    herr = _set_view ( f, start, end );
+    if ( herr < 0 ) return HANDLE_H5PART_SET_VIEW_ERR ( herr, start, end );
+
+#endif
+
+    return H5PART_SUCCESS;
+}
+
+static h5part_int64_t
+_read_data (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate dataset with */
+    void *array,		/*!< [out] Array of data */
+    const hid_t type
+) {
+
+    h5part_int64_t herr;
+    hsize_t ndisk, nread, nmem;
+    hid_t dataset_id;
+    hid_t space_id;
+    hid_t memspace_id;
+
+    if ( f->timegroup < 0 ) {
+        herr = _H5Part_set_step ( f, f->timestep );
+        if ( herr < 0 ) return herr;
+    }
+
+    char name2[H5PART_DATANAME_LEN];
+    _normalize_dataset_name ( name, name2 );
+
+    dataset_id = H5Dopen ( f->timegroup, name2
+#ifndef H5_USE_16_API
+        , H5P_DEFAULT
+#endif
+    );
+
+    if ( dataset_id < 0 ) return HANDLE_H5D_OPEN_ERR ( name2 );
+
+    /* default spaces, if not using a view selection */
+    memspace_id = H5S_ALL;
+    space_id = H5Dget_space ( dataset_id );
+    if ( space_id < 0 ) return HANDLE_H5D_GET_SPACE_ERR;
+
+    /* get the number of elements on disk for the datset */
+    ndisk = H5Sget_simple_extent_npoints ( space_id );
+    if ( ndisk < 0 ) return HANDLE_H5S_GET_SIMPLE_EXTENT_NPOINTS_ERR;
+
+    if ( f->diskshape != H5S_ALL )
+    {
+        nread = H5Sget_select_npoints ( f->diskshape );
+        if ( nread < 0 ) return HANDLE_H5S_GET_SELECT_NPOINTS_ERR;
+
+        /* make sure the disk space selected by the view doesn't
+         * exceed the size of the dataset */
+        if ( nread <= ndisk ) {
+            /* we no longer need the dataset space... */
+            herr = H5Sclose ( space_id );
+            if ( herr < 0 ) HANDLE_H5S_CLOSE_ERR;
+            /* ...because it's safe to use the view selection */
+            space_id = f->diskshape;
+        } else {
+            /* the view selection is too big?
+             * fall back to using the dataset space */
+            _H5Part_print_warn (
+                "Ignoring view: dataset[%s] has fewer "
+                "elements on disk (%lld) than are selected "
+                "(%lld).",
+                name2, (long long)ndisk, (long long)nread );
+            nread = ndisk;
+        }
+    }
+    else {
+        /* since the view selection is H5S_ALL, we will
+         * read all available elements in the dataset space */
+        nread = ndisk;
+    }
+
+    if ( f->memshape != H5S_ALL )
+    {
+        nmem = H5Sget_select_npoints ( f->memshape );
+        if ( nmem <  0 ) return HANDLE_H5S_GET_SELECT_NPOINTS_ERR;
+
+        /* make sure the memory space selected by the view has
+         * enough capacity for the read */
+        if ( nmem >= nread ) {
+            memspace_id = f->memshape;
+        } else {
+            /* the view selection is too small?
+             * fall back to using H5S_ALL */
+            _H5Part_print_warn (
+                "Ignoring view: dataset[%s] has more "
+                "elements selected (%lld) than are available "
+                "in memory (%lld).",
+                name2, (long long)nread, (long long)nmem );
+            memspace_id == H5S_ALL;
+        }
+    }
+
+#ifdef H5PART_PARALLEL_IO
+    herr = _H5Part_start_throttle ( f );
+    if ( herr < 0 ) return herr;
+#endif
+
+    herr = H5Dread (
+        dataset_id,
+        type,
+        memspace_id,		/* shape/size of data in memory (the
+                       complement to disk hyperslab) */
+        space_id,		/* shape/size of data on disk
+                       (get hyperslab if needed) */
+        f->xfer_prop,		/* ignore... its for parallel reads */
+        array );
+    if ( herr < 0 ) return HANDLE_H5D_READ_ERR ( name2, f->timestep );
+
+#ifdef H5PART_PARALLEL_IO
+    herr = _H5Part_end_throttle ( f );
+    if ( herr < 0 ) return herr;
+#endif
+
+    if ( space_id != f->diskshape ) {
+        herr = H5Sclose ( space_id );
+        if ( herr < 0 ) return HANDLE_H5S_CLOSE_ERR;
+    }
+
+    herr = H5Dclose ( dataset_id );
+    if ( herr < 0 ) return HANDLE_H5D_CLOSE_ERR;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  Read array of 64 bit floating point data from file.
+
+  When retrieving datasets from disk, you ask for them
+  by name. There are no restrictions on naming of arrays,
+  but it is useful to arrive at some common naming
+  convention when sharing data with other groups.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartReadDataFloat64 (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate dataset with */
+    h5part_float64_t *array	/*!< [out] Array of data */
+) {
+
+    SET_FNAME ( "H5PartReadDataFloat64" );
+
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    herr = _read_data ( f, name, array, H5T_NATIVE_DOUBLE );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  Read array of 32 bit floating point data from file.
+
+  When retrieving datasets from disk, you ask for them
+  by name. There are no restrictions on naming of arrays,
+  but it is useful to arrive at some common naming
+  convention when sharing data with other groups.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartReadDataFloat32 (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate dataset with */
+    h5part_float32_t *array	/*!< [out] Array of data */
+) {
+
+    SET_FNAME ( "H5PartReadDataFloat32" );
+
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    herr = _read_data ( f, name, array, H5T_NATIVE_FLOAT );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  Read array of 64 bit integer data from file.
+
+  When retrieving datasets from disk, you ask for them
+  by name. There are no restrictions on naming of arrays,
+  but it is useful to arrive at some common naming
+  convention when sharing data with other groups.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartReadDataInt64 (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate dataset with */
+    h5part_int64_t *array	/*!< [out] Array of data */
+) {
+
+    SET_FNAME ( "H5PartReadDataInt64" );
+
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    herr = _read_data ( f, name, array, H5T_NATIVE_INT64 );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  Read array of 32 bit integer data from file.
+
+  When retrieving datasets from disk, you ask for them
+  by name. There are no restrictions on naming of arrays,
+  but it is useful to arrive at some common naming
+  convention when sharing data with other groups.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartReadDataInt32 (
+    H5PartFile *f,		/*!< [in] Handle to open file */
+    const char *name,	/*!< [in] Name to associate dataset with */
+    h5part_int32_t *array	/*!< [out] Array of data */
+) {
+
+    SET_FNAME ( "H5PartReadDataInt64" );
+
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    herr = _read_data ( f, name, array, H5T_NATIVE_INT32 );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_data
+
+  This is an aggregate read function that pulls in all of the data for a
+  typical particle timestep in one shot.
+  It also takes the timestep as an argument
+  and will call \ref H5PartSetStep internally.
+
+  \return	\c H5PART_SUCCESS or error code
+ */
+h5part_int64_t
+H5PartReadParticleStep (
+    H5PartFile *f,		/*!< [in]  Handle to open file */
+    h5part_int64_t step,	/*!< [in]  Step to read */
+    h5part_float64_t *x,	/*!< [out] Buffer for dataset named "x" */
+    h5part_float64_t *y,	/*!< [out] Buffer for dataset named "y" */
+    h5part_float64_t *z,	/*!< [out] Buffer for dataset named "z" */
+    h5part_float64_t *px,	/*!< [out] Buffer for dataset named "px" */
+    h5part_float64_t *py,	/*!< [out] Buffer for dataset named "py" */
+    h5part_float64_t *pz,	/*!< [out] Buffer for dataset named "pz" */
+    h5part_int64_t *id	/*!< [out] Buffer for dataset named "id" */
+) {
+
+    SET_FNAME ( "H5PartReadParticleStep" );
+    h5part_int64_t herr;
+
+    CHECK_FILEHANDLE( f );
+
+    herr = _H5Part_set_step ( f, step );
+    if ( herr < 0 ) return herr;
+
+    herr = _read_data ( f, "x", (void*)x, H5T_NATIVE_DOUBLE );
+    if ( herr < 0 ) return herr;
+
+    herr = _read_data ( f, "y", (void*)y, H5T_NATIVE_DOUBLE );
+    if ( herr < 0 ) return herr;
+
+    herr = _read_data ( f, "z", (void*)z, H5T_NATIVE_DOUBLE );
+    if ( herr < 0 ) return herr;
+
+    herr = _read_data ( f, "px", (void*)px, H5T_NATIVE_DOUBLE );
+    if ( herr < 0 ) return herr;
+
+    herr = _read_data ( f, "py", (void*)py, H5T_NATIVE_DOUBLE );
+    if ( herr < 0 ) return herr;
+
+    herr = _read_data ( f, "pz", (void*)pz, H5T_NATIVE_DOUBLE );
+    if ( herr < 0 ) return herr;
+
+    herr = _read_data ( f, "id", (void*)id, H5T_NATIVE_INT64 );
+    if ( herr < 0 ) return herr;
+
+    return H5PART_SUCCESS;
+}
+
+/************ error handling and configuration ************/
+
+/*!
+  \ingroup h5part_errhandle
+
+  Set the `throttle` factor, which causes HDF5 write and read
+  calls to be issued in that number of batches.
+
+  This can prevent large cuncurrency parallel applications that
+  use independent writes from overwhelming the underlying
+  parallel file system.
+
+  Throttling only works with the H5PART_VFD_MPIPOSIX or
+  H5PART_VFD_MPIIO_IND drivers and is only available in
+  the parallel library.
+
+  \return \c H5PART_SUCCESS
+ */
+#ifdef H5PART_PARALLEL_IO
+h5part_int64_t
+H5PartSetThrottle (
+    H5PartFile *f,
+    int factor
+) {
+
+    SET_FNAME( "H5PartSetThrottle" );
+    CHECK_FILEHANDLE ( f );
+
+    if ( f->flags & H5PART_VFD_MPIIO_IND || f->flags & H5PART_VFD_MPIPOSIX ) {
+        f->throttle = factor;
+        _H5Part_print_info (
+            "Throttling set with factor '%d'", f->throttle );
+    } else {
+        _H5Part_print_warn (
+            "Throttling is only permitted with the MPI-POSIX "
+            "or MPI-IO Independent VFD." );
+    }
+
+    return H5PART_SUCCESS;
+}
+
+h5part_int64_t
+_H5Part_start_throttle (
+    H5PartFile *f
+) {
+
+    if (f->throttle > 0) {
+        int ret;
+        int token = 1;
+        if (f->myproc == 0) {
+            _H5Part_print_info ("Throttling with factor = %d",
+                f->throttle);
+        }
+        if (f->myproc % f->throttle > 0) {
+            _H5Part_print_debug_detail (
+                "[%d] throttle: waiting on token from %d",
+                f->myproc, f->myproc - 1);
+            // wait to receive token before continuing with read
+            ret = MPI_Recv(
+                &token, 1, MPI_INT,
+                f->myproc - 1, // receive from previous proc
+                f->myproc, // use this proc id as message tag
+                f->comm,
+                MPI_STATUS_IGNORE
+            );
+            if ( ret != MPI_SUCCESS ) return HANDLE_MPI_SENDRECV_ERR;
+        }
+        _H5Part_print_debug_detail ("[%d] throttle: received token", f->myproc);
+    }
+    return H5PART_SUCCESS;
+}
+
+h5part_int64_t
+_H5Part_end_throttle (
+    H5PartFile *f
+) {
+
+    if (f->throttle > 0) {
+        int ret;
+        int token;
+        if (f->myproc % f->throttle < f->throttle - 1) {
+            // pass token to next proc
+            if (f->myproc + 1 < f->nprocs) {
+                _H5Part_print_debug_detail (
+                    "[%d] throttle: passing token to %d",
+                    f->myproc, f->myproc + 1);
+                ret = MPI_Send(
+                    &token, 1, MPI_INT,
+                    f->myproc + 1, // send to next proc
+                    f->myproc + 1, // use the id of the target as tag
+                    f->comm
+                );
+            }
+            if ( ret != MPI_SUCCESS ) return HANDLE_MPI_SENDRECV_ERR;
+        }
+    }
+    return H5PART_SUCCESS;
+}
+#endif // H5PART_PARALLEL_IO
+
+/*!
+  \ingroup h5part_open
+
+  Set verbosity level to \c level.
+
+  \return \c H5PART_SUCCESS
+ */
+h5part_int64_t
+H5PartSetVerbosityLevel (
+    h5part_int64_t level
+) {
+
+    _debug = (unsigned int)level;
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_errhandle
+
+  Set error handler to \c handler.
+
+  \return \c H5PART_SUCCESS
+ */
+h5part_int64_t
+H5PartSetErrorHandler (
+    h5part_error_handler handler
+) {
+    _err_handler = handler;
+    return H5PART_SUCCESS;
+}
+
+/*!
+  \ingroup h5part_errhandle
+
+  Get current error handler.
+
+  \return Pointer to error handler.
+ */
+h5part_error_handler
+H5PartGetErrorHandler (
+    void
+) {
+    return _err_handler;
+}
+
+/*!
+  \ingroup h5part_errhandle
+
+  Get last error code.
+
+  \return error code
+ */
+h5part_int64_t
+H5PartGetErrno (
+    void
+) {
+    return _h5part_errno;
+}
+
+/*!
+  \ingroup h5part_errhandle
+
+  This is the H5Part default error handler.  If an error occures, an
+  error message will be printed and an error number will be returned.
+
+  \return value given in \c eno
+ */
+h5part_int64_t
+H5PartReportErrorHandler (
+    const char *funcname,
+    const h5part_int64_t eno,
+    const char *fmt,
+    ...
+) {
+
+    _h5part_errno = eno;
+    if ( _debug > 0 ) {
+        va_list ap;
+        va_start ( ap, fmt );
+        _H5Part_vprint_error ( fmt, ap );
+        va_end ( ap );
+    }
+    return _h5part_errno;
+}
+
+/*!
+  \ingroup h5part_errhandle
+
+  If an error occures, an error message will be printed and the
+  program exists with the error code given in \c eno.
+ */
+h5part_int64_t
+H5PartAbortErrorHandler (
+    const char *funcname,
+    const h5part_int64_t eno,
+    const char *fmt,
+    ...
+) {
+
+    _h5part_errno = eno;
+    if ( _debug > 0 ) {
+        va_list ap;
+        va_start ( ap, fmt );
+        fprintf ( stderr, "%s: ", funcname );
+        vfprintf ( stderr, fmt, ap );
+        fprintf ( stderr, "\n" );
+    }
+    exit ( (int)_h5part_errno );
+}
+
+/*!
+  Initialize H5Part
+ */
+static h5part_int64_t
+_init ( void ) {
+    static int __init = 0;
+
+    herr_t r5;
+    if ( ! __init ) {
+        _H5Part_set_funcname ( "NONE" );
+#ifndef H5_USE_16_API
+        r5 = H5Eset_auto ( H5E_DEFAULT, _h5_error_handler, NULL );
+#else
+        r5 = H5Eset_auto ( _h5_error_handler, NULL );
+#endif
+        if ( r5 < 0 ) return H5PART_ERR_INIT;
+    }
+    __init = 1;
+    return H5PART_SUCCESS;
+}
+/*! @} */
+
+static herr_t
+#ifndef H5_USE_16_API
+_h5_error_handler ( hid_t estack, void* unused ) {
+#else
+    _h5_error_handler ( void* unused ) {
+#endif
+
+        if ( _debug >= 1 ) {
+#ifndef H5_USE_16_API
+            H5Eprint (H5E_DEFAULT,stderr);
+#else
+            H5Eprint (stderr);
+#endif
+        }
+        return 0;
+    }
+
+    static void
+    _vprint (
+        FILE* f,
+        const char *prefix,
+        const char *fmt,
+        va_list ap
+    ) {
+        char *fmt2 = (char*)malloc( strlen ( prefix ) +strlen ( fmt ) + strlen ( __funcname ) + 16 );
+        if ( fmt2 == NULL ) return;
+        sprintf ( fmt2, "%s: %s: %s\n", prefix, __funcname, fmt );
+        vfprintf ( stderr, fmt2, ap );
+        free ( fmt2 );
+    }
+
+    void
+    _H5Part_vprint_error (
+        const char *fmt,
+        va_list ap
+    ) {
+
+        if ( _debug < 1 ) return;
+        _vprint ( stderr, "E", fmt, ap );
+    }
+
+    void
+    _H5Part_print_error (
+        const char *fmt,
+        ...
+    ) {
+
+        va_list ap;
+        va_start ( ap, fmt );
+        _H5Part_vprint_error ( fmt, ap );
+        va_end ( ap );
+    }
+
+    void
+    _H5Part_vprint_warn (
+        const char *fmt,
+        va_list ap
+    ) {
+
+        if ( _debug < 2 ) return;
+        _vprint ( stderr, "W", fmt, ap );
+    }
+
+    void
+    _H5Part_print_warn (
+        const char *fmt,
+        ...
+    ) {
+
+        va_list ap;
+        va_start ( ap, fmt );
+        _H5Part_vprint_warn ( fmt, ap );
+        va_end ( ap );
+    }
+
+    void
+    _H5Part_vprint_info (
+        const char *fmt,
+        va_list ap
+    ) {
+
+        if ( _debug < 3 ) return;
+        _vprint ( stdout, "I", fmt, ap );
+    }
+
+    void
+    _H5Part_print_info (
+        const char *fmt,
+        ...
+    ) {
+
+        va_list ap;
+        va_start ( ap, fmt );
+        _H5Part_vprint_info ( fmt, ap );
+        va_end ( ap );
+    }
+
+    void
+    _H5Part_vprint_debug (
+        const char *fmt,
+        va_list ap
+    ) {
+
+        if ( _debug < 4 ) return;
+        _vprint ( stdout, "D", fmt, ap );
+    }
+
+    void
+    _H5Part_print_debug (
+        const char *fmt,
+        ...
+    ) {
+
+        va_list ap;
+        va_start ( ap, fmt );
+        _H5Part_vprint_debug ( fmt, ap );
+        va_end ( ap );
+    }
+
+    void
+    _H5Part_vprint_debug_detail (
+        const char *fmt,
+        va_list ap
+    ) {
+
+        if ( _debug < 5 ) return;
+        _vprint ( stdout, "DD", fmt, ap );
+    }
+
+    void
+    _H5Part_print_debug_detail (
+        const char *fmt,
+        ...
+    ) {
+
+        va_list ap;
+        va_start ( ap, fmt );
+        _H5Part_vprint_debug_detail ( fmt, ap );
+        va_end ( ap );
+    }
+
+    void
+    _H5Part_set_funcname (
+        char *fname
+    ) {
+        __funcname = fname;
+    }
+
+    char*
+    _H5Part_get_funcname (
+        void
+    ) {
+        return __funcname;
+    }
+

--- a/extern/h5part/H5Part.h
+++ b/extern/h5part/H5Part.h
@@ -1,0 +1,414 @@
+#ifndef _H5Part_H_
+#define _H5Part_H_
+
+#include <stdlib.h>
+#include <stdarg.h>
+#ifdef H5PART_PARALLEL_IO
+#include <mpi.h>
+#endif
+#include <hdf5.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "H5PartTypes.h"
+#include "H5PartAttrib.h"
+//#include "H5Block.h"
+#ifdef H5PART_PARALLEL_IO
+//#include "H5MultiBlock.h"
+#endif
+
+#define H5PART_VER_STRING	"1.6.0"
+#define H5PART_VER_MAJOR	1
+#define H5PART_VER_MINOR	6
+#define H5PART_VER_RELEASE	0
+
+/* error values */
+#define H5PART_SUCCESS		0
+#define H5PART_ERR_NOMEM	-12
+#define H5PART_ERR_INVAL	-22
+#define H5PART_ERR_BADFD	-77
+
+#define H5PART_ERR_INIT         -200
+#define H5PART_ERR_NOENTRY	-201
+#define H5PART_ERR_NOTYPE	-210
+#define H5PART_ERR_BAD_VIEW	-220
+
+#define H5PART_ERR_MPI		-300
+#define H5PART_ERR_HDF5		-400
+
+/* file open flags */
+#define H5PART_READ		0x01
+#define H5PART_WRITE		0x02
+#define H5PART_APPEND		0x04
+#define H5PART_VFD_MPIPOSIX	0x08
+#define H5PART_FS_LUSTRE	0x10
+#define H5PART_VFD_MPIIO_IND	0x20
+
+/* verbosity level flags */
+#define H5PART_VERB_NONE	0
+#define H5PART_VERB_ERROR	1
+#define H5PART_VERB_WARN	2
+#define H5PART_VERB_INFO	3
+#define H5PART_VERB_DEBUG	4
+#define H5PART_VERB_DETAIL	5
+
+/* data types */
+#define H5PART_INT64		((h5part_int64_t)H5T_NATIVE_INT64)
+#define H5PART_INT32		((h5part_int64_t)H5T_NATIVE_INT32)
+#define H5PART_FLOAT64		((h5part_int64_t)H5T_NATIVE_DOUBLE)
+#define H5PART_FLOAT32		((h5part_int64_t)H5T_NATIVE_FLOAT)
+#define H5PART_CHAR		((h5part_int64_t)H5T_NATIVE_CHAR)
+#define H5PART_STRING		((h5part_int64_t)H5T_C_S1)
+
+/*========== File Opening/Closing ===============*/
+H5PartFile*
+H5PartOpenFile(
+    const char *filename,
+    const char flags
+    );
+
+H5PartFile*
+H5PartOpenFileAlign(
+    const char *filename,
+    const char flags,
+    h5part_int64_t align
+    );
+
+#define H5PartOpenFileSerial(x,y) H5PartOpenFile(x,y)
+#define H5PartOpenFileSerialAlign(x,y,z) H5PartOpenFileAlign(x,y,z)
+
+#ifdef H5PART_PARALLEL_IO
+H5PartFile*
+H5PartOpenFileParallel (
+    const char *filename,
+    const char flags,
+    MPI_Comm communicator
+    );
+
+H5PartFile*
+H5PartOpenFileParallelAlign (
+    const char *filename,
+    const char flags,
+    MPI_Comm communicator,
+    h5part_int64_t align
+    );
+#endif
+
+
+h5part_int64_t
+H5PartCloseFile (
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartFileIsValid (
+    H5PartFile *f
+    );
+
+/*============== File Writing Functions ==================== */
+h5part_int64_t
+H5PartDefineStepName (
+    H5PartFile *f,
+    const char *name,
+    const h5part_int64_t width
+    );
+
+h5part_int64_t
+H5PartSetNumParticles (
+    H5PartFile *f,
+    const h5part_int64_t nparticles
+    );
+
+h5part_int64_t
+H5PartSetNumParticlesStrided (
+    H5PartFile *f,				/*!< [in] Handle to open file */
+    const h5part_int64_t nparticles,	/*!< [in] Number of particles */
+    const h5part_int64_t stride		/*!< [in] Stride (e.g. number of fields in the particle array) */
+    );
+
+h5part_int64_t
+H5PartWriteDataFloat64 (
+    H5PartFile *f,
+    const char *name,
+    const h5part_float64_t *array
+    );
+
+h5part_int64_t
+H5PartWriteDataFloat32 (
+    H5PartFile *f,
+    const char *name,
+    const h5part_float32_t *array
+    );
+
+h5part_int64_t
+H5PartWriteDataInt64 (
+    H5PartFile *f,
+    const char *name,
+    const h5part_int64_t *array
+    );
+
+h5part_int64_t
+H5PartWriteDataInt32 (
+    H5PartFile *f,
+    const char *name,
+    const h5part_int32_t *array
+    );
+
+/*================== File Reading Routines =================*/
+h5part_int64_t
+H5PartSetStep (
+    H5PartFile *f,
+    const h5part_int64_t step
+    );
+
+h5part_int64_t
+H5PartHasStep (
+    H5PartFile *f,
+    const h5part_int64_t step
+    );
+
+h5part_int64_t
+H5PartGetNumSteps (
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartGetNumDatasets (
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartGetDatasetName (
+    H5PartFile *f,
+    const h5part_int64_t idx,
+    char *name,
+    const h5part_int64_t maxlen
+    );
+
+h5part_int64_t
+H5PartGetDatasetInfo (
+    H5PartFile *f,
+    const h5part_int64_t idx,
+    char *name,
+    const h5part_int64_t maxlen,
+    h5part_int64_t *type,
+    h5part_int64_t *nelem);
+
+
+h5part_int64_t
+H5PartGetNumParticles (
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartSetView (
+    H5PartFile *f,
+    const h5part_int64_t start,
+    const h5part_int64_t end
+    );
+
+h5part_int64_t
+H5PartSetViewIndices (
+    H5PartFile *f,			/*!< [in]  Handle to open file */
+    const h5part_int64_t *indices,	/*!< [in]  List of indices */
+    h5part_int64_t nelems		/*!< [in]  Size of list */
+    );
+
+h5part_int64_t
+H5PartGetView (
+    H5PartFile *f,
+    h5part_int64_t *start,
+    h5part_int64_t *end
+    );
+
+h5part_int64_t
+H5PartHasView (
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartResetView (
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartSetCanonicalView (
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartReadDataFloat64(
+    H5PartFile *f,
+    const char *name,
+    h5part_float64_t *array
+    );
+
+h5part_int64_t
+H5PartReadDataFloat32(
+    H5PartFile *f,
+    const char *name,
+    h5part_float32_t *array
+    );
+
+h5part_int64_t
+H5PartReadDataInt64 (
+    H5PartFile *f,
+    const char *name,
+    h5part_int64_t *array
+    );
+
+h5part_int64_t
+H5PartReadDataInt32 (
+    H5PartFile *f,
+    const char *name,
+    h5part_int32_t *array
+    );
+
+h5part_int64_t
+H5PartReadParticleStep (
+    H5PartFile *f,
+    const h5part_int64_t step,
+    h5part_float64_t *x, /* particle positions */
+    h5part_float64_t *y,
+    h5part_float64_t *z,
+    h5part_float64_t *px, /* particle momenta */
+    h5part_float64_t *py,
+    h5part_float64_t *pz,
+    h5part_int64_t *id /* and phase */
+    );
+
+/**********==============Attributes Interface============***************/
+/* currently there is file attributes:  Attributes bound to the file
+   and step attributes which are bound to the current timestep.  You
+   must set the timestep explicitly before writing the attributes (just
+   as you must do when you write a new dataset.  Currently there are no
+   attributes that are bound to a particular data array, but this could
+   easily be done if required.
+*/
+h5part_int64_t
+H5PartWriteStepAttrib (
+    H5PartFile *f,
+    const char *attrib_name,
+    const h5part_int64_t attrib_type,
+    const void *attrib_value,
+    const h5part_int64_t attrib_nelem
+    );
+
+h5part_int64_t
+H5PartWriteFileAttrib (
+    H5PartFile *f,
+    const char *attrib_name,
+    const h5part_int64_t attrib_type,
+    const void *attrib_value,
+    const h5part_int64_t attrib_nelem
+    );
+
+h5part_int64_t
+H5PartWriteFileAttribString (
+    H5PartFile *f,
+    const char *name,
+    const char *value
+    );
+
+h5part_int64_t
+H5PartWriteStepAttribString (
+    H5PartFile *f,
+    const char *name,
+    const char *value
+    );
+
+h5part_int64_t
+H5PartGetNumStepAttribs ( /* for current filestep */
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartGetNumFileAttribs (
+    H5PartFile *f
+    );
+
+h5part_int64_t
+H5PartGetStepAttribInfo (
+    H5PartFile *f,
+    const h5part_int64_t attrib_idx,
+    char *attrib_name,
+    const h5part_int64_t len_of_attrib_name,
+    h5part_int64_t *attrib_type,
+    h5part_int64_t *attrib_nelem
+    );
+
+h5part_int64_t
+H5PartGetFileAttribInfo (
+    H5PartFile *f,
+    const h5part_int64_t idx,
+    char *name,
+    const h5part_int64_t maxnamelen,
+    h5part_int64_t *type,
+    h5part_int64_t *nelem
+    );
+
+h5part_int64_t
+H5PartReadStepAttrib (
+    H5PartFile *f,
+    const char *name,
+    void *value
+    );
+
+h5part_int64_t
+H5PartReadFileAttrib (
+    H5PartFile *f,
+    const char *name,
+    void *value
+    );
+
+/*============ Error Reporting and Configuration =============*/
+
+h5part_int64_t
+H5PartSetVerbosityLevel (
+    const h5part_int64_t level
+    );
+
+h5part_int64_t
+H5PartSetThrottle (
+    H5PartFile *f,
+    int factor
+    );
+
+h5part_int64_t
+H5PartSetErrorHandler (
+    const h5part_error_handler handler
+    );
+
+h5part_int64_t
+H5PartGetErrno (
+    void
+    );
+
+h5part_error_handler
+H5PartGetErrorHandler (
+    void
+    );
+
+h5part_int64_t
+H5PartReportErrorHandler (
+    const char *funcname,
+    const h5part_int64_t eno,
+    const char *fmt,
+    ...
+    );
+
+h5part_int64_t
+H5PartAbortErrorHandler (
+    const char *funcname,
+    const h5part_int64_t eno,
+    const char *fmt,
+    ...
+    );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/extern/h5part/H5PartAttrib.h
+++ b/extern/h5part/H5PartAttrib.h
@@ -1,0 +1,71 @@
+
+#ifndef _H5PART_ATTRIB_H_
+#define _H5PART_ATTRIB_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+h5part_int64_t
+H5PartWriteFileAttribFloat64 (
+	H5PartFile *f,
+	const char *name,
+	const h5part_float64_t data
+	);
+
+h5part_int64_t
+H5PartWriteFileAttribFloat32 (
+	H5PartFile *f,
+	const char *name,
+	const h5part_float32_t data
+	);
+
+h5part_int64_t
+H5PartWriteFileAttribInt64 (
+	H5PartFile *f,
+	const char *name,
+	const h5part_int64_t data
+	);
+
+h5part_int64_t
+H5PartWriteFileAttribInt32 (
+	H5PartFile *f,
+	const char *name,
+	const h5part_int32_t data
+	);
+
+h5part_int64_t
+H5PartWriteStepAttribFloat64 (
+	H5PartFile *f,
+	const char *name,
+	const h5part_float64_t data
+	);
+
+h5part_int64_t
+H5PartWriteStepAttribFloat32 (
+	H5PartFile *f,
+	const char *name,
+	const h5part_float32_t data
+	);
+
+h5part_int64_t
+H5PartWriteStepAttribInt64 (
+	H5PartFile *f,
+	const char *name,
+	const h5part_int64_t data
+	);
+
+h5part_int64_t
+H5PartWriteStepAttribInt32 (
+	H5PartFile *f,
+	const char *name,
+	const h5part_int32_t data
+	);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/extern/h5part/H5PartErrors.h
+++ b/extern/h5part/H5PartErrors.h
@@ -1,0 +1,407 @@
+#ifndef __H5PART_ERRORS_H
+#define __H5PART_ERRORS_H
+
+extern h5part_error_handler _err_handler;
+
+/***************** Error Handling ***************/
+
+#define CHECK_FILEHANDLE( f ) \
+	if ( _H5Part_file_is_valid ( f ) != H5PART_SUCCESS ) \
+		return HANDLE_H5PART_BADFD_ERR;
+
+#define CHECK_WRITABLE_MODE( f )  \
+	if ( f->flags & H5PART_READ ) \
+		return (*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_INVAL, \
+			"Attempting to write to read-only file." );
+
+#define CHECK_READONLY_MODE( f )  \
+	if ( ! (f->flags & H5PART_READ) ) \
+		return (*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_INVAL, \
+			"Operation is not allowed on writable files." );
+
+#define CHECK_TIMEGROUP( f ) \
+	if ( f->timegroup <= 0 ) \
+		return (*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_INVAL, \
+			"Timegroup <= 0.");
+
+/**************** H5Part *********************/
+
+#define HANDLE_H5PART_BADFD_ERR \
+	(*_err_handler)( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_BADFD, \
+		"Called with bad filehandle." );
+
+#define HANDLE_H5PART_INIT_ERR \
+	(*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_INIT, \
+		"Cannot initialize H5Part." );
+
+#define HANDLE_H5PART_INVALID_ERR( name, value ) \
+	(*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_INVAL, \
+		"Invalid value '%lld' for '%s'.", \
+		(long long)value, name);
+
+#define HANDLE_H5PART_NOMEM_ERR \
+	(*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_NOMEM, \
+		"Out of memory." );
+
+#define HANDLE_H5PART_SETSTEP_ERR( rc, step ) \
+	(*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		rc, \
+		"Cannont set time-step to %lld.", (long long)step );
+
+#define HANDLE_H5PART_FILE_ACCESS_TYPE_ERR( flags ) \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_INVAL, \
+			"Invalid file access type \"%d\".", flags);
+
+#define HANDLE_H5PART_STEP_EXISTS_ERR( step ) \
+	(*_err_handler)( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_INVAL, \
+		"Step #%lld already exists, step cannot be set to an existing" \
+		" step in write and append mode", (long long)step );
+
+#define HANDLE_H5PART_SET_VIEW_ERR( rc, start, end ) \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			rc, \
+			"Cannot set view to (%lld, %lld).", \
+			(long long)start, (long long)end );
+
+#define HANDLE_H5PART_BAD_VIEW_ERR( start, end ) \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_BAD_VIEW, \
+			"Problem with existing view (%lld, %lld).", \
+			(long long)start, (long long)end );
+
+#define HANDLE_H5PART_GET_NUM_PARTICLES_ERR( rc ) \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			rc, \
+			"Cannot get number of particles." );
+
+#define HANDLE_H5PART_NOENTRY_ERR( group_name, type, idx ) \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_NOENTRY, \
+			"No entry with index %lld and type %d in group %s!", \
+			(long long)idx, type, group_name );
+
+#define HANDLE_H5PART_TYPE_ERR \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_NOTYPE, \
+			"Encountered unkown data type!");
+
+/**************** HDF5 *********************/
+/* H5A: Attribute */
+#define HANDLE_H5A_CLOSE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot terminate access to attribute." );
+
+#define HANDLE_H5A_CREATE_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot create attribute \"%s\".", s );
+
+#define HANDLE_H5A_GET_NAME_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot get attribute name." );
+
+#define HANDLE_H5A_GET_NUM_ATTRS_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot get number of attributes." );
+
+#define HANDLE_H5A_GET_SPACE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot get a copy of dataspace for attribute." );
+
+#define HANDLE_H5A_GET_TYPE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot get attribute datatype." );
+
+#define HANDLE_H5A_OPEN_IDX_ERR( n ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot open attribute specified by index \"%lld\".", \
+		(long long)n );
+
+#define HANDLE_H5A_OPEN_NAME_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot open attribute specified by name \"%s\".", s );
+
+#define HANDLE_H5A_READ_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot read attribute" );
+
+#define HANDLE_H5A_WRITE_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot write attribute \"%s\".", s );
+
+/* H5D: Dataset */
+#define HANDLE_H5D_CLOSE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Close of dataset failed." );
+
+#define HANDLE_H5D_CREATE_ERR( s, n ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot create dataset for name \"%s\", step \"%lld\".", \
+		s, (long long) n );
+
+#define HANDLE_H5D_EXISTS_ERR( s, n ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Dataset already exists with name \"%s\", step \"%lld\".", \
+		s, (long long) n );
+
+#define HANDLE_H5D_GET_SPACE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot get dataspace identifier.");
+
+#define HANDLE_H5D_GET_PLIST_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot get dataspace property list.");
+
+#define HANDLE_H5D_GET_TYPE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot determine dataset type.");
+
+#define HANDLE_H5D_OPEN_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot open dataset \"%s\".", s );
+
+#define HANDLE_H5D_READ_ERR( s, n ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Read from dataset \"%s\" failed, step \"%lld\".", \
+		s, (long long) n );
+
+#define HANDLE_H5D_WRITE_ERR( s, n ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Write to dataset \"%s\" failed, step \"%lld\".", \
+		s, (long long)n );
+
+/* H5F: file */
+#define HANDLE_H5F_CLOSE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot terminate access to file." );
+
+#define HANDLE_H5F_OPEN_ERR( filename, flags ) \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_HDF5, \
+			"Cannot open file \"%s\" with mode \"%d\"", filename, flags );
+
+
+
+/* H5G: group */
+#define HANDLE_H5G_CLOSE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot terminate access to datagroup." );
+
+#define HANDLE_H5G_CREATE_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot create datagroup \"%s\".", s );
+
+#define HANDLE_H5G_GET_OBJINFO_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot get information about object \"%s\".", s );
+
+#define HANDLE_H5G_OPEN_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot open group \"%s\".", s );
+
+#define HANDLE_H5O_OPEN_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot open object \"%s\".", s );
+
+/* H5P: property */
+#define HANDLE_H5P_CLOSE_ERR( s ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot terminate access to property list \"%s\".", s );
+
+#define HANDLE_H5P_CREATE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot create property list." );
+
+#define HANDLE_H5P_SET_DXPL_MPIO_ERR \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_HDF5, \
+			"MPI: Cannot set data transfer mode." );
+
+
+#define HANDLE_H5P_SET_FAPL_ERR \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_HDF5, \
+			"Cannot store IO communicator information to the " \
+			"file access property list." );
+
+#define HANDLE_H5P_SET_CHUNK_ERR \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_HDF5, \
+			"Cannot set chunk dimensions." );
+
+#define HANDLE_H5P_GET_CHUNK_ERR \
+		(*_err_handler) ( \
+			_H5Part_get_funcname(), \
+			H5PART_ERR_HDF5, \
+			"Cannot get chunk dimensions." );
+
+/* H5S: dataspace */
+#define HANDLE_H5S_CREATE_SCALAR_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot create scalar dataspace." );
+
+#define HANDLE_H5S_CREATE_SIMPLE_ERR( n ) \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot create dataspace with len \"%lld\".", (long long) n );
+
+#define HANDLE_H5S_CLOSE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot terminate access to dataspace." ); 
+
+#define HANDLE_H5S_GET_SELECT_NPOINTS_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot determine number of elements in dataspace selection." ); 
+
+#define HANDLE_H5S_GET_SIMPLE_EXTENT_NPOINTS_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot determine number of elements in dataspace." ); 
+
+#define HANDLE_H5S_SELECT_HYPERSLAB_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot select hyperslap region of dataspace." );
+
+#define HANDLE_H5S_SELECT_ELEMENTS_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot select elements in dataspace." );
+
+/* H5T:  type */
+#define HANDLE_H5T_STRING_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot create string datatype." );
+
+#define HANDLE_H5T_CLOSE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot release datatype." );
+
+/* H5L */
+#define HANDLE_H5L_ITERATE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_HDF5, \
+		"Cannot iterate through group." );
+
+/* MPI */
+#define HANDLE_MPI_ALLGATHER_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_MPI, \
+		"Cannot gather data." );
+
+#define HANDLE_MPI_SENDRECV_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_MPI, \
+		"Unable to perform point-to-point MPI send/receive." );
+
+#define HANDLE_MPI_COMM_SIZE_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_MPI, \
+		"Cannot get number of processes in my group." );
+
+#define HANDLE_MPI_COMM_RANK_ERR \
+	 (*_err_handler) ( \
+		_H5Part_get_funcname(), \
+		H5PART_ERR_MPI, \
+		"Cannot get rank of the calling process in my group." );
+
+#endif

--- a/extern/h5part/H5PartPrivate.h
+++ b/extern/h5part/H5PartPrivate.h
@@ -1,0 +1,261 @@
+#ifndef __H5PART_PRIVATE_H
+#define __H5PART_PRIVATE_H
+
+#if H5_VERS_MAJOR == 1 && H5_VERS_MINOR == 6
+#define H5_USE_16_API
+#endif
+
+extern char H5PART_GROUPNAME_STEP[256]	;
+
+#define H5PART_BTREE_IK 10000
+
+h5part_int64_t
+_H5Part_file_is_valid (
+	const H5PartFile *f
+	);
+
+/*!
+  The functions declared here are not part of the API, but may be used
+  in extensions like H5Block. We name these functions "private".
+
+  \note
+  Private function may change there interface even in stable versions.
+  Don't use them in applications!
+*/
+
+struct _iter_op_data {
+	int stop_idx;
+	int count;
+	int type;
+	char *name;
+	size_t len;
+	char *pattern;
+};
+
+h5part_int64_t
+_H5Part_set_step (
+	H5PartFile *f,
+	const h5part_int64_t step
+	);
+
+h5part_int64_t
+_H5Part_get_step_name(
+	H5PartFile *f,
+	const h5part_int64_t step,
+	char *name
+	);
+
+h5part_int64_t
+_H5Part_get_num_particles (
+	H5PartFile *f
+	);
+
+herr_t
+_H5Part_iteration_operator (
+	hid_t group_id,
+	const char *member_name,
+	void *operator_data
+	);
+
+#ifndef H5_USE_16_API
+herr_t
+_H5Part_iteration_operator2 (
+	hid_t group_id,		 /*!< [in] parent object id */
+	const char *member_name, /*!< [in] child object name */
+	const H5L_info_t *linfo, /*!< link info */
+	void *operator_data );   /*!< [in,out] data passed to the iterator */
+#endif
+
+void
+_H5Part_set_funcname (
+	char *fname
+	);
+
+char*
+_H5Part_get_funcname (
+	void
+	);
+
+#define INIT do {\
+	if ( _init() < 0 ) {\
+		HANDLE_H5PART_INIT_ERR;\
+		return NULL;\
+	}}while(0);
+
+#define SET_FNAME( fname )	_H5Part_set_funcname( fname );
+
+h5part_int64_t
+_H5Part_make_string_type (
+	hid_t *type,
+	int size
+	);
+
+h5part_int64_t
+_H5Part_normalize_h5_type (
+	hid_t type
+	);
+
+h5part_int64_t
+_H5Part_read_attrib (
+	hid_t id,
+	const char *attrib_name,
+	void *attrib_value
+	);
+
+h5part_int64_t
+_H5Part_write_attrib (
+	hid_t id,
+	const char *attrib_name,
+	const hid_t attrib_type,
+	const void *attrib_value,
+	const hsize_t attrib_nelem
+	);
+
+h5part_int64_t
+_H5Part_get_attrib_info (
+	hid_t id,
+	const h5part_int64_t attrib_idx,
+	char *attrib_name,
+	const h5part_int64_t len_attrib_name,
+	h5part_int64_t *attrib_type,
+	h5part_int64_t *attrib_nelem
+	);
+
+h5part_int64_t
+_H5Part_get_num_objects (
+	hid_t group_id,
+	const char *group_name,
+	const hid_t type
+	);
+
+h5part_int64_t
+_H5Part_get_num_objects_matching_pattern (
+	hid_t group_id,
+	const char *group_name,
+	const hid_t type,
+	char * const pattern
+	);
+
+h5part_int64_t
+_H5Part_get_object_name (
+	hid_t group_id,
+	const char *group_name,
+	const hid_t type,
+	const h5part_int64_t idx,
+	char *obj_name,
+	const h5part_int64_t len_obj_name
+	);
+
+h5part_int64_t
+_H5Part_have_group (
+	const hid_t id,
+	const char *name
+	);
+
+h5part_int64_t
+_H5Part_start_throttle (
+	H5PartFile *f
+	);
+
+h5part_int64_t
+_H5Part_end_throttle (
+	H5PartFile *f
+	);
+
+h5part_error_handler
+_H5Part_get_err_handle (
+	void
+	);
+
+void
+_H5Part_vprint_error (
+	const char *fmt,
+	va_list ap
+	);
+
+void
+_H5Part_print_error (
+	const char *fmt,
+	... )
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
+;
+
+void
+_H5Part_vprint_warn (
+	const char *fmt,
+	va_list ap
+	);
+
+void
+_H5Part_print_warn (
+	const char *fmt,
+	...
+	)
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
+;
+
+void
+_H5Part_vprint_info (
+	const char *fmt,
+	va_list ap
+	);
+
+void
+_H5Part_print_info (
+	const char *fmt,
+	...
+	)
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
+;
+
+void
+_H5Part_vprint_debug (
+	const char *fmt,
+	va_list ap
+	);
+
+void
+_H5Part_print_debug (
+	const char *fmt,
+	...
+	)
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
+;
+
+void
+_H5Part_vprint_debug_detail (
+	const char *fmt,
+	va_list ap
+	);
+
+void
+_H5Part_print_debug_detail (
+	const char *fmt,
+	...
+	)
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
+;
+
+char *
+_H5Part_strdupfor2c (
+	const char *s,
+	const ssize_t len
+	);
+
+char *
+_H5Part_strc2for (
+	char * const str,
+	const ssize_t l_str
+	);
+
+#endif

--- a/extern/h5part/H5PartTypes.h
+++ b/extern/h5part/H5PartTypes.h
@@ -1,0 +1,106 @@
+/*
+  System dependend definitions
+*/
+
+#ifndef _H5PART_TYPES_H_
+#define _H5PART_TYPES_H_
+
+#ifdef   WIN32
+typedef __int64			int64_t;
+#endif /* WIN32 */
+
+typedef int64_t			h5part_int64_t;
+typedef int			h5part_int32_t;
+typedef double			h5part_float64_t;
+typedef float			h5part_float32_t;
+typedef h5part_int64_t (*h5part_error_handler)( const char*, const h5part_int64_t, const char*,...)
+#ifdef __GNUC__
+__attribute__ ((format (printf, 3, 4)))
+#endif
+ ;
+#if !defined(MPI_INCLUDED) && !defined(MPI_BOTTOM)
+typedef unsigned long		MPI_Comm;
+#endif
+
+#define H5PART_STEPNAME_LEN	64
+#define H5PART_DATANAME_LEN	64
+
+struct H5BlockFile;
+
+/**
+   \struct H5PartFile
+
+   This is an essentially opaque datastructure that
+   acts as the filehandle for all practical purposes.
+   It is created by H5PartOpenFile<xx>() and destroyed by
+   H5PartCloseFile().
+*/
+struct H5PartFile {
+    hid_t	file;
+    char	groupname_step[H5PART_STEPNAME_LEN];
+    int	stepno_width;
+    int	empty;
+
+    char flags;
+
+    h5part_int64_t timestep;
+    hsize_t nparticles;
+
+    hid_t timegroup;
+    hid_t shape;
+    hid_t xfer_prop;
+    hid_t create_prop;
+    hid_t access_prop;
+
+    /* the dataspace on disk for the current view */
+    hid_t diskshape;
+    /* the dataspace in memory for the current view */
+    hid_t memshape;
+
+    h5part_int64_t viewstart; /* -1 if no view is available: A "view" looks */
+    h5part_int64_t viewend;   /* at a subset of the data. */
+    char viewindexed; /* flag for an indexed view */
+
+    /**
+       the number of particles in each processor.
+       With respect to the "VIEW", these numbers
+       can be regarded as non-overlapping subsections
+       of the particle array stored in the file.
+       So they can be used to compute the offset of
+       the view for each processor
+    */
+    h5part_int64_t *pnparticles;
+
+    /**
+       Number of processors
+    */
+    int nprocs;
+
+    /**
+       The index of the processor this process is running on.
+    */
+    int myproc;
+
+    /**
+       MPI communicator
+    */
+    MPI_Comm comm;
+
+    int throttle;
+
+    struct H5BlockStruct *block;
+    h5part_int64_t (*close_block)(struct H5PartFile *f);
+
+#ifdef H5PART_PARALLEL_IO
+    struct H5MultiBlockStruct *multiblock;
+    h5part_int64_t (*close_multiblock)(struct H5PartFile *f);
+#endif
+};
+
+typedef struct H5PartFile H5PartFile;
+
+#ifdef IPL_XT3
+# define SEEK_END 2
+#endif
+
+#endif

--- a/extern/h5part/README-extra
+++ b/extern/h5part/README-extra
@@ -1,0 +1,2 @@
+Please note that the files in this directory are a subset of the H5Part 1.6 distribution, 
+stripped down to make the compilation cleaner/simpler as a mini-lib inside another project

--- a/extern/h5part/h5tools.h
+++ b/extern/h5part/h5tools.h
@@ -1,0 +1,418 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Board of Trustees of the University of Illinois.         *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the files COPYING and Copyright.html.  COPYING can be found at the root   *
+ * of the source code distribution tree; Copyright.html can be found at the  *
+ * root level of an installed copy of the electronic HDF5 document set and   *
+ * is linked from the top-level documents page.  It can also be found at     *
+ * http://hdfgroup.org/HDF5/doc/Copyright.html.  If you do not have          *
+ * access to either file, you may request a copy from help@hdfgroup.org.     *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * Programmer:  Robb Matzke <matzke@llnl.gov>
+ *              Thursday, July 23, 1998
+ *
+ * Purpose:     Support functions for the various tools.
+ */
+#ifndef H5TOOLS_H__
+#define H5TOOLS_H__
+
+#include "hdf5.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESCAPE_HTML             1
+#define OPT(X,S)                ((X) ? (X) : (S))
+#define OPTIONAL_LINE_BREAK     "\001"  /* Special strings embedded in the output */
+#define START_OF_DATA       0x0001
+#define END_OF_DATA     0x0002
+
+/*
+ * The output functions need a temporary buffer to hold a piece of the
+ * dataset while it's being printed. This constant sets the limit on the
+ * size of that temporary buffer in bytes. For efficiency's sake, choose the
+ * largest value suitable for your machine (for testing use a small value).
+ */
+#if 1
+#define H5TOOLS_BUFSIZE         (1024 * 1024)
+#else
+#define H5TOOLS_BUFSIZE         (1024)
+#endif 
+
+/*
+ * Maximum size used in a call to malloc
+ */
+#define H5TOOLS_MALLOCSIZE      (128 * 1024 * 1024)
+
+
+/* format for hsize_t */
+#define HSIZE_T_FORMAT   "%"H5_PRINTF_LL_WIDTH"u"
+
+/*
+ * Information about how to format output.
+ */
+typedef struct h5tool_format_t {
+    /*
+     * Fields associated with formatting numeric data.  If a datatype matches
+     * multiple formats based on its size, then the first applicable format
+     * from this list is used. However, if `raw' is non-zero then dump all
+     * data in hexadecimal format without translating from what appears on
+     * disk.
+     *
+     *   raw:        If set then print all data as hexadecimal without
+     *               performing any conversion from disk.
+     *
+     *   fmt_raw:    The printf() format for each byte of raw data. The
+     *               default is `%02x'.
+     *
+     *   fmt_int:    The printf() format to use when rendering data which is
+     *               typed `int'. The default is `%d'.
+     *
+     *   fmt_uint:   The printf() format to use when rendering data which is
+     *               typed `unsigned'. The default is `%u'.
+     *
+     *   fmt_schar:  The printf() format to use when rendering data which is
+     *               typed `signed char'. The default is `%d'. This format is
+     *               used ony if the `ascii' field is zero.
+     *
+     *   fmt_uchar:  The printf() format to use when rendering data which is
+     *               typed `unsigned char'. The default is `%u'. This format
+     *               is used only if the `ascii' field is zero.
+     *
+     *   fmt_short:  The printf() format to use when rendering data which is
+     *               typed `short'. The default is `%d'.
+     *
+     *   fmt_ushort: The printf() format to use when rendering data which is
+     *               typed `unsigned short'. The default is `%u'.
+     *
+     *   fmt_long:   The printf() format to use when rendering data which is
+     *               typed `long'. The default is `%ld'.
+     *
+     *   fmt_ulong:  The printf() format to use when rendering data which is
+     *               typed `unsigned long'. The default is `%lu'.
+     *
+     *   fmt_llong:  The printf() format to use when rendering data which is
+     *               typed `long long'. The default depends on what printf()
+     *               format is available to print this datatype.
+     *
+     *   fmt_ullong: The printf() format to use when rendering data which is
+     *               typed `unsigned long long'. The default depends on what
+     *               printf() format is available to print this datatype.
+     *
+     *   fmt_double: The printf() format to use when rendering data which is
+     *               typed `double'. The default is `%g'.
+     *
+     *   fmt_float:  The printf() format to use when rendering data which is
+     *               typed `float'. The default is `%g'.
+     *
+     *   ascii:      If set then print 1-byte integer values as an ASCII
+     *               character (no quotes).  If the character is one of the
+     *               standard C escapes then print the escaped version.  If
+     *               the character is unprintable then print a 3-digit octal
+     *               escape.  If `ascii' is zero then then 1-byte integers are
+     *               printed as numeric values.  The default is zero.
+     *
+     *   str_locale: Determines how strings are printed. If zero then strings
+     *               are printed like in C except. If set to ESCAPE_HTML then
+     *               strings are printed using HTML encoding where each
+     *               character not in the class [a-zA-Z0-9] is substituted
+     *               with `%XX' where `X' is a hexadecimal digit.
+     *
+     *   str_repeat: If set to non-zero then any character value repeated N
+     *               or more times is printed as 'C'*N
+     *
+     * Numeric data is also subject to the formats for individual elements.
+     */
+    hbool_t     raw;
+    const char  *fmt_raw;
+    const char  *fmt_int;
+    const char  *fmt_uint;
+    const char  *fmt_schar;
+    const char  *fmt_uchar;
+    const char  *fmt_short;
+    const char  *fmt_ushort;
+    const char  *fmt_long;
+    const char  *fmt_ulong;
+    const char  *fmt_llong;
+    const char  *fmt_ullong;
+    const char  *fmt_double;
+    const char  *fmt_float;
+    int         ascii;
+    int         str_locale;
+    int         str_repeat;
+
+    /*
+     * Fields associated with compound array members.
+     *
+     *   pre:       A string to print at the beginning of each array. The
+     *              default value is the left square bracket `['.
+     *
+     *   sep:       A string to print between array values.  The default
+     *              value is a ",\001" ("\001" indicates an optional line
+     *              break).
+     *
+     *   suf:       A string to print at the end of each array.  The default
+     *              value is a right square bracket `]'.
+     *
+     *   linebreaks: a boolean value to determine if we want to break the line
+     *               after each row of an array.
+     */
+    const char  *arr_pre;
+    const char  *arr_sep;
+    const char  *arr_suf;
+    int         arr_linebreak;
+
+    /*
+     * Fields associated with compound data types.
+     *
+     *   name:      How the name of the struct member is printed in the
+     *              values. By default the name is not printed, but a
+     *              reasonable setting might be "%s=" which prints the name
+     *              followed by an equal sign and then the value.
+     *
+     *   sep:       A string that separates one member from another.  The
+     *              default is ", \001" (the \001 indicates an optional
+     *              line break to allow structs to span multiple lines of
+     *              output).
+     *
+     *   pre:       A string to print at the beginning of a compound type.
+     *              The default is a left curly brace.
+     *
+     *   suf:       A string to print at the end of each compound type.  The
+     *              default is  right curly brace.
+     *
+     *   end:       a string to print after we reach the last element of
+     *              each compound type. prints out before the suf.
+     */
+    const char  *cmpd_name;
+    const char  *cmpd_sep;
+    const char  *cmpd_pre;
+    const char  *cmpd_suf;
+    const char  *cmpd_end;
+
+    /*
+     * Fields associated with vlen data types.
+     *
+     *   sep:       A string that separates one member from another.  The
+     *              default is ", \001" (the \001 indicates an optional
+     *              line break to allow structs to span multiple lines of
+     *              output).
+     *
+     *   pre:       A string to print at the beginning of a vlen type.
+     *              The default is a left parentheses.
+     *
+     *   suf:       A string to print at the end of each vlen type.  The
+     *              default is a right parentheses.
+     *
+     *   end:       a string to print after we reach the last element of
+     *              each compound type. prints out before the suf.
+     */
+    const char  *vlen_sep;
+    const char  *vlen_pre;
+    const char  *vlen_suf;
+    const char  *vlen_end;
+
+    /*
+     * Fields associated with the individual elements.
+     *
+     *   fmt:       A printf(3c) format to use to print the value string
+     *              after it has been rendered.  The default is "%s".
+     *
+     *   suf1:      This string is appended to elements which are followed by
+     *              another element whether the following element is on the
+     *              same line or the next line.  The default is a comma.
+     *
+     *   suf2:      This string is appended (after `suf1') to elements which
+     *              are followed on the same line by another element.  The
+     *              default is a single space.
+     */
+    const char  *elmt_fmt;
+    const char  *elmt_suf1;
+    const char  *elmt_suf2;
+
+    /*
+     * Fields associated with the index values printed at the left edge of
+     * each line of output.
+     *
+     *   n_fmt:     Each index value is printed according to this printf(3c)
+     *              format string which should include a format for a long
+     *              integer.  The default is "%lu".
+     *
+     *   sep:       Each integer in the index list will be separated from the
+     *              others by this string, which defaults to a comma.
+     *
+     *   fmt:       After the index values are formated individually and
+     *              separated from one another by some string, the entire
+     *              resulting string will be formated according to this
+     *              printf(3c) format which should include a format for a
+     *              character string.  The default is "%s".
+     */
+    const char  *idx_n_fmt;             /*index number format           */
+    const char  *idx_sep;               /*separator between numbers     */
+    const char  *idx_fmt;               /*entire index format           */
+
+    /*
+     * Fields associated with entire lines.
+     *
+     *   ncols:     Number of columns per line defaults to 80.
+     *
+     *   per_line:  If this field has a positive value then every Nth element
+     *              will be printed at the beginning of a line.
+     *
+     *   pre:       Each line of output contains an optional prefix area
+     *              before the data. This area can contain the index for the
+     *              first datum (represented by `%s') as well as other
+     *              constant text.  The default value is `%s'.
+     *
+     *   1st:       This is the format to print at the beginning of the first
+     *              line of output. The default value is the current value of
+     *              `pre' described above.
+     *
+     *   cont:      This is the format to print at the beginning of each line
+     *              which was continued because the line was split onto
+     *              multiple lines. This often happens with compound
+     *              data which is longer than one line of output. The default
+     *              value is the current value of the `pre' field
+     *              described above.
+     *
+     *   suf:       This character string will be appended to each line of
+     *              output.  It should not contain line feeds.  The default
+     *              is the empty string.
+     *
+     *   sep:       A character string to be printed after every line feed
+     *              defaulting to the empty string.  It should end with a
+     *              line feed.
+     *
+     *   multi_new: Indicates the algorithm to use when data elements tend to
+     *              occupy more than one line of output. The possible values
+     *              are (zero is the default):
+     *
+     *              0:  No consideration. Each new element is printed
+     *                  beginning where the previous element ended.
+     *
+     *              1:  Print the current element beginning where the
+     *                  previous element left off. But if that would result
+     *                  in the element occupying more than one line and it
+     *                  would only occupy one line if it started at the
+     *                  beginning of a line, then it is printed at the
+     *                  beginning of the next line.
+     *
+     *   multi_new: If an element is continued onto additional lines then
+     *              should the following element begin on the next line? The
+     *              default is to start the next element on the same line
+     *              unless it wouldn't fit.
+     *
+     * indentlevel: a string that shows how far to indent if extra spacing
+     *              is needed. dumper uses it.
+     */
+    int         line_ncols;             /*columns of output             */
+    size_t      line_per_line;          /*max elements per line         */
+    const char  *line_pre;              /*prefix at front of each line  */
+    const char  *line_1st;              /*alternate pre. on first line  */
+    const char  *line_cont;             /*alternate pre. on continuation*/
+    const char  *line_suf;              /*string to append to each line */
+    const char  *line_sep;              /*separates lines               */
+    int         line_multi_new;         /*split multi-line outputs?     */
+    const char  *line_indent;           /*for extra identation if we need it*/
+
+    /*used to skip the first set of checks for line length*/
+    int skip_first;
+
+    /*flag used to hide or show the file number for obj refs*/
+    int obj_hidefileno;
+
+    /*string used to format the output for the obje refs*/
+    const char *obj_format;
+
+    /*flag used to hide or show the file number for dataset regions*/
+    int dset_hidefileno;
+
+    /*string used to format the output for the dataset regions*/
+    const char *dset_format;
+
+    const char *dset_blockformat_pre;
+    const char *dset_ptformat_pre;
+    const char *dset_ptformat;
+
+    /*print array indices in output matrix */
+    int pindex;
+
+    /*escape non printable characters */
+    int do_escape;
+
+} h5tool_format_t;
+
+typedef struct h5tools_context_t {
+    size_t cur_column;                       /*current column for output */
+    size_t cur_elmt;                         /*current element/output line */
+    int  need_prefix;                        /*is line prefix needed? */
+    int  ndims;                              /*dimensionality  */
+    hsize_t p_min_idx[H5S_MAX_RANK];         /*min selected index */
+    hsize_t p_max_idx[H5S_MAX_RANK];         /*max selected index */
+    int  prev_multiline;                     /*was prev datum multiline? */
+    size_t prev_prefix_len;                  /*length of previous prefix */
+    int  continuation;                       /*continuation of previous data?*/
+    hsize_t size_last_dim;                   /*the size of the last dimension,
+                                              *needed so we can break after each
+                                              *row */
+    int  indent_level;                 /*the number of times we need some
+                                       *extra indentation */
+    int  default_indent_level;        /*this is used when the indent level gets changed */
+    hsize_t acc[H5S_MAX_RANK];        /* accumulator position */
+    hsize_t pos[H5S_MAX_RANK];        /* matrix position */
+    hsize_t sm_pos;                   /* current stripmine element position */
+} h5tools_context_t;
+
+/* a structure to hold the subsetting particulars for a dataset */
+struct subset_t {
+    hsize_t *start;
+    hsize_t *stride;
+    hsize_t *count;
+    hsize_t *block;
+};
+
+extern FILE   *rawdatastream;       /*output stream for raw data            */
+extern int     bin_output;          /* binary output */
+extern int     bin_form;            /* binary form */
+
+/* Strings for output */
+#define H5_TOOLS_GROUP           "GROUP"
+#define H5_TOOLS_DATASET         "DATASET"
+#define H5_TOOLS_DATATYPE        "DATATYPE"
+
+/* Definitions of useful routines */
+extern void     h5tools_init(void);
+extern void     h5tools_close(void);
+extern hid_t    h5tools_fopen(const char *fname, const char *driver,
+                              char *drivername, size_t drivername_len);
+extern int      h5tools_dump_dset(FILE *stream, const h5tool_format_t *info, hid_t dset,
+                                  hid_t p_typ, struct subset_t *sset, int indentlevel);
+extern int      h5tools_dump_mem(FILE *stream, const h5tool_format_t *info, hid_t obj_id,
+                                 hid_t type, hid_t space, void *mem, int indentlevel);
+extern hid_t    h5tools_get_native_type(hid_t type);
+extern hid_t    h5tools_get_little_endian_type(hid_t type);
+extern hid_t    h5tools_get_big_endian_type(hid_t type);
+
+extern void     h5tools_dump_simple_data(FILE *stream, const h5tool_format_t *info, hid_t container,
+                         h5tools_context_t *ctx/*in,out*/, unsigned flags,
+                         hsize_t nelmts, hid_t type, void *_mem);
+
+extern int      h5tools_canreadf(const char* name,
+                                 hid_t dcpl_id);
+extern int      h5tools_can_encode(H5Z_filter_t filtn);
+
+void            init_acc_pos(h5tools_context_t *ctx, hsize_t *dims);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* H5TOOLS_H__ */
+

--- a/extern/h5part/h5tools_type.c
+++ b/extern/h5part/h5tools_type.c
@@ -1,0 +1,202 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * Copyright by the Board of Trustees of the University of Illinois.         *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the files COPYING and Copyright.html.  COPYING can be found at the root   *
+ * of the source code distribution tree; Copyright.html can be found at the  *
+ * root level of an installed copy of the electronic HDF5 document set and   *
+ * is linked from the top-level documents page.  It can also be found at     *
+ * http://hdfgroup.org/HDF5/doc/Copyright.html.  If you do not have          *
+ * access to either file, you may request a copy from help@hdfgroup.org.     *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "h5tools.h"
+
+/*-------------------------------------------------------------------------
+ * Function:    h5tools_get_native_type
+ *
+ * Purpose: Wrapper around H5Tget_native_type() to work around
+ *      Problems with bitfields.
+ *
+ * Return:  Success:    datatype ID
+ *
+ *      Failure:    FAIL
+ *
+ * Programmer:  Quincey Koziol
+ *              Tuesday, October  5, 2004
+ *
+ * Modifications:
+ *
+ *-------------------------------------------------------------------------
+ */
+hid_t
+h5tools_get_native_type(hid_t type)
+{
+    hid_t p_type;
+    H5T_class_t type_class;
+
+    type_class = H5Tget_class(type);
+    if(type_class==H5T_BITFIELD)
+        p_type=H5Tcopy(type);
+    else
+        p_type = H5Tget_native_type(type,H5T_DIR_DEFAULT);
+
+    return(p_type);
+}
+
+/*-------------------------------------------------------------------------
+ * Function: h5tools_get_little_endian_type
+ *
+ * Purpose: Get a little endian type from a file type
+ *
+ * Return: Success:    datatype ID
+ *         Failure:    FAIL
+ *
+ * Programmer: Pedro Vicente Nunes
+ *             Tuesday, July 18, 2006
+ *
+ * Modifications:
+ *
+ *-------------------------------------------------------------------------
+ */
+hid_t
+h5tools_get_little_endian_type(hid_t tid)
+{
+ hid_t       p_type=-1;
+ H5T_class_t type_class;
+ size_t      size;
+ H5T_sign_t  sign;
+
+ type_class = H5Tget_class(tid);
+ size       = H5Tget_size(tid);
+ sign       = H5Tget_sign(tid);
+
+ switch( type_class ) 
+ {
+ case H5T_INTEGER:
+  {
+   if ( size == 1 && sign == H5T_SGN_2)
+    p_type=H5Tcopy(H5T_STD_I8LE);
+   else if ( size == 2 && sign == H5T_SGN_2)
+    p_type=H5Tcopy(H5T_STD_I16LE);
+   else if ( size == 4 && sign == H5T_SGN_2)
+    p_type=H5Tcopy(H5T_STD_I32LE);
+   else if ( size == 8 && sign == H5T_SGN_2)
+    p_type=H5Tcopy(H5T_STD_I64LE);
+   else if ( size == 1 && sign == H5T_SGN_NONE)
+    p_type=H5Tcopy(H5T_STD_U8LE); 
+   else if ( size == 2 && sign == H5T_SGN_NONE)
+    p_type=H5Tcopy(H5T_STD_U16LE);
+   else if ( size == 4 && sign == H5T_SGN_NONE)
+    p_type=H5Tcopy(H5T_STD_U32LE);
+   else if ( size == 8 && sign == H5T_SGN_NONE)
+    p_type=H5Tcopy(H5T_STD_U64LE);
+  }
+  break;
+  
+ case H5T_FLOAT:
+  if ( size == 4)
+   p_type=H5Tcopy(H5T_IEEE_F32LE);
+  else if ( size == 8)
+   p_type=H5Tcopy(H5T_IEEE_F64LE);
+  break;
+  
+ case H5T_TIME:
+ case H5T_BITFIELD:
+ case H5T_OPAQUE:
+ case H5T_STRING:
+ case H5T_COMPOUND:
+ case H5T_REFERENCE:
+ case H5T_ENUM:
+ case H5T_VLEN:
+ case H5T_ARRAY:
+  break;
+   
+ default:
+  break;
+  
+ }
+
+ return(p_type);
+}
+
+
+/*-------------------------------------------------------------------------
+ * Function: h5tools_get_big_endian_type
+ *
+ * Purpose: Get a big endian type from a file type
+ *
+ * Return: Success:    datatype ID
+ *         Failure:    FAIL
+ *
+ * Programmer: Pedro Vicente Nunes
+ *             Tuesday, July 18, 2006
+ *
+ * Modifications:
+ *
+ *-------------------------------------------------------------------------
+ */
+hid_t
+h5tools_get_big_endian_type(hid_t tid)
+{
+ hid_t       p_type=-1;
+ H5T_class_t type_class;
+ size_t      size;
+ H5T_sign_t  sign;
+
+ type_class = H5Tget_class(tid);
+ size       = H5Tget_size(tid);
+ sign       = H5Tget_sign(tid);
+
+ switch( type_class ) 
+ {
+ case H5T_INTEGER:
+  {
+   if ( size == 1 && sign == H5T_SGN_2)
+    p_type=H5Tcopy(H5T_STD_I8BE);
+   else if ( size == 2 && sign == H5T_SGN_2)
+    p_type=H5Tcopy(H5T_STD_I16BE);
+   else if ( size == 4 && sign == H5T_SGN_2)
+    p_type=H5Tcopy(H5T_STD_I32BE);
+   else if ( size == 8 && sign == H5T_SGN_2)
+    p_type=H5Tcopy(H5T_STD_I64BE);
+   else if ( size == 1 && sign == H5T_SGN_NONE)
+    p_type=H5Tcopy(H5T_STD_U8BE); 
+   else if ( size == 2 && sign == H5T_SGN_NONE)
+    p_type=H5Tcopy(H5T_STD_U16BE);
+   else if ( size == 4 && sign == H5T_SGN_NONE)
+    p_type=H5Tcopy(H5T_STD_U32BE);
+   else if ( size == 8 && sign == H5T_SGN_NONE)
+    p_type=H5Tcopy(H5T_STD_U64BE);
+  }
+  break;
+  
+ case H5T_FLOAT:
+  if ( size == 4)
+   p_type=H5Tcopy(H5T_IEEE_F32BE);
+  else if ( size == 8)
+   p_type=H5Tcopy(H5T_IEEE_F64BE);
+  break;
+  
+ case H5T_TIME:
+ case H5T_BITFIELD:
+ case H5T_OPAQUE:
+ case H5T_STRING:
+ case H5T_COMPOUND:
+ case H5T_REFERENCE:
+ case H5T_ENUM:
+ case H5T_VLEN:
+ case H5T_ARRAY:
+  break;
+   
+ default:
+  break;
+  
+ }
+
+ 
+ return(p_type);
+}

--- a/include/IFileWriter.hpp
+++ b/include/IFileWriter.hpp
@@ -8,7 +8,7 @@ namespace sphexa
 template <typename Dataset>
 struct IFileWriter
 {
-#ifdef USE_H5
+#ifdef SPH_EXA_HAVE_H5PART
     virtual void dumpParticleDataToH5File(const Dataset& d, const std::vector<int> &clist, const std::string &path) const = 0;
 #endif
     virtual void dumpParticleDataToBinFile(const Dataset& d, const std::string &path) const = 0;

--- a/include/MPIFileUtils.hpp
+++ b/include/MPIFileUtils.hpp
@@ -3,9 +3,12 @@
 #include <mpi.h>
 
 #include "Exceptions.hpp"
-#ifdef USE_H5
-#include "H5hut.h"
+
+#ifdef SPH_EXA_HAVE_H5PART
+# include <filesystem>
+# include "H5Part.h"
 #endif
+
 namespace sphexa
 {
 namespace fileutils
@@ -39,7 +42,7 @@ void writeParticleDataToBinFileWithMPI(const MPI_File &file, const size_t count,
     writeParticleDataToBinFileWithMPI(file, count, offset, col, blockNo + 1, args...);
 }
 
-#ifdef USE_H5
+#ifdef SPH_EXA_HAVE_H5PART
 template <typename Dataset, typename... Args>
 void writeParticleDataToBinFileWithH5Part(const Dataset &, const std::vector<int> &, const std::string &, Args &&... ){}
 #endif
@@ -101,41 +104,44 @@ void writeParticleDataToBinFileWithMPI(const Dataset &d, const std::string &path
 // }}}
 
 // {{{ writeParticleDataToBinFileWithH5Part
-#ifdef USE_H5
+#ifdef SPH_EXA_HAVE_H5PART
 template <typename Dataset, typename... Args>
 void writeParticleDataToBinFileWithH5Part(const Dataset &d, const std::vector<int> &clist, const std::string &path, Args &&... data)
 {
+    using h5_int64_t = h5part_int64_t;
+    using h5_id_t    = h5part_int64_t;
+
     // verbosity level: H5_VERBOSE_DEBUG/H5_VERBOSE_INFO/H5_VERBOSE_DEFAULT
-    const h5_int64_t h5_verbosity = H5_VERBOSE_DEFAULT;
-    H5AbortOnError();
+//    const h5_int64_t h5_verbosity = H5_VERBOSE_DEFAULT;
+//    H5AbortOnError();
     // output name
     const char* h5_fname = path.c_str();
+    H5PartFile *h5_file = nullptr;
     // open file
-    h5_file_t h5_file = H5OpenFile(h5_fname, H5_O_RDWR, H5_PROP_DEFAULT);
-    //h5 H5_file.h:
-    //h5 TODO: H5_O_WRONLY & H5_FS_LUSTRE
-    //h5   File mode flags are:
-    //h5   - H5_O_RDONLY: Only reading allowed
-    //h5   - H5_O_WRONLY: create new file, dataset must not exist
-    //h5   - H5_O_APPENDONLY: allows to append new data to an existing file
-    //h5   - H5_O_RDWR: dataset may exist
-    //h5   - H5_FS_LUSTRE: enable optimizations for the Lustre file system
-    //h5   - H5_VFD_MPIO_POSIX: use the HDF5 MPI-POSIX virtual file driver
-    //h5   - H5_VFD_MPIO_INDEPENDENT: use MPI-IO in indepedent mode
+    if (std::filesystem::exists(h5_fname)) {
+        h5_file = H5PartOpenFile(h5_fname, H5PART_APPEND);
+    }
+    else {
+        h5_file = H5PartOpenFile(h5_fname, H5PART_WRITE);
+    }
+
     // create first step
     const h5_id_t h5_step = d.iteration;
-    H5SetStep(h5_file, h5_step);
+    H5PartSetStep(h5_file, h5_step);
+
     // get number of particles that each rank will write
     const int h5_begin = *min_element(clist.begin(), clist.end());
     const int h5_end   = *max_element(clist.begin(), clist.end());
     const h5_int64_t h5_num_particles = h5_end - h5_begin + 1;
+
     // set number of particles that each rank will write
     H5PartSetNumParticles(h5_file, h5_num_particles);
-    h5_float64_t h5_data_x[h5_num_particles];
-    h5_float64_t h5_data_y[h5_num_particles];
-    h5_float64_t h5_data_z[h5_num_particles];
-    h5_float64_t h5_data_h[h5_num_particles];
-    h5_float64_t h5_data_ro[h5_num_particles];
+
+    h5part_float64_t h5_data_x[h5_num_particles];
+    h5part_float64_t h5_data_y[h5_num_particles];
+    h5part_float64_t h5_data_z[h5_num_particles];
+    h5part_float64_t h5_data_h[h5_num_particles];
+    h5part_float64_t h5_data_ro[h5_num_particles];
     // TODO:
     //   vector<T>::const_iterator first = myVec.begin() + 100000;
     //   vector<T>::const_iterator last = myVec.begin() + 101000;
@@ -156,7 +162,7 @@ void writeParticleDataToBinFileWithH5Part(const Dataset &d, const std::vector<in
     H5PartWriteDataFloat64(h5_file, "z", h5_data_z);
     H5PartWriteDataFloat64(h5_file, "h", h5_data_h);
     H5PartWriteDataFloat64(h5_file, "ro", h5_data_ro);
-    H5CloseFile(h5_file);
+    H5PartCloseFile(h5_file);
 }
 #endif
 // }}}

--- a/src/evrard/CMakeLists.txt
+++ b/src/evrard/CMakeLists.txt
@@ -1,10 +1,20 @@
 
 set(exename evrard_new)
 add_executable(${exename} evrard_new.cpp)
+
 target_include_directories(${exename} PRIVATE ${PROJECT_SOURCE_DIR}/domain/include)
 target_include_directories(${exename} PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(${exename} PRIVATE ${MPI_CXX_INCLUDE_PATH})
+
 target_compile_definitions(${exename} PRIVATE USE_MPI GRAVITY)
-target_link_libraries(${exename} ${MPI_CXX_LIBRARIES})
-target_link_libraries(${exename} OpenMP::OpenMP_CXX)
+
+target_link_libraries(${exename} PRIVATE ${MPI_CXX_LIBRARIES})
+target_link_libraries(${exename} PRIVATE OpenMP::OpenMP_CXX)
+
+if (SPH_EXA_WITH_H5PART)
+    target_include_directories(${exename} PUBLIC ${PROJECT_SOURCE_DIR}/extern/h5part)
+    target_compile_definitions(${exename} PUBLIC SPH_EXA_HAVE_H5PART)
+    target_link_libraries(${exename} PRIVATE H5Part ${HDF5_LIBRARIES})
+endif()
+
 unset(exename)

--- a/src/evrard/EvrardCollapseFileWriter.hpp
+++ b/src/evrard/EvrardCollapseFileWriter.hpp
@@ -63,6 +63,13 @@ struct EvrardCollapseFileWriter : public IFileWriter<Dataset>
 template <typename Dataset>
 struct EvrardCollapseMPIFileWriter : IFileWriter<Dataset>
 {
+#ifdef SPH_EXA_HAVE_H5PART
+    void dumpParticleDataToH5File(const Dataset& d, const std::vector<int> &clist, const std::string &path) const override
+    {
+        fileutils::writeParticleDataToBinFileWithH5Part(d, clist, path);
+    }
+#endif
+
     void dumpParticleDataToBinFile(const Dataset &d, const std::string &path) const override
     {
         try

--- a/src/evrard/evrard.cpp
+++ b/src/evrard/evrard.cpp
@@ -133,8 +133,13 @@ int main(int argc, char** argv)
 
         if ((writeFrequency > 0 && d.iteration % writeFrequency == 0) || writeFrequency == 0)
         {
+#ifdef SPH_EXA_HAVE_H5PART
+            fileWriter.dumpParticleDataToH5File(d, domain.clist,
+                                                   outDirectory + "dump_evrard.h5part");
+#else
             fileWriter.dumpParticleDataToAsciiFile(d, domain.clist,
                                                    outDirectory + "dump_evrard" + std::to_string(d.iteration) + ".txt");
+#endif
             timer.step("writeFile");
         }
         if (checkpointFrequency > 0 && d.iteration % checkpointFrequency == 0)

--- a/src/sedov/CMakeLists.txt
+++ b/src/sedov/CMakeLists.txt
@@ -1,11 +1,19 @@
 add_executable(sedov sedov.cpp)
+
 target_include_directories(sedov PRIVATE ${PROJECT_SOURCE_DIR}/domain/include)
 target_include_directories(sedov PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(sedov PRIVATE ${MPI_CXX_INCLUDE_PATH})
+
 target_link_libraries(sedov PRIVATE ${MPI_CXX_LIBRARIES})
 target_link_libraries(sedov PRIVATE OpenMP::OpenMP_CXX)
 
 install(TARGETS sedov RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+if (SPH_EXA_WITH_H5PART)
+    target_compile_definitions(sedov PUBLIC SPH_EXA_HAVE_H5PART)
+    target_include_directories(sedov PUBLIC ${PROJECT_SOURCE_DIR}/extern/h5part)
+    target_link_libraries(sedov PRIVATE H5Part ${HDF5_LIBRARIES})
+endif()
 
 if(CMAKE_CUDA_COMPILER)
     add_executable(sedov-cuda $<TARGET_OBJECTS:gather_obj> $<TARGET_OBJECTS:cuda_find_neighbors_obj> $<TARGET_OBJECTS:cuda_sph> sedov.cpp)

--- a/src/sedov/sedov.cpp
+++ b/src/sedov/sedov.cpp
@@ -162,9 +162,13 @@ int main(int argc, char** argv)
 
         if ((writeFrequency > 0 && d.iteration % writeFrequency == 0) || writeFrequency == 0)
         {
+#ifdef SPH_EXA_HAVE_H5PART
+            fileWriter.dumpParticleDataToH5File(d, clist, outDirectory + "dump_Sedov.h5part");
+#else
             fileWriter.dumpParticleDataToAsciiFile(d, clist,
                                                    outDirectory + "dump_Sedov" + std::to_string(d.iteration) + ".txt");
             fileWriter.dumpParticleDataToBinFile(d, outDirectory + "dump_Sedov" + std::to_string(d.iteration) + ".bin");
+#endif
             timer.step("writeFile");
         }
 


### PR DESCRIPTION
Please be warned that I am making this pull request based on my branch which has conflicts with the develop branch since the cuda/cmake stuff merged into develop does not work for me. So I patched my stuff into this branch without checking it, since I am busy on another project and want to let others experiment with this. It should work fine, but I may have messed up a merge and introduced an error in the cmake.

To enable H5Part IO, simply use
```
cmake -DSPH_EXA_WITH_H5PART=ON ...
``` 
and make sure you have an HDF5 module loaded, or installed somewhere cmake can find it