### PR TITLE
Prefer hdf5 parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ endif()
 # {{{ i/o
 option(SPH_EXA_WITH_H5PART "Enable HDF5 IO using the H5Part library" ON)
 if (SPH_EXA_WITH_H5PART)
+    set(HDF5_PREFER_PARALLEL true)
     find_package(HDF5)
     if (HDF5_FOUND)
         add_subdirectory(./extern/h5part)


### PR DESCRIPTION
Instructs CMake to find a parallel HDF5 installation (e.g. libhdf5-mpich-dev) when a serial version is also present (libhdf5-dev)