### PR TITLE
Fix focus transfer

### DIFF
--- a/domain/include/cstone/focus/exchange_focus.hpp
+++ b/domain/include/cstone/focus/exchange_focus.hpp
@@ -320,7 +320,7 @@ void focusTransfer(gsl::span<const KeyType> cstree,
 
         size_t numNodes = end - start;
         auto treelet    = updateTreelet(gsl::span<const KeyType>(cstree.data() + start, numNodes + 1),
-                                        {counts.data() + start, numNodes}, bucketSize);
+                                        gsl::span<const unsigned>(counts.data() + start, numNodes), bucketSize);
 
         mpiSendAsync(treelet.data(), int(treelet.size() - 1), myRank - 1, ownerTag, sendRequests);
         sendBuffers.push_back(std::move(treelet));
@@ -334,7 +334,7 @@ void focusTransfer(gsl::span<const KeyType> cstree,
 
         size_t numNodes = end - start;
         auto treelet    = updateTreelet(gsl::span<const KeyType>(cstree.data() + start, numNodes + 1),
-                                        {counts.data() + start, numNodes}, bucketSize);
+                                        gsl::span<const unsigned>(counts.data() + start, numNodes), bucketSize);
 
         mpiSendAsync(treelet.data(), int(treelet.size() - 1), myRank + 1, ownerTag, sendRequests);
         sendBuffers.push_back(std::move(treelet));

