### PR TITLE
Fix for grid creation and isobaric cube

### DIFF
--- a/main/src/init/grid.hpp
+++ b/main/src/init/grid.hpp
@@ -80,14 +80,15 @@ void regularGrid(double r, size_t side, size_t first, size_t last, Vector& x, Ve
 {
     double step = (2. * r) / side;
 
+    double r_ini = -r + 0.5 * step;
 #pragma omp parallel for
     for (size_t i = first / (side * side); i < last / (side * side) + 1; ++i)
     {
-        double lz = -r + (i * step);
+        double lz = r_ini + (i * step);
 
         for (size_t j = 0; j < side; ++j)
         {
-            double ly = -r + (j * step);
+            double ly = r_ini + (j * step);
 
             for (size_t k = 0; k < side; ++k)
             {
@@ -95,7 +96,7 @@ void regularGrid(double r, size_t side, size_t first, size_t last, Vector& x, Ve
 
                 if (first <= lindex && lindex < last)
                 {
-                    double lx = -r + (k * step);
+                    double lx = r_ini + (k * step);
 
                     z[lindex - first] = lz;
                     y[lindex - first] = ly;


### PR DESCRIPTION
Basic regularGrid function created a grid that was not centered in the box leading to potential problems with PBCs, embedded grids, and probably all tests using it. This is fixed now so that PBC box must be always exactly of the desired size.
Also fixed the particle distribution in the isobaric cube test so that now it works for any number of particles and everything is correctly centered.