### PR TITLE
fixed unused warnings in release build

### DIFF
--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -427,7 +427,8 @@ public:
 private:
 
     //! @brief check that only owned particles in [particleStart_:particleEnd_] are sent out as halos
-    void checkIndices(const SendList& sendList, LocalParticleIndex start, LocalParticleIndex end)
+    void checkIndices(const SendList& sendList, [[maybe_unused]] LocalParticleIndex start,
+                      [[maybe_unused]] LocalParticleIndex end)
     {
         for (const auto& manifest : sendList)
         {
@@ -439,10 +440,6 @@ private:
                                          manifest.rangeStart(ri), manifest.rangeEnd(ri)));
             }
         }
-
-		#define _unused(x) ((void)(x))
-		_unused(start);
-		_unused(end);
     }
 
     //! @brief return true if all array sizes are equal to value


### PR DESCRIPTION
Starting with C++17, we can use `[[maybe_unused]]` to prevent the compiler from warning about an unused variable.