### PR TITLE
Ryoanji SOA

### DIFF
--- a/domain/include/cstone/sfc/box_mpi.hpp
+++ b/domain/include/cstone/sfc/box_mpi.hpp
@@ -41,50 +41,28 @@
 #include "box.hpp"
 #include "cstone/primitives/mpi_wrappers.hpp"
 
-
 namespace cstone
 {
 
-//! @brief compute global minimum of an array range
+//! @brief compute minimum and maximum of an array range with an OpenMP reduction
 template<class Iterator>
-auto globalMin(Iterator start, Iterator end)
+auto localMinMax(Iterator start, Iterator end)
 {
     assert(end > start);
     using T = std::decay_t<decltype(*start)>;
 
     T minimum = INFINITY;
+    T maximum = -INFINITY;
 
-    #pragma omp parallel for reduction(min : minimum)
-    for (size_t pi = 0; pi < std::size_t(end-start); pi++)
+#pragma omp parallel for reduction(min : minimum) reduction(max : maximum)
+    for (size_t pi = 0; pi < std::size_t(end - start); pi++)
     {
         T value = start[pi];
         minimum = std::min(minimum, value);
-    }
-
-    MPI_Allreduce(MPI_IN_PLACE, &minimum, 1, MpiType<T>{}, MPI_MIN, MPI_COMM_WORLD);
-
-    return minimum;
-}
-
-//! @brief compute global maximum of an array range
-template<class Iterator>
-auto globalMax(Iterator start, Iterator end)
-{
-    assert(end > start);
-    using T = std::decay_t<decltype(*start)>;
-
-    T maximum = -INFINITY;
-
-    #pragma omp parallel for reduction(max : maximum)
-    for (size_t pi = 0; pi < std::size_t(end-start); pi++)
-    {
-        T value = start[pi];
         maximum = std::max(maximum, value);
     }
 
-    MPI_Allreduce(MPI_IN_PLACE, &maximum, 1, MpiType<T>{}, MPI_MAX, MPI_COMM_WORLD);
-
-    return maximum;
+    return std::make_tuple(minimum, maximum);
 }
 
 /*! @brief compute global bounding box for local x,y,z arrays
@@ -106,16 +84,27 @@ auto makeGlobalBox(Iterator xB, Iterator xE, Iterator yB, Iterator zB, const Box
 {
     std::size_t nElements = xE - xB;
 
-    T newXmin = (previousBox.pbcX()) ? previousBox.xmin() : globalMin(xB, xB + nElements);
-    T newYmin = (previousBox.pbcY()) ? previousBox.ymin() : globalMin(yB, yB + nElements);
-    T newZmin = (previousBox.pbcZ()) ? previousBox.zmin() : globalMin(zB, zB + nElements);
-    T newXmax = (previousBox.pbcX()) ? previousBox.xmax() : globalMax(xB, xB + nElements);
-    T newYmax = (previousBox.pbcY()) ? previousBox.ymax() : globalMax(yB, yB + nElements);
-    T newZmax = (previousBox.pbcZ()) ? previousBox.zmax() : globalMax(zB, zB + nElements);
+    std::array<T, 6> extrema;
+    std::tie(extrema[0], extrema[1]) =
+        previousBox.pbcX() ? std::make_tuple(previousBox.xmin(), previousBox.xmax()) : localMinMax(xB, xB + nElements);
+    std::tie(extrema[2], extrema[3]) =
+        previousBox.pbcY() ? std::make_tuple(previousBox.ymin(), previousBox.ymax()) : localMinMax(yB, yB + nElements);
+    std::tie(extrema[4], extrema[5]) =
+        previousBox.pbcZ() ? std::make_tuple(previousBox.zmin(), previousBox.zmax()) : localMinMax(zB, zB + nElements);
 
-    return Box<T>{newXmin, newXmax, newYmin, newYmax, newZmin, newZmax,
-                  previousBox.pbcX(), previousBox.pbcY(), previousBox.pbcZ()};
+    if (!previousBox.pbcX() || !previousBox.pbcY() || !previousBox.pbcZ())
+    {
+        extrema[1] = -extrema[1];
+        extrema[3] = -extrema[3];
+        extrema[5] = -extrema[5];
+        MPI_Allreduce(MPI_IN_PLACE, extrema.data(), extrema.size(), MpiType<T>{}, MPI_MIN, MPI_COMM_WORLD);
+        extrema[1] = -extrema[1];
+        extrema[3] = -extrema[3];
+        extrema[5] = -extrema[5];
+    }
+
+    return Box<T>{extrema[0], extrema[1],         extrema[2],         extrema[3],        extrema[4],
+                  extrema[5], previousBox.pbcX(), previousBox.pbcY(), previousBox.pbcZ()};
 };
 
 } // namespace cstone
-

--- a/domain/test/performance/hilbert.cu
+++ b/domain/test/performance/hilbert.cu
@@ -34,7 +34,7 @@
 
 #include <thrust/device_vector.h>
 
-#include "cstone/sfc/sfc.hpp"
+#include "cstone/sfc/sfc.cuh"
 #include "cstone/util/util.hpp"
 
 #include "timing.cuh"
@@ -59,23 +59,6 @@ inline void computeSfcKeys(KeyType* keys, const unsigned* x, const unsigned* y, 
     computeSfcKeysKernel<<<iceil(numKeys, threadsPerBlock), threadsPerBlock>>>(keys, x, y, z, numKeys);
 }
 
-template<class KeyType, class T>
-__global__ void
-computeSfcKeysRealKernel(KeyType* keys, const T* x, const T* y, const T* z, size_t numKeys, const Box<T> box)
-{
-    size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < numKeys)
-    {
-        keys[tid] = sfc3D<KeyType>(x[tid], y[tid], z[tid], box);
-    }
-}
-
-template<class KeyType, class T>
-inline void computeSfcRealKeys(KeyType* keys, const T* x, const T* y, const T* z, size_t numKeys, const Box<T>& box)
-{
-    constexpr int threadsPerBlock = 256;
-    computeSfcKeysRealKernel<<<iceil(numKeys, threadsPerBlock), threadsPerBlock>>>(keys, x, y, z, numKeys, box);
-}
 
 template<class KeyType>
 __global__ void decodeSfcKeysKernel(const KeyType* keys, unsigned* x, unsigned* y, unsigned* z, size_t numKeys)

--- a/domain/test/performance/hilbert.cu
+++ b/domain/test/performance/hilbert.cu
@@ -46,10 +46,7 @@ __global__ void
 computeSfcKeysKernel(KeyType* keys, const unsigned* x, const unsigned* y, const unsigned* z, size_t numKeys)
 {
     size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < numKeys)
-    {
-        keys[tid] = iSfcKey<KeyType>(x[tid], y[tid], z[tid]);
-    }
+    if (tid < numKeys) { keys[tid] = iSfcKey<KeyType>(x[tid], y[tid], z[tid]); }
 }
 
 template<class KeyType>
@@ -59,15 +56,11 @@ inline void computeSfcKeys(KeyType* keys, const unsigned* x, const unsigned* y, 
     computeSfcKeysKernel<<<iceil(numKeys, threadsPerBlock), threadsPerBlock>>>(keys, x, y, z, numKeys);
 }
 
-
 template<class KeyType>
 __global__ void decodeSfcKeysKernel(const KeyType* keys, unsigned* x, unsigned* y, unsigned* z, size_t numKeys)
 {
     size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < numKeys)
-    {
-        thrust::tie(x[tid], y[tid], z[tid]) = decodeSfc(keys[tid]);
-    }
+    if (tid < numKeys) { thrust::tie(x[tid], y[tid], z[tid]) = decodeSfc(keys[tid]); }
 }
 
 template<class KeyType>
@@ -97,7 +90,7 @@ int main()
     std::generate(begin(y), end(y), getRand);
     std::generate(begin(z), end(z), getRand);
 
-    thrust::device_vector<MortonKey<IntegerType>>  mortonKeys(numKeys);
+    thrust::device_vector<MortonKey<IntegerType>> mortonKeys(numKeys);
     thrust::device_vector<HilbertKey<IntegerType>> hilbertKeys(numKeys);
 
     {
@@ -129,7 +122,7 @@ int main()
         };
 
         float t_hilbert = timeGpu(computeHilbert);
-        float t_morton = timeGpu(computeMorton);
+        float t_morton  = timeGpu(computeMorton);
         std::cout << "compute time for " << numKeys << " hilbert keys: " << t_hilbert / 1000 << " s" << std::endl;
         std::cout << "compute time for " << numKeys << " morton keys: " << t_morton / 1000 << " s" << std::endl;
 
@@ -143,7 +136,7 @@ int main()
                           thrust::raw_pointer_cast(dy2.data()), thrust::raw_pointer_cast(dz2.data()), numKeys);
         };
 
-        float t_decode = timeGpu(decodeHilbert);
+        float t_decode  = timeGpu(decodeHilbert);
         bool passDecode = thrust::equal(dx.begin(), dx.end(), dx2.begin()) &&
                           thrust::equal(dy.begin(), dy.end(), dy2.begin()) &&
                           thrust::equal(dz.begin(), dz.end(), dz2.begin());
@@ -152,7 +145,7 @@ int main()
                   << std::endl;
     }
 
-    thrust::device_vector<MortonKey<IntegerType>>  mortonKeys2(numKeys);
+    thrust::device_vector<MortonKey<IntegerType>> mortonKeys2(numKeys);
     thrust::device_vector<HilbertKey<IntegerType>> hilbertKeys2(numKeys);
 
     {
@@ -174,10 +167,10 @@ int main()
 
         float t_hilbert = timeGpu(computeHilbert);
         float t_morton  = timeGpu(computeMorton);
-        std::cout << "compute time for " << numKeys << " hilbert keys from doubles : "
-                  << t_hilbert / 1000 << " s" << std::endl;
-        std::cout << "compute time for " << numKeys << " morton keys from doubles: "
-                  << t_morton / 1000 << " s" << std::endl;
+        std::cout << "compute time for " << numKeys << " hilbert keys from doubles : " << t_hilbert / 1000 << " s"
+                  << std::endl;
+        std::cout << "compute time for " << numKeys << " morton keys from doubles: " << t_morton / 1000 << " s"
+                  << std::endl;
     }
 
     std::cout << "keys match: " << thrust::equal(hilbertKeys.begin(), hilbertKeys.end(), hilbertKeys2.begin())

--- a/main/src/analytical_solutions/CMakeLists.txt
+++ b/main/src/analytical_solutions/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 add_subdirectory(sedov_solution)
 
-install(FILES ${CMAKE_SOURCE_DIR}/main/src/analytical_solutions/compare_solutions.py TYPE BIN)
-install(FILES ${CMAKE_SOURCE_DIR}/main/src/analytical_solutions/compare_noh.py TYPE BIN)
+install(FILES compare_solutions.py TYPE BIN)
+install(FILES compare_noh.py TYPE BIN)

--- a/ryoanji/src/ryoanji/kernel.hpp
+++ b/ryoanji/src/ryoanji/kernel.hpp
@@ -561,12 +561,12 @@ HOST_DEVICE_FUN DEVICE_INLINE Vec4<Ta> P2P(Vec4<Ta> acc, const Vec3<T>& pos_i, c
  * @return        input acceleration plus contribution from this call
  */
 template<class T, class MType>
-HOST_DEVICE_FUN DEVICE_INLINE Vec4<T> M2P(Vec4<T> acc, const Vec3<T>& pos_i, const Vec3<T>& pos_j, MType& M, T EPS2)
+HOST_DEVICE_FUN DEVICE_INLINE Vec4<T> M2P(Vec4<T> acc, const Vec3<T>& pos_i, const Vec3<T>& pos_j, MType& M)
 {
     constexpr int P = ExpansionOrder<MType{}.size()>{};
 
     Vec3<T> dX    = pos_i - pos_j;
-    T       R2    = norm2(dX) + EPS2;
+    T       R2    = norm2(dX);
     T       invR  = inverseSquareRoot(R2);
     T       invR2 = invR * invR;
 

--- a/ryoanji/src/ryoanji/kernel.hpp
+++ b/ryoanji/src/ryoanji/kernel.hpp
@@ -508,8 +508,8 @@ HOST_DEVICE_FUN DEVICE_INLINE void M2M(int begin, int end, const Vec4<T>& Xout, 
  * @param EPS2
  * @return        input acceleration plus contribution from this call
  */
-template<class T>
-HOST_DEVICE_FUN DEVICE_INLINE Vec4<T> P2P(Vec4<T> acc, const Vec3<T>& pos_i, const Vec3<T>& pos_j, T q_j, T EPS2)
+template<class Ta, class T>
+HOST_DEVICE_FUN DEVICE_INLINE Vec4<Ta> P2P(Vec4<Ta> acc, const Vec3<T>& pos_i, const Vec3<T>& pos_j, T q_j, T EPS2)
 {
     Vec3<T> dX    = pos_j - pos_i;
     T       R2    = norm2(dX) + EPS2;

--- a/ryoanji/src/ryoanji/kernel.hpp
+++ b/ryoanji/src/ryoanji/kernel.hpp
@@ -499,15 +499,6 @@ HOST_DEVICE_FUN DEVICE_INLINE void M2M(int begin, int end, const Vec4<T>& Xout, 
     }
 }
 
-/*! @brief interaction between two particles
- *
- * @param acc     acceleration to add to
- * @param pos_i
- * @param pos_j
- * @param q_j
- * @param EPS2
- * @return        input acceleration plus contribution from this call
- */
 template<class Ta, class T>
 HOST_DEVICE_FUN DEVICE_INLINE Vec4<Ta> P2P(Vec4<Ta> acc, const Vec3<T>& pos_i, const Vec3<T>& pos_j, T q_j, T EPS2)
 {
@@ -523,6 +514,39 @@ HOST_DEVICE_FUN DEVICE_INLINE Vec4<Ta> P2P(Vec4<Ta> acc, const Vec3<T>& pos_i, c
     acc[1] += dX[0];
     acc[2] += dX[1];
     acc[3] += dX[2];
+
+    return acc;
+}
+
+/*! @brief interaction between two particles
+ *
+ * @param acc     acceleration to add to
+ * @param pos_i
+ * @param pos_j
+ * @param m_j
+ * @param h_i
+ * @param h_j
+ * @return        input acceleration plus contribution from this call
+ */
+template<class Ta, class T>
+HOST_DEVICE_FUN DEVICE_INLINE Vec4<Ta> P2P(Vec4<Ta> acc, const Vec3<T>& pos_i, const Vec3<T>& pos_j, T m_j, T h_i,
+                                           T h_j)
+{
+    Vec3<T> dX = pos_j - pos_i;
+    T       R2 = norm2(dX);
+
+    T h_ij  = h_i + h_j;
+    T h_ij2 = h_ij * h_ij;
+    T R2eff = (R2 < h_ij2) ? h_ij2 : R2;
+
+    T invR   = inverseSquareRoot(R2eff);
+    T invR2  = invR * invR;
+    T invR3m = m_j * invR * invR2;
+
+    acc[0] -= invR3m * R2;
+    acc[1] += dX[0] * invR3m;
+    acc[2] += dX[1] * invR3m;
+    acc[3] += dX[2] * invR3m;
 
     return acc;
 }

--- a/ryoanji/src/ryoanji/kernel.hpp
+++ b/ryoanji/src/ryoanji/kernel.hpp
@@ -499,25 +499,6 @@ HOST_DEVICE_FUN DEVICE_INLINE void M2M(int begin, int end, const Vec4<T>& Xout, 
     }
 }
 
-template<class Ta, class T>
-HOST_DEVICE_FUN DEVICE_INLINE Vec4<Ta> P2P(Vec4<Ta> acc, const Vec3<T>& pos_i, const Vec3<T>& pos_j, T q_j, T EPS2)
-{
-    Vec3<T> dX    = pos_j - pos_i;
-    T       R2    = norm2(dX) + EPS2;
-    T       invR  = inverseSquareRoot(R2);
-    T       invR2 = invR * invR;
-    T       invR1 = q_j * invR;
-
-    dX *= invR1 * invR2;
-
-    acc[0] -= invR1;
-    acc[1] += dX[0];
-    acc[2] += dX[1];
-    acc[3] += dX[2];
-
-    return acc;
-}
-
 /*! @brief interaction between two particles
  *
  * @param acc     acceleration to add to

--- a/ryoanji/src/ryoanji/treebuilder.cu
+++ b/ryoanji/src/ryoanji/treebuilder.cu
@@ -236,4 +236,4 @@ template int TreeBuilder<uint64_t>::update(float*, float*, float*, size_t, const
 template int TreeBuilder<uint32_t>::update(double*, double*, double*, size_t, const cstone::Box<double>&);
 template int TreeBuilder<uint64_t>::update(double*, double*, double*, size_t, const cstone::Box<double>&);
 
-} //namespace ryoanji
+} // namespace ryoanji

--- a/ryoanji/src/ryoanji/treebuilder.cuh
+++ b/ryoanji/src/ryoanji/treebuilder.cuh
@@ -46,11 +46,30 @@ public:
 
     ~TreeBuilder();
 
+    //! @brief initialize with the desired maximum particles per leaf cell
     TreeBuilder(unsigned ncrit);
 
+    /*! @brief construct an octree from body coordinates
+     *
+     * @tparam        T           float or double
+     * @param[inout]  x           body x-coordinates, will be sorted in SFC-order
+     * @param[inout]  y           body y-coordinates, will be sorted in SFC-order
+     * @param[inout]  z           body z-coordinates, will be sorted in SFC-order
+     * @param[in]     numBodies   number of bodies in @p x,y,z
+     * @param[in]     box         the coordinate bounding box
+     * @return                    the total number of cells in the constructed octree
+     *
+     * Note: x,y,z arrays will be sorted in SFC order to match be consistent with the cell body offsets of the tree
+     */
     template<class T>
     int update(T* x, T* y, T* z, size_t numBodies, const cstone::Box<T>& box);
 
+    /*! @brief extract the octree from the previous update call in ryoanji format
+     *
+     * @param[out] d_ryoanjiTree array of length numSources as returned by the previous update call
+     * @param[out] h_levelRange  indices of the first node at each subdivison level
+     * @return     the maximum subdivision level in the output tree
+     */
     int extract(ryoanji::CellData* d_ryoanjiTree, int2* h_levelRange);
 
     unsigned maxTreeLevel() const;

--- a/ryoanji/src/ryoanji/upwardpass.cuh
+++ b/ryoanji/src/ryoanji/upwardpass.cuh
@@ -58,14 +58,15 @@ struct UpsweepConfig
  */
 template<class T, class MType>
 __global__ void upwardPass(const int firstCell, const int lastCell, CellData* cells, const T* x, const T* y, const T* z,
-                           const T* m, Vec4<T>* sourceCenter, Vec3<T>* cellXmin, Vec3<T>* cellXmax, MType* Multipole)
+                           const T* m, const T* h, Vec4<T>* sourceCenter, Vec4<T>* cellXmin, Vec4<T>* cellXmax,
+                           MType* Multipole)
 {
     const int cellIdx = blockIdx.x * blockDim.x + threadIdx.x + firstCell;
     if (cellIdx >= lastCell) return;
     CellData& cell = cells[cellIdx];
     const T   huge = T(1e10);
-    Vec3<T>   Xmin{+huge, +huge, +huge};
-    Vec3<T>   Xmax{-huge, -huge, -huge};
+    Vec4<T>   Xmin{+huge, +huge, +huge, +huge};
+    Vec4<T>   Xmax{-huge, -huge, -huge, -huge};
     Vec4<T>   center;
     MType     M;
     M = 0;
@@ -77,7 +78,7 @@ __global__ void upwardPass(const int firstCell, const int lastCell, CellData* ce
         center          = setCenter(begin, end, x, y, z, m);
         for (int i = begin; i < end; i++)
         {
-            Vec3<T> pos = {x[i], y[i], z[i]};
+            Vec4<T> pos = {x[i], y[i], z[i], h[i]};
             Xmin        = min(Xmin, pos);
             Xmax        = max(Xmax, pos);
         }
@@ -109,21 +110,22 @@ __global__ void upwardPass(const int firstCell, const int lastCell, CellData* ce
 }
 
 template<class T>
-__global__ void setMAC(int numCells, T invTheta, Vec4<T>* sourceCenter, const Vec3<T>* cellXmin,
-                       const Vec3<T>* cellXmax)
+__global__ void setMAC(int numCells, T invTheta, Vec4<T>* sourceCenter, const Vec4<T>* cellXmin,
+                       const Vec4<T>* cellXmax)
 {
     int cellIdx = blockIdx.x * blockDim.x + threadIdx.x;
     if (cellIdx >= numCells) { return; }
 
-    Vec3<T> Xmin = cellXmin[cellIdx];
-    Vec3<T> Xmax = cellXmax[cellIdx];
+    Vec3<T> Xmin = makeVec3(cellXmin[cellIdx]);
+    Vec3<T> Xmax = makeVec3(cellXmax[cellIdx]);
+    T       Hmax = cellXmax[cellIdx][3];
     Vec3<T> Xi   = makeVec3(sourceCenter[cellIdx]);
     Vec3<T> X    = (Xmax + Xmin) * T(0.5);
-    Vec3<T> R    = (Xmax - Xmin) * T(0.5f);
+    Vec3<T> R    = (Xmax - Xmin) * T(0.5);
     Vec3<T> dX   = X - Xi;
     T       s    = sqrt(norm2(dX));
-    T       l    = max(T(2.0) * max(R), T(1.0e-6));
-    T       MAC  = l * invTheta + s;
+    T       l    = T(2) * max(R);
+    T       MAC  = max(l * invTheta + s, 2 * Hmax + s + l * 0.5);
     T       MAC2 = MAC * MAC;
 
     sourceCenter[cellIdx][3] = MAC2;
@@ -141,13 +143,13 @@ __global__ void normalize(int numCells, MType* multipoles)
 
 template<class T, class MType>
 void upsweep(int numSources, int numLevels, T theta, const int2* levelRange, const T* x, const T* y, const T* z,
-             const T* m, CellData* sourceCells, Vec4<T>* sourceCenter, MType* Multipole)
+             const T* m, const T* h, CellData* sourceCells, Vec4<T>* sourceCenter, MType* Multipole)
 {
     constexpr int numThreads = UpsweepConfig::numThreads;
 
-    thrust::device_vector<Vec3<T>> d_cellXminmax(2 * numSources);
-    Vec3<T>*                       cellXmin = rawPtr(d_cellXminmax.data());
-    Vec3<T>*                       cellXmax = cellXmin + numSources;
+    thrust::device_vector<Vec4<T>> d_cellXminmax(2 * numSources);
+    Vec4<T>*                       cellXmin = rawPtr(d_cellXminmax.data());
+    Vec4<T>*                       cellXmax = cellXmin + numSources;
 
     auto t0 = std::chrono::high_resolution_clock::now();
 
@@ -162,6 +164,7 @@ void upsweep(int numSources, int numLevels, T theta, const int2* levelRange, con
                                               y,
                                               z,
                                               m,
+                                              h,
                                               sourceCenter,
                                               cellXmin,
                                               cellXmax,

--- a/ryoanji/src/ryoanji/upwardpass.cuh
+++ b/ryoanji/src/ryoanji/upwardpass.cuh
@@ -50,7 +50,7 @@ struct UpsweepConfig
  * @param[in]  level            current level to process
  * @param[in]  levelRange       first and last node in @p cells of @p level
  * @param[in]  cells            the tree cells
- * @param[in]  bodyPos          SFC sorted bodies as referenced by @p cells
+ * @param[in]  x,y,z,m,h        SFC sorted bodies as referenced by @p cells
  * @param[out] sourceCenter     the center of mass of each tree cell
  * @param[out] cellXmin         coordinate minimum of each cell
  * @param[out] cellXmax         coordinate maximum of each cell
@@ -109,6 +109,7 @@ __global__ void upwardPass(const int firstCell, const int lastCell, CellData* ce
     Multipole[cellIdx]    = M;
 }
 
+//! @brief calculate the squared MAC radius of each cell, store as the 4-th member sourceCenter
 template<class T>
 __global__ void setMAC(int numCells, T invTheta, Vec4<T>* sourceCenter, const Vec4<T>* cellXmin,
                        const Vec4<T>* cellXmax)

--- a/ryoanji/test/dataset.hpp
+++ b/ryoanji/test/dataset.hpp
@@ -37,24 +37,24 @@ namespace ryoanji
 {
 
 template<class T>
-static void makeCubeBodies(Vec4<T>* bodies, size_t n, double extent = 3)
+static void makeCubeBodies(T* x, T* y, T* z, T* m, size_t n, double extent = 3)
 {
     for (size_t i = 0; i < n; i++)
     {
-        bodies[i][0] = drand48() * 2 * extent - extent;
-        bodies[i][1] = drand48() * 2 * extent - extent;
-        bodies[i][2] = drand48() * 2 * extent - extent;
-        bodies[i][3] = drand48() / n;
+        x[i] = drand48() * 2 * extent - extent;
+        y[i] = drand48() * 2 * extent - extent;
+        z[i] = drand48() * 2 * extent - extent;
+        m[i] = drand48() / n;
     }
 
     // set non-random corners
-    bodies[0][0] = -extent;
-    bodies[0][1] = -extent;
-    bodies[0][2] = -extent;
+    x[0] = -extent;
+    y[0] = -extent;
+    z[0] = -extent;
 
-    bodies[n - 1][0] = extent;
-    bodies[n - 1][1] = extent;
-    bodies[n - 1][2] = extent;
+    x[n - 1] = extent;
+    y[n - 1] = extent;
+    z[n - 1] = extent;
 }
 
 //! generate a grid with npOnEdge^3 bodies

--- a/ryoanji/test/dataset.hpp
+++ b/ryoanji/test/dataset.hpp
@@ -59,17 +59,17 @@ static void makeCubeBodies(T* x, T* y, T* z, T* m, size_t n, double extent = 3)
 
 //! generate a grid with npOnEdge^3 bodies
 template<class T>
-static void makeGridBodies(Vec4<T>* bodies, int npOnEdge, double spacing)
+static void makeGridBodies(T* x, T* y, T* z, T* m, int npOnEdge, double spacing)
 {
     for (size_t i = 0; i < npOnEdge; i++)
         for (size_t j = 0; j < npOnEdge; j++)
             for (size_t k = 0; k < npOnEdge; k++)
             {
-                size_t linIdx     = i * npOnEdge * npOnEdge + j * npOnEdge + k;
-                bodies[linIdx][0] = i * spacing;
-                bodies[linIdx][1] = j * spacing;
-                bodies[linIdx][2] = k * spacing;
-                bodies[linIdx][3] = 1.0 / (npOnEdge * npOnEdge * npOnEdge);
+                size_t linIdx = i * npOnEdge * npOnEdge + j * npOnEdge + k;
+                x[linIdx]     = i * spacing;
+                y[linIdx]     = j * spacing;
+                z[linIdx]     = k * spacing;
+                m[linIdx]     = 1.0 / (npOnEdge * npOnEdge * npOnEdge);
             }
 }
 

--- a/ryoanji/test/dataset.hpp
+++ b/ryoanji/test/dataset.hpp
@@ -37,14 +37,16 @@ namespace ryoanji
 {
 
 template<class T>
-static void makeCubeBodies(T* x, T* y, T* z, T* m, size_t n, double extent = 3)
+static void makeCubeBodies(T* x, T* y, T* z, T* m, T* h, size_t n, double extent = 3)
 {
+    T hInit = std::cbrt(800.0 / n) * extent;
     for (size_t i = 0; i < n; i++)
     {
         x[i] = drand48() * 2 * extent - extent;
         y[i] = drand48() * 2 * extent - extent;
         z[i] = drand48() * 2 * extent - extent;
         m[i] = drand48() / n;
+        h[i] = hInit;
     }
 
     // set non-random corners
@@ -55,22 +57,6 @@ static void makeCubeBodies(T* x, T* y, T* z, T* m, size_t n, double extent = 3)
     x[n - 1] = extent;
     y[n - 1] = extent;
     z[n - 1] = extent;
-}
-
-//! generate a grid with npOnEdge^3 bodies
-template<class T>
-static void makeGridBodies(T* x, T* y, T* z, T* m, int npOnEdge, double spacing)
-{
-    for (size_t i = 0; i < npOnEdge; i++)
-        for (size_t j = 0; j < npOnEdge; j++)
-            for (size_t k = 0; k < npOnEdge; k++)
-            {
-                size_t linIdx = i * npOnEdge * npOnEdge + j * npOnEdge + k;
-                x[linIdx]     = i * spacing;
-                y[linIdx]     = j * spacing;
-                z[linIdx]     = k * spacing;
-                m[linIdx]     = 1.0 / (npOnEdge * npOnEdge * npOnEdge);
-            }
 }
 
 } // namespace ryoanji

--- a/ryoanji/test/dataset.hpp
+++ b/ryoanji/test/dataset.hpp
@@ -39,7 +39,8 @@ namespace ryoanji
 template<class T>
 static void makeCubeBodies(T* x, T* y, T* z, T* m, T* h, size_t n, double extent = 3)
 {
-    T hInit = std::cbrt(800.0 / n) * extent;
+    double ng0   = 100;
+    T      hInit = std::cbrt(ng0 / n / 4.19) * extent;
     for (size_t i = 0; i < n; i++)
     {
         x[i] = drand48() * 2 * extent - extent;

--- a/ryoanji/test/demo.cu
+++ b/ryoanji/test/demo.cu
@@ -45,13 +45,10 @@ int main(int argc, char** argv)
     int directRef = argc > 2 ? std::stoi(argv[2]) : 1;
 
     std::size_t numBodies = (1 << power) - 1;
-    int         images    = 0;
     T           theta     = 0.6;
     T           boxSize   = 3;
 
-    const T   eps   = 0.05;
     const int ncrit = 64;
-    const T   cycle = 2 * M_PI;
 
     fprintf(stdout, "--- BH Parameters ---------------\n");
     fprintf(stdout, "numBodies            : %lu\n", numBodies);
@@ -98,13 +95,11 @@ int main(int argc, char** argv)
 
     Vec4<T> interactions = computeAcceleration(0,
                                                numBodies,
-                                               images,
-                                               eps,
-                                               cycle,
                                                rawPtr(d_x.data()),
                                                rawPtr(d_y.data()),
                                                rawPtr(d_z.data()),
                                                rawPtr(d_m.data()),
+                                               rawPtr(d_h.data()),
                                                rawPtr(d_p.data()),
                                                rawPtr(d_ax.data()),
                                                rawPtr(d_ay.data()),

--- a/ryoanji/test/demo.cu
+++ b/ryoanji/test/demo.cu
@@ -47,6 +47,7 @@ int main(int argc, char** argv)
     std::size_t numBodies = (1 << power) - 1;
     T           theta     = 0.6;
     T           boxSize   = 3;
+    T           G         = 1.0;
 
     const int ncrit = 64;
 
@@ -88,7 +89,7 @@ int main(int argc, char** argv)
             rawPtr(sourceCenter.data()),
             rawPtr(Multipole.data()));
 
-    thrust::device_vector<T> d_p(numBodies), d_ax(numBodies), d_ay(numBodies), d_az(numBodies);
+    thrust::device_vector<T> d_p(numBodies, 0), d_ax(numBodies, 0), d_ay(numBodies, 0), d_az(numBodies, 0);
 
     fprintf(stdout, "--- BH Profiling ----------------\n");
 
@@ -101,6 +102,7 @@ int main(int argc, char** argv)
                                                rawPtr(d_z.data()),
                                                rawPtr(d_m.data()),
                                                rawPtr(d_h.data()),
+                                               G,
                                                rawPtr(d_p.data()),
                                                rawPtr(d_ax.data()),
                                                rawPtr(d_ay.data()),

--- a/ryoanji/test/demo.cu
+++ b/ryoanji/test/demo.cu
@@ -59,11 +59,11 @@ int main(int argc, char** argv)
     fprintf(stdout, "theta                : %f\n", theta);
     fprintf(stdout, "ncrit                : %d\n", ncrit);
 
-    thrust::host_vector<T> x(numBodies), y(numBodies), z(numBodies), m(numBodies);
-    makeCubeBodies(x.data(), y.data(), z.data(), m.data(), numBodies, boxSize);
+    thrust::host_vector<T> x(numBodies), y(numBodies), z(numBodies), m(numBodies), h(numBodies);
+    makeCubeBodies(x.data(), y.data(), z.data(), m.data(), h.data(), numBodies, boxSize);
 
     // upload bodies to device
-    thrust::device_vector<T> d_x = x, d_y = y, d_z = z, d_m = m;
+    thrust::device_vector<T> d_x = x, d_y = y, d_z = z, d_m = m, d_h = h;
 
     cstone::Box<T> box(-boxSize, boxSize);
 
@@ -131,11 +131,12 @@ int main(int argc, char** argv)
               rawPtr(d_y.data()),
               rawPtr(d_z.data()),
               rawPtr(d_m.data()),
+              rawPtr(d_h.data()),
               rawPtr(refP.data()),
               rawPtr(refAx.data()),
               rawPtr(refAy.data()),
-              rawPtr(refAz.data()),
-              eps);
+              rawPtr(refAz.data()));
+
     t1 = std::chrono::high_resolution_clock::now();
     dt = std::chrono::duration<double>(t1 - t0).count();
 

--- a/ryoanji/test/demo.cu
+++ b/ryoanji/test/demo.cu
@@ -83,6 +83,7 @@ int main(int argc, char** argv)
             rawPtr(d_y.data()),
             rawPtr(d_z.data()),
             rawPtr(d_m.data()),
+            rawPtr(d_h.data()),
             rawPtr(sources.data()),
             rawPtr(sourceCenter.data()),
             rawPtr(Multipole.data()));

--- a/ryoanji/test/direct.cu
+++ b/ryoanji/test/direct.cu
@@ -43,7 +43,7 @@ using namespace ryoanji;
 
 TEST(DirectSum, MatchCpu)
 {
-    using T = double;
+    using T       = double;
     int npOnEdge  = 10;
     int numBodies = npOnEdge * npOnEdge * npOnEdge;
 
@@ -74,7 +74,7 @@ TEST(DirectSum, MatchCpu)
     thrust::host_vector<T> h_p = p, h_ax = ax, h_ay = ay, h_az = az;
 
     std::vector<T> h(numBodies, 0);
-    T G = 1.0;
+    T              G = 1.0;
 
     std::vector<T> refP(numBodies), refAx(numBodies), refAy(numBodies), refAz(numBodies);
     directSum(x.data(),

--- a/ryoanji/test/direct.cu
+++ b/ryoanji/test/direct.cu
@@ -94,8 +94,9 @@ TEST(DirectSum, MatchCpu)
         Vec3<T> ref   = {refAx[i], refAy[i], refAz[i]};
         Vec3<T> probe = {h_ax[i], h_ay[i], h_az[i]};
 
-        EXPECT_NEAR(std::sqrt(norm2(ref - probe) / norm2(probe)), 0, 1e-6);
-        // the potential
+        EXPECT_NEAR(h_ax[i], refAx[i], 1e-6);
+        EXPECT_NEAR(h_ay[i], refAy[i], 1e-6);
+        EXPECT_NEAR(h_az[i], refAz[i], 1e-6);
         EXPECT_NEAR(refP[i], h_p[i], 1e-6);
 
         // printf("%f %f %f\n", ref[1], ref[2], ref[3]);

--- a/ryoanji/test/direct.cu
+++ b/ryoanji/test/direct.cu
@@ -46,7 +46,7 @@ TEST(DirectSum, MatchCpu)
     using T          = double;
     size_t numBodies = 1000;
 
-    std::vector<T> x(numBodies), y(numBodies), z(numBodies), m(numBodies), h(numBodies, 0.1);
+    std::vector<T> x(numBodies), y(numBodies), z(numBodies), m(numBodies), h(numBodies);
     ryoanji::makeCubeBodies(x.data(), y.data(), z.data(), m.data(), h.data(), numBodies);
 
     // upload to device

--- a/ryoanji/test/multipole.cu
+++ b/ryoanji/test/multipole.cu
@@ -66,27 +66,27 @@ TEST(Multipole, P2M)
 
     EXPECT_NEAR(sphericalOctopole[0], cartesianQuadrupole[Cqi::mass], 1e-6);
 
-    EXPECT_NEAR(centerMass[0], csCenter[0] , 1e-6);
-    EXPECT_NEAR(centerMass[1], csCenter[1] , 1e-6);
-    EXPECT_NEAR(centerMass[2], csCenter[2] , 1e-6);
+    EXPECT_NEAR(centerMass[0], csCenter[0], 1e-6);
+    EXPECT_NEAR(centerMass[1], csCenter[1], 1e-6);
+    EXPECT_NEAR(centerMass[2], csCenter[2], 1e-6);
     EXPECT_NEAR(centerMass[3], cartesianQuadrupole[Cqi::mass], 1e-6);
 
     // compare M2P results on a test target
     {
-        double eps2 = 0;
+        double       eps2 = 0;
         Vec3<double> testTarget{-8, -8, -8};
 
         Vec4<double> acc{0, 0, 0, 0};
         acc = ryoanji::M2P(acc, testTarget, util::makeVec3(centerMass), sphericalOctopole, eps2);
-        //printf("test acceleration: %f %f %f %f\n", acc[0], acc[1], acc[2], acc[3]);
+        // printf("test acceleration: %f %f %f %f\n", acc[0], acc[1], acc[2], acc[3]);
 
         // cstone is less precise
-        //float ax = 0;
-        //float ay = 0;
-        //float az = 0;
-        //cstone::multipole2particle(
+        // float ax = 0;
+        // float ay = 0;
+        // float az = 0;
+        // cstone::multipole2particle(
         //    testTarget[0], testTarget[1], testTarget[2], cstoneMultipole, eps2, &ax, &ay, &az);
-        //printf("cstone test acceleration: %f %f %f\n", ax, ay, az);
+        // printf("cstone test acceleration: %f %f %f\n", ax, ay, az);
 
         auto [axd, ayd, azd, pot] = particle2Particle(double(testTarget[0]),
                                                       double(testTarget[1]),
@@ -107,4 +107,3 @@ TEST(Multipole, P2M)
         EXPECT_NEAR(acc[3], azd, 1e-5);
     }
 }
-

--- a/ryoanji/test/multipole.cu
+++ b/ryoanji/test/multipole.cu
@@ -43,22 +43,13 @@ TEST(Multipole, P2M)
 {
     int numBodies = 1023;
 
-    std::vector<Vec4<float>> bodies(numBodies);
-    ryoanji::makeCubeBodies(bodies.data(), numBodies);
-
     std::vector<double> x(numBodies);
     std::vector<double> y(numBodies);
     std::vector<double> z(numBodies);
     std::vector<double> h(numBodies, 0.0);
     std::vector<double> m(numBodies);
 
-    for (size_t i = 0; i < numBodies; ++i)
-    {
-        x[i] = bodies[i][0];
-        y[i] = bodies[i][1];
-        z[i] = bodies[i][2];
-        m[i] = bodies[i][3];
-    }
+    ryoanji::makeCubeBodies(x.data(), y.data(), z.data(), m.data(), numBodies);
 
     CartesianQuadrupole<double>      cartesianQuadrupole;
     cstone::SourceCenterType<double> csCenter =
@@ -66,12 +57,12 @@ TEST(Multipole, P2M)
     particle2Multipole(
         x.data(), y.data(), z.data(), m.data(), 0, numBodies, util::makeVec3(csCenter), cartesianQuadrupole);
 
-    Vec4<float> centerMass = ryoanji::setCenter(0, numBodies, bodies.data());
+    Vec4<double> centerMass = ryoanji::setCenter(0, numBodies, x.data(), y.data(), z.data(), m.data());
 
-    ryoanji::SphericalMultipole<float, 4> sphericalOctopole;
+    ryoanji::SphericalMultipole<double, 4> sphericalOctopole;
     std::fill(sphericalOctopole.begin(), sphericalOctopole.end(), 0.0);
 
-    ryoanji::P2M(0, numBodies, centerMass, bodies.data(), sphericalOctopole);
+    ryoanji::P2M(0, numBodies, centerMass, x.data(), y.data(), z.data(), m.data(), sphericalOctopole);
 
     EXPECT_NEAR(sphericalOctopole[0], cartesianQuadrupole[Cqi::mass], 1e-6);
 
@@ -82,10 +73,10 @@ TEST(Multipole, P2M)
 
     // compare M2P results on a test target
     {
-        float eps2 = 0;
-        Vec3<float> testTarget{-8, -8, -8};
+        double eps2 = 0;
+        Vec3<double> testTarget{-8, -8, -8};
 
-        Vec4<float> acc{0, 0, 0, 0};
+        Vec4<double> acc{0, 0, 0, 0};
         acc = ryoanji::M2P(acc, testTarget, util::makeVec3(centerMass), sphericalOctopole, eps2);
         //printf("test acceleration: %f %f %f %f\n", acc[0], acc[1], acc[2], acc[3]);
 

--- a/ryoanji/test/multipole.cu
+++ b/ryoanji/test/multipole.cu
@@ -73,11 +73,10 @@ TEST(Multipole, P2M)
 
     // compare M2P results on a test target
     {
-        double       eps2 = 0;
         Vec3<double> testTarget{-8, -8, -8};
 
         Vec4<double> acc{0, 0, 0, 0};
-        acc = ryoanji::M2P(acc, testTarget, util::makeVec3(centerMass), sphericalOctopole, eps2);
+        acc = ryoanji::M2P(acc, testTarget, util::makeVec3(centerMass), sphericalOctopole);
         // printf("test acceleration: %f %f %f %f\n", acc[0], acc[1], acc[2], acc[3]);
 
         // cstone is less precise

--- a/ryoanji/test/multipole.cu
+++ b/ryoanji/test/multipole.cu
@@ -46,10 +46,10 @@ TEST(Multipole, P2M)
     std::vector<double> x(numBodies);
     std::vector<double> y(numBodies);
     std::vector<double> z(numBodies);
-    std::vector<double> h(numBodies, 0.0);
     std::vector<double> m(numBodies);
+    std::vector<double> h(numBodies);
 
-    ryoanji::makeCubeBodies(x.data(), y.data(), z.data(), m.data(), numBodies);
+    ryoanji::makeCubeBodies(x.data(), y.data(), z.data(), m.data(), h.data(), numBodies);
 
     CartesianQuadrupole<double>      cartesianQuadrupole;
     cstone::SourceCenterType<double> csCenter =

--- a/ryoanji/test/treebuilder.cu
+++ b/ryoanji/test/treebuilder.cu
@@ -130,8 +130,8 @@ TEST(Buildtree, cstone)
     T   extent    = 3;
     T   theta     = 0.75;
 
-    thrust::host_vector<T> x(numBodies), y(numBodies), z(numBodies), m(numBodies);
-    makeCubeBodies(x.data(), y.data(), z.data(), m.data(), numBodies, extent);
+    thrust::host_vector<T> x(numBodies), y(numBodies), z(numBodies), m(numBodies), h(numBodies);
+    makeCubeBodies(x.data(), y.data(), z.data(), m.data(), h.data(), numBodies, extent);
     // upload to device
     thrust::device_vector<T> d_x = x, d_y = y, d_z = z, d_m = m;
 

--- a/ryoanji/test/treebuilder.cu
+++ b/ryoanji/test/treebuilder.cu
@@ -133,7 +133,7 @@ TEST(Buildtree, cstone)
     thrust::host_vector<T> x(numBodies), y(numBodies), z(numBodies), m(numBodies), h(numBodies);
     makeCubeBodies(x.data(), y.data(), z.data(), m.data(), h.data(), numBodies, extent);
     // upload to device
-    thrust::device_vector<T> d_x = x, d_y = y, d_z = z, d_m = m;
+    thrust::device_vector<T> d_x = x, d_y = y, d_z = z, d_m = m, d_h = h;
 
     cstone::Box<T> box(-extent * 1.1, extent * 1.1);
 
@@ -161,6 +161,7 @@ TEST(Buildtree, cstone)
                      rawPtr(d_y.data()),
                      rawPtr(d_z.data()),
                      rawPtr(d_m.data()),
+                     rawPtr(d_h.data()),
                      rawPtr(sources.data()),
                      rawPtr(sourceCenter.data()),
                      rawPtr(Multipole.data()));

--- a/ryoanji/test/treebuilder.cu
+++ b/ryoanji/test/treebuilder.cu
@@ -103,8 +103,7 @@ void checkUpsweep(const cstone::Box<T>& box, const thrust::host_vector<CellData>
             {
                 cellMass += m[j];
 
-                uint64_t bodyKey =
-                    cstone::sfc3D<cstone::SfcKind<uint64_t>>(x[j], y[j], z[j], box);
+                uint64_t bodyKey = cstone::sfc3D<cstone::SfcKind<uint64_t>>(x[j], y[j], z[j], box);
                 // check that the referenced body really lies inside the cell
                 // this is true if the keys, truncated to the first key-in-cell match
                 EXPECT_EQ(cellKey, cstone::enclosingBoxCode(bodyKey, sources[i].level()));

--- a/ryoanji/test/warpscan.cu
+++ b/ryoanji/test/warpscan.cu
@@ -81,11 +81,10 @@ TEST(WarpScan, max)
 
 __global__ void testScan(int* values)
 {
-    int val = 1;
-    int scan = inclusiveScanInt(val);
+    int val             = 1;
+    int scan            = inclusiveScanInt(val);
     values[threadIdx.x] = scan;
 }
-
 
 TEST(WarpScan, inclusiveInt)
 {
@@ -101,7 +100,7 @@ TEST(WarpScan, inclusiveInt)
 
 __global__ void testScanBool(int* result)
 {
-    bool val = threadIdx.x % 2;
+    bool val            = threadIdx.x % 2;
     result[threadIdx.x] = exclusiveScanBool(val);
 }
 
@@ -121,17 +120,14 @@ __global__ void testSegScan(int* values)
 {
     int val = 1;
 
-    if (threadIdx.x == 8)
-        val = 2;
+    if (threadIdx.x == 8) val = 2;
 
-    if (threadIdx.x == 16)
-        val = -2;
+    if (threadIdx.x == 16) val = -2;
 
-    if (threadIdx.x == 31)
-        val = -3;
+    if (threadIdx.x == 31) val = -3;
 
-    int carry = 1;
-    int scan = inclusiveSegscanInt(val, carry);
+    int carry           = 1;
+    int scan            = inclusiveSegscanInt(val, carry);
     values[threadIdx.x] = scan;
 }
 
@@ -158,9 +154,9 @@ __global__ void streamCompactTest(int* result)
 {
     __shared__ int exchange[GpuConfig::warpSize];
 
-    int val     = threadIdx.x;
-    bool keep   = threadIdx.x % 2 == 0;
-    int numKeep = streamCompact(&val, keep, exchange);
+    int  val     = threadIdx.x;
+    bool keep    = threadIdx.x % 2 == 0;
+    int  numKeep = streamCompact(&val, keep, exchange);
 
     result[threadIdx.x] = val;
 }
@@ -171,8 +167,8 @@ TEST(WarpScan, streamCompact)
     streamCompactTest<<<1, GpuConfig::warpSize>>>(rawPtr(d_values.data()));
     thrust::host_vector<int> h_values = d_values;
 
-    for (int i = 0; i < GpuConfig::warpSize/2; ++i)
+    for (int i = 0; i < GpuConfig::warpSize / 2; ++i)
     {
-        EXPECT_EQ(h_values[i], 2*i);
+        EXPECT_EQ(h_values[i], 2 * i);
     }
 }


### PR DESCRIPTION
Adapt Ryoanji so that it can be used in SPH-EXA
- convert body data from arrays-of-struct to struct-of-arrays
- replace plummer softening with smoothing-length-based softening.
- allow acceleration output to be accumulative and multiplied times G
- add option to only calculate potential sum instead of storing the potential of each particle