--- a/domain/include/cstone/focus/exchange_focus.hpp
+++ b/domain/include/cstone/focus/exchange_focus.hpp
@@ -280,14 +280,16 @@ void exchangePeerCounts(gsl::span<const int> peerRanks,
 
 /*! @brief Pass on focus tree parts from old owners to new owners
  *
- * @tparam     KeyType         32- or 64-bit unsigned integer
- * @param[in]  cstree          cornerstone leaf cell array (of the locally focused tree)
- * @param[in]  myRank          the executing rank
- * @param[in]  oldFocusStart   SFC assignment boundaries from previous iteration
- * @param[in]  oldFocusEnd
- * @param[in]  newFocusStart   new SFC assignment boundaries
- * @param[in]  newFocusEnd
- * @param[out] buffer          cell keys of parts of a remote rank's @p cstree for the newly assigned area of @p myRank
+ * @tparam       KeyType        32- or 64-bit unsigned integer
+ * @param[in]    cstree         cornerstone leaf cell array (of the locally focused tree)
+ * @param[in]    counts         particle counts per cell in @p cstree, length cstree.size() - 1
+ * @param[in]    myRank         the executing rank
+ * @param[in]    oldFocusStart  SFC assignment boundaries from previous iteration
+ * @param[in]    oldFocusEnd
+ * @param[in]    newFocusStart  new SFC assignment boundaries
+ * @param[in]    newFocusEnd
+ * @param[inout] buffer         cell keys of parts of a remote rank's @p cstree for the newly assigned area of @p myRank
+ *                              will be appended to this
  *
  * When the assignment boundaries change, we let the previous owning rank pass on its focus tree of the part that it
  * lost to the new owning rank. Thanks to doing so we can guarantee that each rank always has the highest focus
@@ -296,6 +298,8 @@ void exchangePeerCounts(gsl::span<const int> peerRanks,
  */
 template<class KeyType>
 void focusTransfer(gsl::span<const KeyType> cstree,
+                   gsl::span<const unsigned> counts,
+                   unsigned bucketSize,
                    int myRank,
                    KeyType oldFocusStart,
                    KeyType oldFocusEnd,
@@ -306,13 +310,20 @@ void focusTransfer(gsl::span<const KeyType> cstree,
     constexpr int ownerTag = static_cast<int>(P2pTags::focusTransfer);
 
     std::vector<MPI_Request> sendRequests;
+    std::vector<std::vector<KeyType>> sendBuffers;
 
     if (oldFocusStart < newFocusStart)
     {
         // current rank lost range [oldFocusStart : newFocusStart] to rank below
         TreeNodeIndex start = findNodeAbove(cstree, oldFocusStart);
         TreeNodeIndex end   = findNodeAbove(cstree, newFocusStart);
-        mpiSendAsync(cstree.data() + start, end - start, myRank - 1, ownerTag, sendRequests);
+
+        size_t numNodes = end - start;
+        auto treelet    = updateTreelet(gsl::span<const KeyType>(cstree.data() + start, numNodes + 1),
+                                        {counts.data() + start, numNodes}, bucketSize);
+
+        mpiSendAsync(treelet.data(), int(treelet.size() - 1), myRank - 1, ownerTag, sendRequests);
+        sendBuffers.push_back(std::move(treelet));
     }
 
     if (newFocusEnd < oldFocusEnd)
@@ -320,8 +331,13 @@ void focusTransfer(gsl::span<const KeyType> cstree,
         // current rank lost range [newFocusEnd : oldFocusEnd] to rank above
         TreeNodeIndex start = findNodeAbove(cstree, newFocusEnd);
         TreeNodeIndex end   = findNodeAbove(cstree, oldFocusEnd);
-        int sendCount       = end - start;
-        mpiSendAsync(cstree.data() + start, sendCount, myRank + 1, ownerTag, sendRequests);
+
+        size_t numNodes = end - start;
+        auto treelet    = updateTreelet(gsl::span<const KeyType>(cstree.data() + start, numNodes + 1),
+                                        {counts.data() + start, numNodes}, bucketSize);
+
+        mpiSendAsync(treelet.data(), int(treelet.size() - 1), myRank + 1, ownerTag, sendRequests);
+        sendBuffers.push_back(std::move(treelet));
     }
 
     if (newFocusStart < oldFocusStart)

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -60,6 +60,7 @@ public:
         : myRank_(myRank)
         , numRanks_(numRanks)
         , theta_(theta)
+        , bucketSize_(bucketSize)
         , treelets_(numRanks_)
         , tree_(bucketSize)
         , counts_{bucketSize + 1}
@@ -103,7 +104,8 @@ public:
         std::vector<KeyType> enforcedKeys;
         enforcedKeys.reserve(peers_.size() * 2);
 
-        focusTransfer(treeLeaves(), myRank_, prevFocusStart, prevFocusEnd, focusStart, focusEnd, enforcedKeys);
+        focusTransfer(treeLeaves(), leafCounts(), bucketSize_, myRank_, prevFocusStart, prevFocusEnd, focusStart,
+                      focusEnd, enforcedKeys);
         for (int peer : peers_)
         {
             enforcedKeys.push_back(globalTreeLeaves[assignment.firstNodeIdx(peer)]);
@@ -408,6 +410,8 @@ private:
     int numRanks_;
     //! @brief opening angle refinement criterion
     float theta_;
+    //! @brief bucket size (ncrit) inside the focus are
+    unsigned bucketSize_;
 
     //! @brief list of peer ranks from last call to updateTree()
     std::vector<int> peers_;

--- a/domain/test/integration_mpi/focus_transfer.cpp
+++ b/domain/test/integration_mpi/focus_transfer.cpp
@@ -43,10 +43,18 @@ using namespace cstone;
 template<class KeyType>
 static void focusTransfer(int myRank, [[maybe_unused]] int numRanks)
 {
-    std::vector<KeyType>  treeLeaves = makeUniformNLevelTree<KeyType>(64, 1);
-    std::vector<unsigned> counts(nNodes(treeLeaves), 0);
+    std::vector<KeyType> treeLeaves = makeUniformNLevelTree<KeyType>(64, 1);
+    std::vector<unsigned> counts(nNodes(treeLeaves), 32);
+    unsigned bucketSize = 64;
+
+    // one of the nodes in the area to be handed over from rank 0 to rank 1 should be split based on counts
+    TreeNodeIndex fullNode = findNodeAbove<KeyType>(treeLeaves, pad(KeyType(032), 6));
+    counts[fullNode]       = bucketSize + 1;
 
     std::vector<KeyType> buffer;
+
+    // assignment before: 0 --- 040 --- nodeRange(0)
+    //            after:  0 --- 032 --- nodeRange(0)
 
     KeyType a = 0;
     KeyType b = 0;
@@ -67,11 +75,15 @@ static void focusTransfer(int myRank, [[maybe_unused]] int numRanks)
         d = nodeRange<KeyType>(0);
     }
 
-    focusTransfer<KeyType>(treeLeaves, myRank, a, b, c, d, buffer);
+    focusTransfer<KeyType>(treeLeaves, counts, 64, myRank, a, b, c, d, buffer);
 
+    // rank 1 receives rebalanced treelet for [032 - 040] from rank 0
     if (myRank == 1)
     {
-        EXPECT_EQ(buffer.size(), 6);
+        EXPECT_EQ(buffer.size(), 13);
+        EXPECT_EQ(buffer.front(), pad(KeyType(032), 6));
+        EXPECT_EQ(buffer[1], pad(KeyType(0321), 9));
+        EXPECT_EQ(buffer.back(), pad(KeyType(037), 6));
     }
 }
 
@@ -88,13 +100,14 @@ TEST(FocusTransfer, simpleTest)
 template<class KeyType>
 static void focusTransferNRanks(int myRank, int numRanks)
 {
-    using SignedKey = std::make_signed_t<KeyType>;
-    std::vector<KeyType>  treeLeaves = makeUniformNLevelTree<KeyType>(64, 1);
-    std::vector<unsigned> counts(nNodes(treeLeaves), 0);
+    using SignedKey                 = std::make_signed_t<KeyType>;
+    std::vector<KeyType> treeLeaves = makeUniformNLevelTree<KeyType>(64, 1);
+    std::vector<unsigned> counts(nNodes(treeLeaves), 32);
+    unsigned bucketSize = 64;
 
     std::vector<KeyType> buffer;
 
-    SignedKey sign = (myRank % 2 == 1) ? 1 : -1;
+    SignedKey sign  = (myRank % 2 == 1) ? 1 : -1;
     SignedKey delta = pad<KeyType>(02, 6);
 
     KeyType a = myRank * (nodeRange<KeyType>(0) / numRanks);
@@ -102,15 +115,9 @@ static void focusTransferNRanks(int myRank, int numRanks)
     KeyType c = (myRank == 0) ? 0 : a - sign * delta;
     KeyType d = (myRank == numRanks - 1) ? nodeRange<KeyType>(0) : b + sign * delta;
 
-    if (myRank < numRanks)
-    {
-        focusTransfer<KeyType>(treeLeaves, myRank, a, b, c, d, buffer);
-    }
+    if (myRank < numRanks) { focusTransfer<KeyType>(treeLeaves, counts, bucketSize, myRank, a, b, c, d, buffer); }
 
-    if (myRank == 0)
-    {
-        EXPECT_EQ(buffer.size(), 0);
-    }
+    if (myRank == 0) { EXPECT_EQ(buffer.size(), 0); }
     else if (myRank == numRanks - 1)
     {
         EXPECT_EQ(buffer.size(), 2);

--- a/domain/test/unit/tree/octree.cpp
+++ b/domain/test/unit/tree/octree.cpp
@@ -42,7 +42,7 @@ template<class T>
 using pair = util::array<T, 2>;
 
 template<class KeyType>
-void findSearchBounds()
+static void findSearchBounds()
 {
     //                          0   1   2   3   4   5   6   7   8   9
     std::vector<KeyType> codes{3, 10, 11, 14, 16, 16, 16, 18, 19, 21};
@@ -50,7 +50,7 @@ void findSearchBounds()
 
     {
         // upward search direction, guess distance from target: 0
-        int guess = 3;
+        int guess  = 3;
         auto probe = findSearchBounds(guess, KeyType(14), c, c + codes.size());
         pair<const KeyType*> reference{c + 2, c + 4};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -58,7 +58,7 @@ void findSearchBounds()
     }
     {
         // upward search direction, guess distance from target: 1
-        int guess = 3;
+        int guess  = 3;
         auto probe = findSearchBounds(guess, KeyType(15), c, c + codes.size());
         pair<const KeyType*> reference{c + 3, c + 4};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -66,7 +66,7 @@ void findSearchBounds()
     }
     {
         // upward search direction, guess distance from target: 1
-        int guess = 3;
+        int guess  = 3;
         auto probe = findSearchBounds(guess, KeyType(16), c, c + codes.size());
         pair<const KeyType*> reference{c + 3, c + 7};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -74,7 +74,7 @@ void findSearchBounds()
     }
     {
         // upward search direction, guess distance from target: 6
-        int guess = 0;
+        int guess  = 0;
         auto probe = findSearchBounds(guess, KeyType(17), c, c + codes.size());
         pair<const KeyType*> reference{c + 0, c + 8};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -82,7 +82,7 @@ void findSearchBounds()
     }
     {
         // downward search direction
-        int guess = 4;
+        int guess  = 4;
         auto probe = findSearchBounds(guess, KeyType(12), c, c + codes.size());
         pair<const KeyType*> reference{c + 2, c + 4};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -90,7 +90,7 @@ void findSearchBounds()
     }
     {
         // downward search direction
-        int guess = 4;
+        int guess  = 4;
         auto probe = findSearchBounds(guess, KeyType(11), c, c + codes.size());
         pair<const KeyType*> reference{c + 0, c + 4};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -98,7 +98,7 @@ void findSearchBounds()
     }
     {
         // downward search direction
-        int guess = 4;
+        int guess  = 4;
         auto probe = findSearchBounds(guess, KeyType(10), c, c + codes.size());
         pair<const KeyType*> reference{c + 0, c + 4};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -106,7 +106,7 @@ void findSearchBounds()
     }
     {
         // downward search direction
-        int guess = 8;
+        int guess  = 8;
         auto probe = findSearchBounds(guess, KeyType(16), c, c + codes.size());
         pair<const KeyType*> reference{c + 0, c + 8};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -114,7 +114,7 @@ void findSearchBounds()
     }
     {
         // downward search direction
-        int guess = 6;
+        int guess  = 6;
         auto probe = findSearchBounds(guess, KeyType(16), c, c + codes.size());
         pair<const KeyType*> reference{c + 3, c + 7};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -122,7 +122,7 @@ void findSearchBounds()
     }
     {
         // direct hit on the last element
-        int guess = 9;
+        int guess  = 9;
         auto probe = findSearchBounds(guess, KeyType(21), c, c + codes.size());
         pair<const KeyType*> reference{c + 8, c + 10};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -130,7 +130,7 @@ void findSearchBounds()
     }
     {
         // must be able to handle out-of-bounds guess
-        int guess = 12;
+        int guess  = 12;
         auto probe = findSearchBounds(guess, KeyType(16), c, c + codes.size());
         pair<const KeyType*> reference{c + 1, c + 9};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
@@ -139,27 +139,21 @@ void findSearchBounds()
     {
         // must be able to handle the upper bound of the last node
         std::make_signed_t<KeyType> guess = 8;
-        KeyType targetKey = nodeRange<KeyType>(0);
-        auto probe = findSearchBounds(guess, targetKey, c, c + codes.size());
+        KeyType targetKey                 = nodeRange<KeyType>(0);
+        auto probe                        = findSearchBounds(guess, targetKey, c, c + codes.size());
         pair<const KeyType*> reference{c + 8, c + 10};
         EXPECT_EQ(probe[0] - c, reference[0] - c);
         EXPECT_EQ(probe[1] - c, reference[1] - c);
     }
 }
 
-TEST(CornerstoneOctree, findSearchBounds32)
-{
-    findSearchBounds<unsigned>();
-}
+TEST(CornerstoneOctree, findSearchBounds32) { findSearchBounds<unsigned>(); }
 
-TEST(CornerstoneOctree, findSearchBounds64)
-{
-    findSearchBounds<uint64_t>();
-}
+TEST(CornerstoneOctree, findSearchBounds64) { findSearchBounds<uint64_t>(); }
 
 //! @brief test that computeNodeCounts correctly counts the number of codes for each node
 template<class CodeType>
-void checkCountTreeNodes()
+static void checkCountTreeNodes()
 {
     std::vector<CodeType> tree = OctreeMaker<CodeType>{}.divide().divide(0).makeTree();
 
@@ -185,7 +179,7 @@ TEST(CornerstoneOctree, countTreeNodes32) { checkCountTreeNodes<unsigned>(); }
 TEST(CornerstoneOctree, countTreeNodes64) { checkCountTreeNodes<uint64_t>(); }
 
 template<class KeyType>
-void computeNodeCountsSTree()
+static void computeNodeCountsSTree()
 {
     std::vector<KeyType> cornerstones{0, 1, nodeRange<KeyType>(0) - 1, nodeRange<KeyType>(0)};
     std::vector<KeyType> tree = computeSpanningTree<KeyType>(cornerstones);
@@ -211,7 +205,7 @@ TEST(CornerstoneOctree, computeNodeCounts_spanningTree)
 }
 
 template<class CodeType, class LocalIndex>
-void rebalanceDecision()
+static void rebalanceDecision()
 {
     std::vector<CodeType> tree = OctreeMaker<CodeType>{}.divide().divide(0).makeTree();
 
@@ -233,7 +227,7 @@ TEST(CornerstoneOctree, rebalanceDecision)
 }
 
 template<class CodeType, class LocalIndex>
-void rebalanceDecisionSingleRoot()
+static void rebalanceDecisionSingleRoot()
 {
     std::vector<CodeType> tree = OctreeMaker<CodeType>{}.makeTree();
 
@@ -262,7 +256,7 @@ TEST(CornerstoneOctree, rebalanceDecisionSingleRoot)
  *  of the underlying 30-bit or 63 bit Morton code is exhausted.
  */
 template<class CodeType>
-void rebalanceInsufficentResolution()
+static void rebalanceInsufficentResolution()
 {
     constexpr int bucketSize = 1;
 
@@ -296,7 +290,7 @@ TEST(CornerstoneOctree, rebalanceInsufficientResolution)
 
 //! @brief check that nodes can be fused at the start of the tree
 template<class CodeType>
-void rebalanceTree()
+static void rebalanceTree()
 {
     std::vector<CodeType> tree = OctreeMaker<CodeType>{}.divide().divide(0).makeTree();
 
@@ -317,8 +311,66 @@ TEST(CornerstoneOctree, rebalance)
 }
 
 template<class KeyType>
-void checkOctreeWithCounts(const std::vector<KeyType>& tree, const std::vector<unsigned>& counts, int bucketSize,
-                           const std::vector<KeyType>& mortonCodes, bool relaxBucketCount)
+static void updateTreelet()
+{
+    unsigned bucketSize = 64;
+    auto tree           = OctreeMaker<KeyType>{}.divide().divide(0).makeTree();
+
+    TreeNodeIndex treeletStart = 7;
+    TreeNodeIndex treeletEnd   = 9;
+
+    {
+        gsl::span<const KeyType> treelet(tree.data() + treeletStart, tree.data() + treeletEnd + 1);
+        std::vector<unsigned> treeletCounts{bucketSize + 1, bucketSize - 1};
+
+        auto newTreelet = updateTreelet<KeyType>(treelet, treeletCounts, bucketSize);
+
+        std::vector<KeyType> reference{treelet.front(),      pad(KeyType(071), 9), pad(KeyType(072), 9),
+                                       pad(KeyType(073), 9), pad(KeyType(074), 9), pad(KeyType(075), 9),
+                                       pad(KeyType(076), 9), pad(KeyType(077), 9), pad(KeyType(01), 3),
+                                       treelet.back()};
+        EXPECT_EQ(nNodes(newTreelet), 9);
+        EXPECT_EQ(newTreelet, reference);
+    }
+    {
+        gsl::span<const KeyType> treelet(tree.data() + treeletStart, tree.data() + treeletEnd + 1);
+        std::vector<unsigned> treeletCounts{bucketSize - 1, bucketSize + 1};
+
+        auto newTreelet = updateTreelet<KeyType>(treelet, treeletCounts, bucketSize);
+
+        std::vector<KeyType> reference{treelet.front(),      pad(KeyType(010), 6), pad(KeyType(011), 6),
+                                       pad(KeyType(012), 6), pad(KeyType(013), 6), pad(KeyType(014), 6),
+                                       pad(KeyType(015), 6), pad(KeyType(016), 6), pad(KeyType(017), 6),
+                                       treelet.back()};
+        EXPECT_EQ(nNodes(newTreelet), 9);
+        EXPECT_EQ(newTreelet, reference);
+    }
+    treeletStart = 0;
+    treeletEnd   = 8;
+    {
+        gsl::span<const KeyType> treelet(tree.data() + treeletStart, tree.data() + treeletEnd + 1);
+        std::vector<unsigned> treeletCounts{1, 2, 3, 4, 5, 6, 7, 8};
+
+        auto newTreelet = updateTreelet<KeyType>(treelet, treeletCounts, bucketSize);
+
+        std::vector<KeyType> reference{treelet.front(), treelet.back()};
+        EXPECT_EQ(nNodes(newTreelet), 1);
+        EXPECT_EQ(newTreelet, reference);
+    }
+}
+
+TEST(CornerstoneOctree, updateTreelet)
+{
+    updateTreelet<unsigned>();
+    updateTreelet<uint64_t>();
+}
+
+template<class KeyType>
+static void checkOctreeWithCounts(const std::vector<KeyType>& tree,
+                                  const std::vector<unsigned>& counts,
+                                  int bucketSize,
+                                  const std::vector<KeyType>& mortonCodes,
+                                  bool relaxBucketCount)
 {
     using CodeType = KeyType;
     EXPECT_TRUE(checkOctreeInvariants(tree.data(), nNodes(tree)));


### PR DESCRIPTION
This fixes a domain bug that occurs when an octree cell should be split and handed over to a different rank
in the same step. In order to a void the bug, we must first rebalance the tree part before handing it over to the new owner rank.