### PR TITLE
Domain fixes for Evrard

### DIFF
--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -371,10 +371,10 @@ private:
         {
             if (i == myRank_)
             {
-                std::cout << "rank " << i << " " << assignedSize << " " << layout_.back()
-                          << " flags: " << numFlags << "/" << halos_.haloFlags().size()
-                          << " peers: [" << peers.size() << "] ";
-                for (auto r : peers) std::cout << r << " ";
+                std::cout << "rank " << i << " " << assignedSize << " " << layout_.back() << " flags: " << numFlags
+                          << "/" << halos_.haloFlags().size() << " peers: [" << peers.size() << "] ";
+                for (auto r : peers)
+                    std::cout << r << " ";
                 std::cout << std::endl;
             }
             MPI_Barrier(MPI_COMM_WORLD);

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -205,7 +205,8 @@ public:
 #pragma omp parallel for schedule(static)
         for (TreeNodeIndex globalIdx = firstGlobalIdx; globalIdx < lastGlobalIdx; ++globalIdx)
         {
-            TreeNodeIndex localIdx      = octree().locate(globalLeaves[globalIdx], globalLeaves[globalIdx + 1]);
+            TreeNodeIndex localIdx = octree().locate(globalLeaves[globalIdx], globalLeaves[globalIdx + 1]);
+            if (localIdx == octree().numTreeNodes()) { continue; }
             globalQuantities[globalIdx] = localQuantities[localIdx];
             assert(octree().codeStart(localIdx) == globalLeaves[globalIdx]);
             assert(octree().codeEnd(localIdx) == globalLeaves[globalIdx + 1]);

--- a/domain/include/cstone/halos/halos.hpp
+++ b/domain/include/cstone/halos/halos.hpp
@@ -47,7 +47,8 @@ template<class KeyType>
 class Halos
 {
 public:
-    Halos(int myRank) : myRank_(myRank)
+    Halos(int myRank)
+        : myRank_(myRank)
     {
     }
 
@@ -153,7 +154,7 @@ private:
 
         for (int range = 0; range < 2; ++range)
         {
-            #pragma omp parallel for
+#pragma omp parallel for
             for (TreeNodeIndex i = checkRanges[range][0]; i < checkRanges[range][1]; ++i)
             {
                 if (haloFlags_[i])
@@ -161,10 +162,7 @@ private:
                     bool peerFound = false;
                     for (auto peerRange : focusAssignment)
                     {
-                        if (peerRange.start() <= i && i < peerRange.end())
-                        {
-                            peerFound = true;
-                        }
+                        if (peerRange.start() <= i && i < peerRange.end()) { peerFound = true; }
                     }
                     if (!peerFound)
                     {

--- a/domain/include/cstone/halos/halos.hpp
+++ b/domain/include/cstone/halos/halos.hpp
@@ -173,7 +173,7 @@ private:
                                   << " of similar magnitude than the rank domain volume. In that case, either"
                                   << " the number of ranks needs to be decreased or the number of particles"
                                   << " increased, leading to shorter smoothing lengths\n";
-                        MPI_Abort(MPI_COMM_WORLD, 1);
+                        MPI_Abort(MPI_COMM_WORLD, 35);
                     }
                 }
             }

--- a/domain/include/cstone/sfc/box_mpi.hpp
+++ b/domain/include/cstone/sfc/box_mpi.hpp
@@ -48,7 +48,7 @@ namespace cstone
 template<class Iterator>
 auto localMinMax(Iterator start, Iterator end)
 {
-    assert(end > start);
+    assert(end >= start);
     using T = std::decay_t<decltype(*start)>;
 
     T minimum = INFINITY;
@@ -105,6 +105,6 @@ auto makeGlobalBox(Iterator xB, Iterator xE, Iterator yB, Iterator zB, const Box
 
     return Box<T>{extrema[0], extrema[1],         extrema[2],         extrema[3],        extrema[4],
                   extrema[5], previousBox.pbcX(), previousBox.pbcY(), previousBox.pbcZ()};
-};
+}
 
 } // namespace cstone

--- a/domain/include/cstone/traversal/peers.hpp
+++ b/domain/include/cstone/traversal/peers.hpp
@@ -82,7 +82,7 @@ std::vector<int> findPeersMac(int myRank,
         IBox bBox             = sfcIBox(sfcKey(tree.codeStart(b)), tree.level(b));
         auto [aCenter, aSize] = centerAndSize<KeyType>(aBox, box);
         auto [bCenter, bSize] = centerAndSize<KeyType>(bBox, box);
-        return !minMacMutual(aCenter, aSize, bCenter, bSize, box, invTheta);
+        return !minVecMacMutual(aCenter, aSize, bCenter, bSize, box, invTheta);
     };
 
     auto m2l = [](TreeNodeIndex, TreeNodeIndex) {};
@@ -164,3 +164,4 @@ std::vector<int> findPeersMacStt(
 }
 
 } // namespace cstone
+

--- a/domain/include/cstone/traversal/peers.hpp
+++ b/domain/include/cstone/traversal/peers.hpp
@@ -143,7 +143,7 @@ std::vector<int> findPeersMacStt(
 
             IBox sourceBox                  = sfcIBox(sfcKey(nodeStart), octree.level(idx));
             auto [sourceCenter, sourceSize] = centerAndSize<KeyType>(sourceBox, box);
-            return !minMacMutual(targetCenter, targetSize, sourceCenter, sourceSize, box, invTheta);
+            return !minVecMacMutual(targetCenter, targetSize, sourceCenter, sourceSize, box, invTheta);
         };
 
         auto markLeafIdx = [&peers, &assignment](TreeNodeIndex idx)

--- a/domain/include/cstone/traversal/peers.hpp
+++ b/domain/include/cstone/traversal/peers.hpp
@@ -98,7 +98,7 @@ std::vector<int> findPeersMac(int myRank,
     spanSfcRange(domainStart, domainEnd, spanningNodeKeys.data());
     spanningNodeKeys.back() = domainEnd;
 
-    #pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for schedule(dynamic)
     for (std::size_t i = 0; i < spanningNodeKeys.size() - 1; ++i)
     {
         TreeNodeIndex nodeIdx = domainTree.locate(spanningNodeKeys[i], spanningNodeKeys[i + 1]);
@@ -119,13 +119,13 @@ template<template<class> class TreeType, class KeyType, class T>
 std::vector<int> findPeersMacStt(
     int myRank, const SpaceCurveAssignment& assignment, const TreeType<KeyType>& octree, const Box<T>& box, float theta)
 {
-    float invTheta = 1.0f / theta;
+    float invTheta      = 1.0f / theta;
     KeyType domainStart = octree.codeStart(octree.toInternal(assignment.firstNodeIdx(myRank)));
     KeyType domainEnd   = octree.codeEnd(octree.toInternal(assignment.lastNodeIdx(myRank) - 1));
 
     std::vector<int> peers(assignment.numRanks());
 
-    #pragma omp parallel for
+#pragma omp parallel for
     for (TreeNodeIndex i = assignment.firstNodeIdx(myRank); i < assignment.lastNodeIdx(myRank); ++i)
     {
         TreeNodeIndex internalIdx = octree.toInternal(i);
@@ -133,21 +133,22 @@ std::vector<int> findPeersMacStt(
         Vec3<T> targetCenter, targetSize;
         std::tie(targetCenter, targetSize) = centerAndSize<KeyType>(target, box);
 
-        auto violatesMac = [&targetCenter, &targetSize, &octree, &box, invTheta, domainStart, domainEnd](TreeNodeIndex idx)
+        auto violatesMac =
+            [&targetCenter, &targetSize, &octree, &box, invTheta, domainStart, domainEnd](TreeNodeIndex idx)
         {
             KeyType nodeStart = octree.codeStart(idx);
             KeyType nodeEnd   = octree.codeEnd(idx);
             // if the tree node with index idx is fully contained in the focus, we stop traversal
             if (containedIn(nodeStart, nodeEnd, domainStart, domainEnd)) { return false; }
 
-            IBox sourceBox = sfcIBox(sfcKey(nodeStart), octree.level(idx));
+            IBox sourceBox                  = sfcIBox(sfcKey(nodeStart), octree.level(idx));
             auto [sourceCenter, sourceSize] = centerAndSize<KeyType>(sourceBox, box);
             return !minMacMutual(targetCenter, targetSize, sourceCenter, sourceSize, box, invTheta);
         };
 
         auto markLeafIdx = [&peers, &assignment](TreeNodeIndex idx)
         {
-            int peerRank = assignment.findRank(idx);
+            int peerRank    = assignment.findRank(idx);
             peers[peerRank] = 1;
         };
 
@@ -164,4 +165,3 @@ std::vector<int> findPeersMacStt(
 }
 
 } // namespace cstone
-

--- a/domain/include/cstone/tree/octree.cuh
+++ b/domain/include/cstone/tree/octree.cuh
@@ -94,6 +94,11 @@ findPopulatedNodes(const KeyType* tree, TreeNodeIndex nNodes, const KeyType* cod
         populatedNodes[0] = stl::upper_bound(tree, tree + nNodes, *codesStart) - tree - 1;
         populatedNodes[1] = stl::upper_bound(tree, tree + nNodes, *(codesEnd - 1)) - tree;
     }
+    else
+    {
+        populatedNodes[0] = nNodes;
+        populatedNodes[1] = nNodes;
+    }
 }
 
 /*! @brief count number of particles in each octree node

--- a/domain/include/cstone/tree/octree.cuh
+++ b/domain/include/cstone/tree/octree.cuh
@@ -50,14 +50,15 @@ namespace cstone
 
 //! @brief see computeNodeCounts
 template<class KeyType>
-__global__ void computeNodeCountsKernel(const KeyType* tree, unsigned* counts, TreeNodeIndex nNodes, const KeyType* codesStart,
-                                        const KeyType* codesEnd, unsigned maxCount)
+__global__ void computeNodeCountsKernel(const KeyType* tree,
+                                        unsigned* counts,
+                                        TreeNodeIndex nNodes,
+                                        const KeyType* codesStart,
+                                        const KeyType* codesEnd,
+                                        unsigned maxCount)
 {
     unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
-    if (tid < nNodes)
-    {
-        counts[tid] = calculateNodeCount(tree[tid], tree[tid+1], codesStart, codesEnd, maxCount);
-    }
+    if (tid < nNodes) { counts[tid] = calculateNodeCount(tree[tid], tree[tid + 1], codesStart, codesEnd, maxCount); }
 }
 
 //! @brief see updateNodeCounts
@@ -85,7 +86,8 @@ __device__ TreeNodeIndex populatedNodes[2];
 
 //! @brief compute first and last non-empty nodes in the tree
 template<class KeyType>
-__global__ void findPopulatedNodes(const KeyType* tree, TreeNodeIndex nNodes, const KeyType* codesStart, const KeyType* codesEnd)
+__global__ void
+findPopulatedNodes(const KeyType* tree, TreeNodeIndex nNodes, const KeyType* codesStart, const KeyType* codesEnd)
 {
     if (threadIdx.x == 0 && codesStart != codesEnd)
     {
@@ -107,12 +109,17 @@ __global__ void findPopulatedNodes(const KeyType* tree, TreeNodeIndex nNodes, co
  *                          to prevent overflow in MPI_Allreduce
  */
 template<class KeyType>
-void computeNodeCountsGpu(const KeyType* tree, unsigned* counts, TreeNodeIndex nNodes, const KeyType* codesStart,
-                          const KeyType* codesEnd, unsigned maxCount, bool useCountsAsGuess = false)
+void computeNodeCountsGpu(const KeyType* tree,
+                          unsigned* counts,
+                          TreeNodeIndex nNodes,
+                          const KeyType* codesStart,
+                          const KeyType* codesEnd,
+                          unsigned maxCount,
+                          bool useCountsAsGuess = false)
 {
     TreeNodeIndex popNodes[2];
 
-    findPopulatedNodes<<<1,1>>>(tree, nNodes, codesStart, codesEnd);
+    findPopulatedNodes<<<1, 1>>>(tree, nNodes, codesStart, codesEnd);
     checkGpuErrors(cudaMemcpyFromSymbol(popNodes, populatedNodes, 2 * sizeof(TreeNodeIndex)));
 
     checkGpuErrors(cudaMemset(counts, 0, popNodes[0] * sizeof(unsigned)));
@@ -122,13 +129,13 @@ void computeNodeCountsGpu(const KeyType* tree, unsigned* counts, TreeNodeIndex n
     if (useCountsAsGuess)
     {
         thrust::exclusive_scan(thrust::device, counts + popNodes[0], counts + popNodes[1], counts + popNodes[0]);
-        updateNodeCountsKernel<<<iceil(popNodes[1] - popNodes[0], nThreads), nThreads>>>
-            (tree + popNodes[0], counts + popNodes[0], popNodes[1] - popNodes[0], codesStart, codesEnd, maxCount);
+        updateNodeCountsKernel<<<iceil(popNodes[1] - popNodes[0], nThreads), nThreads>>>(
+            tree + popNodes[0], counts + popNodes[0], popNodes[1] - popNodes[0], codesStart, codesEnd, maxCount);
     }
     else
     {
-        computeNodeCountsKernel<<<iceil(popNodes[1] - popNodes[0], nThreads), nThreads>>>
-            (tree + popNodes[0], counts + popNodes[0], popNodes[1] - popNodes[0], codesStart, codesEnd, maxCount);
+        computeNodeCountsKernel<<<iceil(popNodes[1] - popNodes[0], nThreads), nThreads>>>(
+            tree + popNodes[0], counts + popNodes[0], popNodes[1] - popNodes[0], codesStart, codesEnd, maxCount);
     }
 }
 
@@ -155,39 +162,32 @@ __device__ int rebalanceChangeCounter;
  *  - 8 if to be split.
  */
 template<class KeyType>
-__global__ void rebalanceDecisionKernel(const KeyType* tree, const unsigned* counts, TreeNodeIndex nNodes,
-                                        unsigned bucketSize, TreeNodeIndex* nodeOps)
+__global__ void rebalanceDecisionKernel(
+    const KeyType* tree, const unsigned* counts, TreeNodeIndex nNodes, unsigned bucketSize, TreeNodeIndex* nodeOps)
 {
     unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
     if (tid < nNodes)
     {
         int decision = calculateNodeOp(tree, tid, counts, bucketSize);
-        if (decision != 1) { rebalanceChangeCounter = 1;}
+        if (decision != 1) { rebalanceChangeCounter = 1; }
         nodeOps[tid] = decision;
     }
 }
 
 //! @brief construct new nodes in the balanced tree
 template<class KeyType>
-__global__ void processNodes(const KeyType* oldTree, const TreeNodeIndex* nodeOps,
-                             TreeNodeIndex nOldNodes, TreeNodeIndex nNewNodes,
+__global__ void processNodes(const KeyType* oldTree,
+                             const TreeNodeIndex* nodeOps,
+                             TreeNodeIndex nOldNodes,
+                             TreeNodeIndex nNewNodes,
                              KeyType* newTree)
 {
     unsigned tid = blockDim.x * blockIdx.x + threadIdx.x;
-    if (tid < nOldNodes)
-    {
-        processNode(tid, oldTree, nodeOps, newTree);
-    }
-    if (tid == nNewNodes)
-    {
-        newTree[tid] = nodeRange<KeyType>(0);
-    }
+    if (tid < nOldNodes) { processNode(tid, oldTree, nodeOps, newTree); }
+    if (tid == nNewNodes) { newTree[tid] = nodeRange<KeyType>(0); }
 }
 
-__global__ void resetRebalanceCounter()
-{
-    rebalanceChangeCounter = 0;
-}
+__global__ void resetRebalanceCounter() { rebalanceChangeCounter = 0; }
 
 /*! @brief split or fuse octree nodes based on node counts relative to bucketSize
  *
@@ -202,33 +202,36 @@ __global__ void resetRebalanceCounter()
  * @return                 true if converged, false otherwise
  */
 template<class SfcVector>
-bool rebalanceTreeGpu(SfcVector& tree, const unsigned* counts, unsigned bucketSize,
-                      SfcVector& tmpTree, thrust::device_vector<TreeNodeIndex>& workArray)
+bool rebalanceTreeGpu(SfcVector& tree,
+                      const unsigned* counts,
+                      unsigned bucketSize,
+                      SfcVector& tmpTree,
+                      thrust::device_vector<TreeNodeIndex>& workArray)
 {
-    using KeyType = typename SfcVector::value_type;
+    using KeyType           = typename SfcVector::value_type;
     TreeNodeIndex nOldNodes = nNodes(tree);
 
     // +1 to store the total sum of the exclusive scan in the last element
     workArray.resize(tree.size());
 
-    resetRebalanceCounter<<<1,1>>>();
+    resetRebalanceCounter<<<1, 1>>>();
 
     constexpr unsigned nThreads = 512;
-    rebalanceDecisionKernel<<<iceil(nOldNodes, nThreads), nThreads>>>(
-        thrust::raw_pointer_cast(tree.data()), counts, nOldNodes, bucketSize,
-        thrust::raw_pointer_cast(workArray.data()));
+    rebalanceDecisionKernel<<<iceil(nOldNodes, nThreads), nThreads>>>(thrust::raw_pointer_cast(tree.data()), counts,
+                                                                      nOldNodes, bucketSize,
+                                                                      thrust::raw_pointer_cast(workArray.data()));
 
     thrust::exclusive_scan(thrust::device, thrust::raw_pointer_cast(workArray.data()),
-                          thrust::raw_pointer_cast(workArray.data()) + workArray.size(),
-                          thrust::raw_pointer_cast(workArray.data()));
+                           thrust::raw_pointer_cast(workArray.data()) + workArray.size(),
+                           thrust::raw_pointer_cast(workArray.data()));
 
     // +1 for the end marker (nodeRange<KeyType>(0))
     tmpTree.resize(*workArray.rbegin() + 1);
 
     TreeNodeIndex nElements = stl::max(tree.size(), tmpTree.size());
     processNodes<<<iceil(nElements, nThreads), nThreads>>>(thrust::raw_pointer_cast(tree.data()),
-                                                           thrust::raw_pointer_cast(workArray.data()), nOldNodes, nNodes(tmpTree),
-                                                           thrust::raw_pointer_cast(tmpTree.data()));
+                                                           thrust::raw_pointer_cast(workArray.data()), nOldNodes,
+                                                           nNodes(tmpTree), thrust::raw_pointer_cast(tmpTree.data()));
     int changeCounter;
     checkGpuErrors(cudaMemcpyFromSymbol(&changeCounter, rebalanceChangeCounter, sizeof(int)));
 
@@ -251,17 +254,21 @@ bool rebalanceTreeGpu(SfcVector& tree, const unsigned* counts, unsigned bucketSi
  * @return                   true if converged, false otherwise
  */
 template<class KeyType>
-bool updateOctreeGpu(const KeyType* codesStart, const KeyType* codesEnd, unsigned bucketSize,
-                     thrust::device_vector<KeyType>& tree, thrust::device_vector<unsigned>& counts,
-                     thrust::device_vector<KeyType>& tmpTree, thrust::device_vector<TreeNodeIndex>& workArray,
+bool updateOctreeGpu(const KeyType* codesStart,
+                     const KeyType* codesEnd,
+                     unsigned bucketSize,
+                     thrust::device_vector<KeyType>& tree,
+                     thrust::device_vector<unsigned>& counts,
+                     thrust::device_vector<KeyType>& tmpTree,
+                     thrust::device_vector<TreeNodeIndex>& workArray,
                      unsigned maxCount = std::numeric_limits<unsigned>::max())
 {
     bool converged = rebalanceTreeGpu(tree, thrust::raw_pointer_cast(counts.data()), bucketSize, tmpTree, workArray);
     counts.resize(nNodes(tree));
 
     // local node counts
-    computeNodeCountsGpu(thrust::raw_pointer_cast(tree.data()), thrust::raw_pointer_cast(counts.data()),
-                         nNodes(tree), codesStart, codesEnd, maxCount, true);
+    computeNodeCountsGpu(thrust::raw_pointer_cast(tree.data()), thrust::raw_pointer_cast(counts.data()), nNodes(tree),
+                         codesStart, codesEnd, maxCount, true);
 
     return converged;
 }

--- a/domain/include/cstone/tree/octree.hpp
+++ b/domain/include/cstone/tree/octree.hpp
@@ -208,6 +208,11 @@ void computeNodeCounts(const KeyType* tree,
         lastNode  = std::upper_bound(tree, tree + nNodes, *(codesEnd - 1)) - tree;
         assert(firstNode <= lastNode && "Are your particle codes sorted?");
     }
+    else
+    {
+        firstNode = nNodes;
+        lastNode  = nNodes;
+    }
 
 #pragma omp parallel for schedule(static)
     for (TreeNodeIndex i = 0; i < firstNode; ++i)
@@ -224,18 +229,13 @@ void computeNodeCounts(const KeyType* tree,
     {
         exclusiveScan(counts + firstNode, nNonZeroNodes);
 #pragma omp parallel for schedule(static)
-        for (TreeNodeIndex i = 0; i < nNonZeroNodes - 1; ++i)
+        for (TreeNodeIndex i = 0; i < nNonZeroNodes; ++i)
         {
             unsigned firstGuess  = counts[i + firstNode];
-            unsigned secondGuess = counts[i + firstNode + 1];
+            unsigned secondGuess = counts[std::min(i + firstNode + 1, nNodes - 1)];
             counts[i + firstNode] =
                 updateNodeCount(i, populatedTree, firstGuess, secondGuess, codesStart, codesEnd, maxCount);
         }
-
-        TreeNodeIndex lastIdx = nNonZeroNodes - 1;
-        unsigned lastGuess    = counts[lastIdx + firstNode];
-        counts[lastIdx + firstNode] =
-            updateNodeCount(lastIdx, populatedTree, lastGuess, lastGuess, codesStart, codesEnd, maxCount);
     }
     else
     {

--- a/domain/include/cstone/tree/octree_internal.hpp
+++ b/domain/include/cstone/tree/octree_internal.hpp
@@ -369,7 +369,11 @@ public:
         unsigned level = decodePrefixLength(nodeKey) / 3;
         auto it = std::lower_bound(prefixes_.begin() + levelRange_[level], prefixes_.begin() + levelRange_[level + 1],
                                    nodeKey);
-        return it - prefixes_.begin();
+        if (it != prefixes_.end() && *it == nodeKey) { return it - prefixes_.begin(); }
+        else
+        {
+            return numTreeNodes();
+        }
     }
 
 private:

--- a/main/src/sphexa/sphexa.cpp
+++ b/main/src/sphexa/sphexa.cpp
@@ -105,6 +105,8 @@ int main(int argc, char** argv)
 
     if (ve)
         domain.sync(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1, d.alpha);
+    else if (haveGrav)
+        domain.syncGrav(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1);
     else
         domain.sync(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1);
 

--- a/main/src/sphexa/sphexa.cpp
+++ b/main/src/sphexa/sphexa.cpp
@@ -162,7 +162,7 @@ int main(int argc, char** argv)
     {
         propagator->step(domain, d);
 
-        observables -> computeAndWrite(d, domain.startIndex(), domain.endIndex(), box);
+        observables->computeAndWrite(d, domain.startIndex(), domain.endIndex(), box);
 
         if (isPeriodicOutputStep(d.iteration, writeFrequency) ||
             isExtraOutputStep(d.iteration, d.ttot - d.minDt, d.ttot, writeExtra))

--- a/ryoanji/test/interface/global_upsweep_cpu.cpp
+++ b/ryoanji/test/interface/global_upsweep_cpu.cpp
@@ -43,7 +43,7 @@ template<class T, class KeyType>
 static int multipoleExchangeTest(int thisRank, int numRanks)
 {
     using MultipoleType              = CartesianQuadrupole<T>;
-    const LocalIndex numParticles    = 1000;
+    const LocalIndex numParticles    = 1000 * numRanks;
     unsigned         bucketSize      = 64;
     unsigned         bucketSizeLocal = 16;
     float            theta           = 10.0;

--- a/ryoanji/test/interface/global_upsweep_gpu.cpp
+++ b/ryoanji/test/interface/global_upsweep_gpu.cpp
@@ -46,7 +46,7 @@ template<class T, class KeyType>
 static int multipoleHolderTest(int thisRank, int numRanks)
 {
     using MultipoleType              = SphericalMultipole<T, 4>;
-    const LocalIndex numParticles    = 1000;
+    const LocalIndex numParticles    = 1000 * numRanks;
     unsigned         bucketSize      = 64;
     unsigned         bucketSizeLocal = 16;
     float            theta           = 10.0;


### PR DESCRIPTION
Various fixes to address problems with large-scale runs of the Evrard test case:
- Made domain exchange tolerate calls to `domain::sync(Grav)` with zero particles on some ranks
- Initialize `FocusOctree` with the same MAC criterion that is used for gravity traversal instead of minDistance MAC, this prevents MAC failures for far-way nodes that would lead to a catastrophic amount of halo particles in the first iteration.
- When gravity is active, also initialize domain with `domain::syncGrav` instead of `domain::sync` to ensure initial convergence of `FocusOctree` with the correct MAC criterion
- Change peer rank detection to a MAC criterion to a stricter combination of minDistance MAC and VecMac.
- Global focus exchange: `FocusOctree` has to tolerate a global tree with a higher resolution than the focus tree during initial build up
- Fixed `Octree:locate()` which was directly returning the result of `std::lower_bound` instead of checking whether the queried node exists in the tree.