### PR TITLE
fix for nvc++

### DIFF
--- a/src/analytical_solutions/sedov_solution/main.cpp
+++ b/src/analytical_solutions/sedov_solution/main.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <iostream>
+#include <iomanip>
 #include <cmath>
 #include <vector>
 #include <filesystem>


### PR DESCRIPTION
Fix to avoid 
```
main.cpp", line 134: error: namespace "std" has no member "setw"
std::setw(16),
```