### PR TITLE
Fix h5part compilation with newer hdf5 versions

### DIFF
--- a/extern/h5part/CMakeLists.txt
+++ b/extern/h5part/CMakeLists.txt
@@ -66,6 +66,8 @@ ADD_LIBRARY(H5Part STATIC
   ${H5Part_SRCS}
 )
 
+target_compile_definitions(H5Part PUBLIC H5_USE_110_API)
+
 TARGET_LINK_LIBRARIES(H5Part
   PUBLIC
     ${H5Part_LIBS}


### PR DESCRIPTION
Add compilation flag to for API for hdf5 1.10.x