### PR TITLE
Flexible macs

### DIFF
--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -181,7 +181,8 @@ public:
         // h is already reordered here for use in halo discovery
         reorderFunctor(h.data() + exchangeStart, h.data());
 
-        std::vector<int> peers = findPeersMac(myRank_, global_.assignment(), global_.octree(), box(), theta_);
+        float invThetaEff      = invThetaMinMac(theta_);
+        std::vector<int> peers = findPeersMac(myRank_, global_.assignment(), global_.octree(), box(), invThetaEff);
 
         // half the box-length results in a standard min-mac criterion
         float macOffset = 0.5;
@@ -218,7 +219,8 @@ public:
         auto [exchangeStart, keyView] = distribute(particleKeys, x, y, z, h, m, particleProperties...);
         reorderArrays(reorderFunctor, exchangeStart, 0, x.data(), y.data(), z.data(), h.data(), m.data());
 
-        std::vector<int> peers = findPeersMac(myRank_, global_.assignment(), global_.octree(), box(), theta_);
+        float invThetaEff      = invThetaVecMac(theta_);
+        std::vector<int> peers = findPeersMac(myRank_, global_.assignment(), global_.octree(), box(), invThetaEff);
 
         // results in a worst-case vector-mac, sqrt(3) * box-length is the maximum com distance from cell-center
         float macOffset = std::sqrt(3.0f);

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -221,7 +221,7 @@ public:
         std::vector<int> peers = findPeersMac(myRank_, global_.assignment(), global_.octree(), box(), theta_);
 
         // results in a worst-case vector-mac, sqrt(3) * box-length is the maximum com distance from cell-center
-        float macOffset = std::sqrt(3);
+        float macOffset = std::sqrt(3.0f);
 
         if (firstCall_)
         {
@@ -232,7 +232,7 @@ public:
                 converged = focusTree_.updateTree(peers, global_.assignment(), global_.treeLeaves());
                 focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts());
                 focusTree_.template updateCenters<T, T>(x, y, z, m, global_.assignment(), global_.octree(), box());
-                focusTree_.updateVecMac(box(), global_.assignment(), global_.treeLeaves());
+                focusTree_.updateMacs(box(), global_.assignment(), global_.treeLeaves());
                 MPI_Allreduce(MPI_IN_PLACE, &converged, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
             }
         }
@@ -240,7 +240,7 @@ public:
         focusTree_.updateTree(peers, global_.assignment(), global_.treeLeaves());
         focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts());
         focusTree_.template updateCenters<T, T>(x, y, z, m, global_.assignment(), global_.octree(), box());
-        focusTree_.updateVecMac(box(), global_.assignment(), global_.treeLeaves());
+        focusTree_.updateMacs(box(), global_.assignment(), global_.treeLeaves());
 
         halos_.discover(focusTree_.octree(), focusTree_.assignment(), keyView, box(), h.data());
         focusTree_.addMacs(halos_.haloFlags());

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -186,8 +186,8 @@ public:
 
         if (firstCall_)
         {
-            focusTree_.converge(box(), keyView, peers, global_.assignment(), global_.treeLeaves(),
-                                global_.nodeCounts(), invThetaEff);
+            focusTree_.converge(box(), keyView, peers, global_.assignment(), global_.treeLeaves(), global_.nodeCounts(),
+                                invThetaEff);
         }
         focusTree_.updateTree(peers, global_.assignment(), global_.treeLeaves());
         focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts());
@@ -407,7 +407,10 @@ private:
                           << halos_.haloFlags().size() << " peers: [" << peers.size() << "] ";
                 if (numRanks_ <= 32)
                 {
-                    for (auto r : peers) { std::cout << r << " "; }
+                    for (auto r : peers)
+                    {
+                        std::cout << r << " ";
+                    }
                 }
                 std::cout << std::endl;
             }

--- a/domain/include/cstone/focus/octree_focus.hpp
+++ b/domain/include/cstone/focus/octree_focus.hpp
@@ -395,7 +395,7 @@ public:
         }
 
         macs_.resize(tree_.octree().numTreeNodes());
-        markVecMac(octree(), centers_.data(), box, focusStart, focusEnd, macs_.data());
+        markMacs(octree(), centers_.data(), box, focusStart, focusEnd, macs_.data());
 
         gsl::span<const KeyType> leaves = tree_.treeLeaves();
         leafCounts_.resize(nNodes(leaves));

--- a/domain/include/cstone/focus/octree_focus.hpp
+++ b/domain/include/cstone/focus/octree_focus.hpp
@@ -222,10 +222,7 @@ ResolutionStatus enforceKeys(gsl::span<const KeyType> treeLeaves,
             constexpr int maxAddLevels = 1;
             int levelDiff              = keyPos - level;
             if (levelDiff > maxAddLevels) { status = ResolutionStatus::failed; }
-            else
-            {
-                status = std::max(status, ResolutionStatus::rebalance);
-            }
+            else { status = std::max(status, ResolutionStatus::rebalance); }
 
             levelDiff        = std::min(levelDiff, maxAddLevels);
             nodeOps[nodeIdx] = std::max(nodeOps[nodeIdx], 1 << (3 * levelDiff));
@@ -322,10 +319,7 @@ public:
         {
             converged = std::all_of(nodeOps.begin(), nodeOps.end() - 1, [](TreeNodeIndex i) { return i == 1; });
         }
-        else if (status == ResolutionStatus::rebalance)
-        {
-            converged = false;
-        }
+        else if (status == ResolutionStatus::rebalance) { converged = false; }
 
         auto& newLeaves = tree_.prefixes_;
         rebalanceTree(leaves, newLeaves, nodeOps.data());

--- a/domain/include/cstone/focus/octree_focus.hpp
+++ b/domain/include/cstone/focus/octree_focus.hpp
@@ -384,14 +384,14 @@ public:
         bool converged = tree_.update(focusStart, focusEnd, mandatoryKeys, counts_, macs_);
 
         std::vector<Vec4<T>> centers_(tree_.octree().numTreeNodes());
-        auto nodeKeys  = octree().nodeKeys();
-        float invTheta = 1.0f / theta_;
+        auto nodeKeys     = octree().nodeKeys();
+        float invThetaEff = 1.0f / theta_ + 0.5;
 
 #pragma omp parallel for schedule(static)
         for (size_t i = 0; i < nodeKeys.size(); ++i)
         {
             //! set centers to geometric centers for min dist Mac
-            centers_[i] = computeMinMacR2(nodeKeys[i], invTheta, box);
+            centers_[i] = computeMinMacR2(nodeKeys[i], invThetaEff, box);
         }
 
         macs_.resize(tree_.octree().numTreeNodes());

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -123,9 +123,7 @@ public:
 
     /*! @brief Perform a global update of the tree structure
      *
-     * @param[in] box              global coordinate bounding box
      * @param[in] particleKeys     SFC keys of local particles
-     * @param[in] myRank           ID of the executing rank
      * @param[in] globalTreeLeaves global cornerstone leaf tree
      * @param[in] globalCounts     global cornerstone leaf tree counts
      * @return                     true if the tree structure did not change
@@ -320,7 +318,7 @@ public:
             centers_[i] = computeMinMacR2(nodeKeys[i], invThetaEff, box);
         }
 
-        updateVecMac(box, assignment, globalTreeLeaves);
+        updateMacs(box, assignment, globalTreeLeaves);
     }
 
     /*! @brief Update the MAC criteria based on the vector MAC
@@ -332,13 +330,13 @@ public:
      */
     template<class T>
     void
-    updateVecMac(const Box<T>& box, const SpaceCurveAssignment& assignment, gsl::span<const KeyType> globalTreeLeaves)
+    updateMacs(const Box<T>& box, const SpaceCurveAssignment& assignment, gsl::span<const KeyType> globalTreeLeaves)
     {
         KeyType focusStart = globalTreeLeaves[assignment.firstNodeIdx(myRank_)];
         KeyType focusEnd   = globalTreeLeaves[assignment.lastNodeIdx(myRank_)];
 
         macs_.resize(octree().numTreeNodes());
-        markVecMac(octree(), centers_.data(), box, focusStart, focusEnd, macs_.data());
+        markMacs(octree(), centers_.data(), box, focusStart, focusEnd, macs_.data());
 
         rebalanceStatus_ |= macCriterion;
     }

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -302,9 +302,10 @@ public:
      * @param[in] globalTreeLeaves global cornerstone leaf tree
      */
     template<class T>
-    void
-    updateMinMac(const Box<T>& box, const SpaceCurveAssignment& assignment, gsl::span<const KeyType> globalTreeLeaves,
-                 float invThetaEff)
+    void updateMinMac(const Box<T>& box,
+                      const SpaceCurveAssignment& assignment,
+                      gsl::span<const KeyType> globalTreeLeaves,
+                      float invThetaEff)
     {
         centers_.resize(octree().numTreeNodes());
         auto nodeKeys = octree().nodeKeys();

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -309,14 +309,14 @@ public:
     {
         centers_.resize(octree().numTreeNodes());
 
-        auto nodeKeys  = octree().nodeKeys();
-        float invTheta = 1.0f / theta_;
+        auto nodeKeys     = octree().nodeKeys();
+        float invThetaEff = 1.0f / theta_ + 0.5f;
 
 #pragma omp parallel for schedule(static)
         for (size_t i = 0; i < nodeKeys.size(); ++i)
         {
             //! set centers to geometric centers for min dist Mac
-            centers_[i] = computeMinMacR2(nodeKeys[i], invTheta, box);
+            centers_[i] = computeMinMacR2(nodeKeys[i], invThetaEff, box);
         }
 
         updateVecMac(box, assignment, globalTreeLeaves);

--- a/domain/include/cstone/focus/source_center.hpp
+++ b/domain/include/cstone/focus/source_center.hpp
@@ -33,6 +33,7 @@
 
 #include "cstone/util/array.hpp"
 #include "cstone/tree/octree_internal.hpp"
+#include "cstone/traversal/macs.hpp"
 
 namespace cstone
 {
@@ -103,7 +104,7 @@ void computeLeafMassCenter(gsl::span<const T1> x,
                            const Octree<KeyType>& octree,
                            gsl::span<SourceCenterType<T3>> sourceCenter)
 {
-    #pragma omp parallel for
+#pragma omp parallel for
     for (TreeNodeIndex nodeIdx = 0; nodeIdx < octree.numTreeNodes(); ++nodeIdx)
     {
         if (octree.isLeaf(nodeIdx))
@@ -120,24 +121,6 @@ void computeLeafMassCenter(gsl::span<const T1> x,
     }
 }
 
-template<class T, class KeyType>
-HOST_DEVICE_FUN T computeMac(KeyType prefix, Vec3<T> expCenter, float invTheta, const Box<T>& box)
-{
-    KeyType nodeKey  = decodePlaceholderBit(prefix);
-    int prefixLength = decodePrefixLength(prefix);
-
-    IBox cellBox              = sfcIBox(sfcKey(nodeKey), prefixLength / 3);
-    auto [geoCenter, geoSize] = centerAndSize<KeyType>(cellBox, box);
-
-    Vec3<T> dX = expCenter - geoCenter;
-
-    T s   = sqrt(norm2(dX));
-    T l   = T(2.0) * max(geoSize);
-    T mac = l * invTheta + s;
-
-    return mac * mac;
-}
-
 //! @brief replace the last center element (mass) with the squared mac radius
 template<class T, class KeyType>
 void setMac(gsl::span<const KeyType> nodeKeys,
@@ -145,12 +128,12 @@ void setMac(gsl::span<const KeyType> nodeKeys,
             float invTheta,
             const Box<T>& box)
 {
-    #pragma omp parallel for schedule(static)
+#pragma omp parallel for schedule(static)
     for (size_t i = 0; i < nodeKeys.size(); ++i)
     {
         Vec4<T> center = centers[i];
-        T mac = computeMac(nodeKeys[i], util::makeVec3(center), invTheta, box);
-        centers[i][3] = (center[3] != T(0)) ? mac : T(0);
+        T mac          = computeVecMacR2(nodeKeys[i], util::makeVec3(center), invTheta, box);
+        centers[i][3]  = (center[3] != T(0)) ? mac : T(0);
     }
 }
 

--- a/domain/include/cstone/halos/halos.hpp
+++ b/domain/include/cstone/halos/halos.hpp
@@ -77,7 +77,6 @@ public:
         reallocate(nNodes(leaves), haloFlags_);
         std::fill(begin(haloFlags_), end(haloFlags_), 0);
         findHalos(focusedTree, haloRadii.data(), box, firstAssignedNode, lastAssignedNode, haloFlags_.data());
-        checkHalos(focusAssignment);
     }
 
     /*! @brief Compute particle offsets of each tree node and determine halo send/receive indices
@@ -107,6 +106,8 @@ public:
 
         outgoingHaloIndices_ =
             exchangeRequestKeys<KeyType>(leaves, haloFlags_, particleKeys, newParticleStart, assignment, peers);
+
+        checkHalos(assignment);
         checkIndices(outgoingHaloIndices_, newParticleStart, newParticleEnd, layout.back());
 
         incomingHaloIndices_ = computeHaloReceiveList(layout, haloFlags_, assignment, peers);

--- a/domain/include/cstone/traversal/macs.hpp
+++ b/domain/include/cstone/traversal/macs.hpp
@@ -79,16 +79,10 @@ HOST_DEVICE_FUN T minDistanceSq(IBox a, IBox b, const Box<T>& box)
 }
 
 //! @brief compute 1/theta + s for the minimum distance MAC
-HOST_DEVICE_FUN inline float invThetaMinMac(float theta)
-{
-    return 1.0f / theta + 0.5f;
-}
+HOST_DEVICE_FUN inline float invThetaMinMac(float theta) { return 1.0f / theta + 0.5f; }
 
 //! @brief compute 1/theta + s for the worst-case vector MAC
-HOST_DEVICE_FUN inline float invThetaVecMac(float theta)
-{
-    return 1.0f / theta + std::sqrt(3.0f);
-}
+HOST_DEVICE_FUN inline float invThetaVecMac(float theta) { return 1.0f / theta + std::sqrt(3.0f); }
 
 /*! @brief Compute square of the acceptance radius for the minimum distance MAC
  *
@@ -222,15 +216,15 @@ HOST_DEVICE_FUN bool minVecMacMutual(const Vec3<T>& centerA,
     {
         // A = target, B = source
         Vec3<T> dX = minDistance(centerB, centerA, sizeA, box);
-        T mac = max(sizeB) * 2 * invThetaEff;
-        passA = norm2(dX) > (mac * mac);
+        T mac      = max(sizeB) * 2 * invThetaEff;
+        passA      = norm2(dX) > (mac * mac);
     }
     bool passB;
     {
         // B = target, A = source
         Vec3<T> dX = minDistance(centerA, centerB, sizeB, box);
-        T mac = max(sizeA) * 2 * invThetaEff;
-        passB = norm2(dX) > (mac * mac);
+        T mac      = max(sizeA) * 2 * invThetaEff;
+        passB      = norm2(dX) > (mac * mac);
     }
     return passA && passB;
 }

--- a/domain/include/cstone/traversal/macs.hpp
+++ b/domain/include/cstone/traversal/macs.hpp
@@ -81,13 +81,13 @@ HOST_DEVICE_FUN T minDistanceSq(IBox a, IBox b, const Box<T>& box)
 /*! @brief Compute square of the acceptance radius for the minimum distance MAC
  *
  * @param prefix       SFC key of the tree cell with Warren-Salmon placeholder-bit
- * @param invTheta     theta^-1 (opening parameter)
+ * @param invThetaEff  theta^-1 + s (effective opening parameter)
  * @param box          global coordinate bounding box
  * @return             geometric center in the first 3 elements, the square of the distance from @p sourceCenter
  *                     beyond which the MAC fails or passes in the 4th element
  */
 template<class T, class KeyType>
-HOST_DEVICE_FUN Vec4<T> computeMinMacR2(KeyType prefix, float invTheta, const Box<T>& box)
+HOST_DEVICE_FUN Vec4<T> computeMinMacR2(KeyType prefix, float invThetaEff, const Box<T>& box)
 {
     KeyType nodeKey  = decodePlaceholderBit(prefix);
     int prefixLength = decodePrefixLength(prefix);
@@ -96,8 +96,7 @@ HOST_DEVICE_FUN Vec4<T> computeMinMacR2(KeyType prefix, float invTheta, const Bo
     auto [geoCenter, geoSize] = centerAndSize<KeyType>(cellBox, box);
 
     T l   = T(2) * max(geoSize);
-    T s   = l / T(2);
-    T mac = l * invTheta + s;
+    T mac = l * invThetaEff;
 
     return {geoCenter[0], geoCenter[1], geoCenter[2], mac * mac};
 }

--- a/domain/include/cstone/traversal/macs.hpp
+++ b/domain/include/cstone/traversal/macs.hpp
@@ -204,6 +204,8 @@ HOST_DEVICE_FUN bool minMacMutual(const Vec3<T>& centerA,
 
 /*! @brief commutative combination of min-distance and vector map
  *
+ * @param invThetaEff  1/theta + s, effective inverse opening parameter
+ *
  * This MAC doesn't pass any A-B pairs that would fail either the min-distance
  * or vector MAC. Can be used instead of the vector mac when the mass center locations
  * are not known.
@@ -214,20 +216,20 @@ HOST_DEVICE_FUN bool minVecMacMutual(const Vec3<T>& centerA,
                                      const Vec3<T>& centerB,
                                      const Vec3<T>& sizeB,
                                      const Box<T>& box,
-                                     float invTheta)
+                                     float invThetaEff)
 {
     bool passA;
     {
         // A = target, B = source
         Vec3<T> dX = minDistance(centerB, centerA, sizeA, box);
-        T mac = max(sizeB) * 2 * (invTheta + std::sqrt(3));
+        T mac = max(sizeB) * 2 * invThetaEff;
         passA = norm2(dX) > (mac * mac);
     }
     bool passB;
     {
         // B = target, A = source
         Vec3<T> dX = minDistance(centerA, centerB, sizeB, box);
-        T mac = max(sizeA) * 2 * (invTheta + std::sqrt(3));
+        T mac = max(sizeA) * 2 * invThetaEff;
         passB = norm2(dX) > (mac * mac);
     }
     return passA && passB;

--- a/domain/include/cstone/traversal/macs.hpp
+++ b/domain/include/cstone/traversal/macs.hpp
@@ -196,17 +196,21 @@ HOST_DEVICE_FUN bool minVecMacMutual(const Vec3<T>& centerA,
                                      const Box<T>& box,
                                      float invTheta)
 {
-    Vec3<T> dX = minDistance(centerA, sizeA, centerB, sizeB, box);
-
-    T distSq = norm2(dX);
-    T sizeAB = 2 * stl::max(max(sizeA), max(sizeB));
-
-    Vec3<T> maxComOffset = max(sizeA, sizeB);
-    // s is the worst-case distance of the c.o.m from the geometrical center
-    T s   = std::sqrt(norm2(maxComOffset));
-    T mac = sizeAB * invTheta + s;
-
-    return distSq > (mac * mac);
+    bool passA;
+    {
+        // A = target, B = source
+        Vec3<T> dX = minDistance(centerB, centerA, sizeA, box);
+        T mac = max(sizeB) * 2 * (invTheta + std::sqrt(3));
+        passA = norm2(dX) > (mac * mac);
+    }
+    bool passB;
+    {
+        // B = target, A = source
+        Vec3<T> dX = minDistance(centerA, centerB, sizeB, box);
+        T mac = max(sizeA) * 2 * (invTheta + std::sqrt(3));
+        passB = norm2(dX) > (mac * mac);
+    }
+    return passA && passB;
 }
 
 //! @brief mark all nodes of @p octree (leaves and internal) that fail the evaluateMac w.r.t to @p target

--- a/domain/include/cstone/tree/octree_internal.hpp
+++ b/domain/include/cstone/tree/octree_internal.hpp
@@ -240,10 +240,11 @@ public:
     //! @brief rebalance based on leaf counts only, optimized version that avoids unnecessary allocations
     bool rebalance(unsigned bucketSize, gsl::span<const unsigned> counts)
     {
-        assert(TreeNodeIndex(counts.size()) == numLeafNodes_);
+        assert(childOffsets_.size() >= cstoneTree_.size());
+
         bool converged =
-            rebalanceDecision(cstoneTree_.data(), counts.data(), numLeafNodes_, bucketSize, internalToLeaf_.data());
-        rebalanceTree(cstoneTree_, prefixes_, internalToLeaf_.data());
+            rebalanceDecision(cstoneTree_.data(), counts.data(), numLeafNodes_, bucketSize, childOffsets_.data());
+        rebalanceTree(cstoneTree_, prefixes_, childOffsets_.data());
         swap(cstoneTree_, prefixes_);
 
         updateInternalTree();

--- a/domain/include/cstone/tree/octree_internal.hpp
+++ b/domain/include/cstone/tree/octree_internal.hpp
@@ -371,10 +371,7 @@ public:
         auto it = std::lower_bound(prefixes_.begin() + levelRange_[level], prefixes_.begin() + levelRange_[level + 1],
                                    nodeKey);
         if (it != prefixes_.end() && *it == nodeKey) { return it - prefixes_.begin(); }
-        else
-        {
-            return numTreeNodes();
-        }
+        else { return numTreeNodes(); }
     }
 
 private:

--- a/domain/include/cstone/tree/octree_mpi.hpp
+++ b/domain/include/cstone/tree/octree_mpi.hpp
@@ -52,9 +52,11 @@ bool updateOctreeGlobal(const KeyType* keyStart,
                         std::vector<KeyType>& tree,
                         std::vector<unsigned>& counts)
 {
-    int nRanks;
-    MPI_Comm_size(MPI_COMM_WORLD, &nRanks);
-    unsigned maxCount = std::numeric_limits<unsigned>::max() / nRanks;
+    int numRanks;
+    MPI_Comm_size(MPI_COMM_WORLD, &numRanks);
+    // to prevent 32-bit overflow we limit the maximum count to 2^32-1, divided by numRanks due to MPI_Allreduce
+    // and divided by 8 due to computing parent node counts
+    unsigned maxCount = std::numeric_limits<unsigned>::max() / (8 * numRanks);
 
     bool converged = updateOctree(keyStart, keyEnd, bucketSize, tree, counts, maxCount);
     MPI_Allreduce(MPI_IN_PLACE, counts.data(), counts.size(), MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
@@ -81,7 +83,9 @@ bool updateOctreeGlobal(const KeyType* keyStart,
                         std::vector<unsigned>& counts,
                         int numRanks)
 {
-    unsigned maxCount = std::numeric_limits<unsigned>::max() / numRanks;
+    // to prevent 32-bit overflow we limit the maximum count to 2^32-1, divided by numRanks due to MPI_Allreduce
+    // and divided by 8 due to computing parent node counts
+    unsigned maxCount = std::numeric_limits<unsigned>::max() / (8 * numRanks);
 
     bool converged = tree.rebalance(bucketSize, counts);
 

--- a/domain/test/integration_mpi/exchange_general.cpp
+++ b/domain/test/integration_mpi/exchange_general.cpp
@@ -61,6 +61,7 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
     unsigned bucketSizeLocal      = 16;
     float theta                   = 10.0;
     float macOffset               = 0.5;
+    float invThetaEff             = invThetaMinMac(theta);
 
     Box<T> box{-1, 1};
 
@@ -80,7 +81,7 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
 
     // *******************************
 
-    auto peers = findPeersMac(thisRank, assignment, domainTree, box, theta);
+    auto peers = findPeersMac(thisRank, assignment, domainTree, box, invThetaEff);
 
     KeyType focusStart = tree[assignment.firstNodeIdx(thisRank)];
     KeyType focusEnd   = tree[assignment.lastNodeIdx(thisRank)];
@@ -167,6 +168,7 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
     unsigned bucketSizeLocal      = 16;
     float theta                   = 10.0;
     float macOffset               = 0.5;
+    float invThetaEff             = invThetaMinMac(theta);
 
     Box<T> box{-1, 1};
 
@@ -187,7 +189,7 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
 
     /*******************************/
 
-    auto peers = findPeersMac(thisRank, assignment, domainTree, box, theta);
+    auto peers = findPeersMac(thisRank, assignment, domainTree, box, invThetaEff);
 
     KeyType focusStart = tree[assignment.firstNodeIdx(thisRank)];
     KeyType focusEnd   = tree[assignment.lastNodeIdx(thisRank)];

--- a/domain/test/integration_mpi/exchange_general.cpp
+++ b/domain/test/integration_mpi/exchange_general.cpp
@@ -60,6 +60,7 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
     unsigned bucketSize           = 64;
     unsigned bucketSizeLocal      = 16;
     float theta                   = 10.0;
+    float macOffset               = 0.5;
 
     Box<T> box{-1, 1};
 
@@ -99,7 +100,7 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
     computeSfcKeys(x.data(), y.data(), z.data(), sfcKindPointer(particleKeys.data()), x.size(), box);
 
     FocusedOctree<KeyType, T> focusTree(thisRank, numRanks, bucketSizeLocal, theta);
-    focusTree.converge(box, particleKeys, peers, assignment, tree, counts);
+    focusTree.converge(box, particleKeys, peers, assignment, tree, counts, macOffset);
 
     const Octree<KeyType>& octree = focusTree.octree();
     std::vector<int> testCounts(octree.numTreeNodes(), -1);
@@ -165,6 +166,7 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
     unsigned bucketSize           = 64;
     unsigned bucketSizeLocal      = 16;
     float theta                   = 10.0;
+    float macOffset               = 0.5;
 
     Box<T> box{-1, 1};
 
@@ -206,7 +208,7 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
     computeSfcKeys(x.data(), y.data(), z.data(), sfcKindPointer(particleKeys.data()), x.size(), box);
 
     FocusedOctree<KeyType, T> focusTree(thisRank, numRanks, bucketSizeLocal, theta);
-    focusTree.converge(box, particleKeys, peers, assignment, tree, counts);
+    focusTree.converge(box, particleKeys, peers, assignment, tree, counts, macOffset);
 
     const Octree<KeyType>& octree = focusTree.octree();
 

--- a/domain/test/integration_mpi/exchange_general.cpp
+++ b/domain/test/integration_mpi/exchange_general.cpp
@@ -226,7 +226,7 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
             SourceCenterType<T> reference = massCenter<T>(coords.x().data(), coords.y().data(), coords.z().data(),
                                                           globalMasses.data(), startIndex, endIndex);
 
-            T refMac     = computeMac(octree.nodeKeys()[i], makeVec3(reference), 1.0 / theta, box);
+            T refMac     = computeVecMacR2(octree.nodeKeys()[i], makeVec3(reference), 1.0 / theta, box);
             reference[3] = (reference[3] == T(0)) ? T(0) : refMac;
 
             EXPECT_NEAR(sourceCenter[i][0], reference[0], tol);

--- a/domain/test/integration_mpi/exchange_general.cpp
+++ b/domain/test/integration_mpi/exchange_general.cpp
@@ -60,7 +60,6 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
     unsigned bucketSize           = 64;
     unsigned bucketSizeLocal      = 16;
     float theta                   = 10.0;
-    float macOffset               = 0.5;
     float invThetaEff             = invThetaMinMac(theta);
 
     Box<T> box{-1, 1};
@@ -101,7 +100,7 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
     computeSfcKeys(x.data(), y.data(), z.data(), sfcKindPointer(particleKeys.data()), x.size(), box);
 
     FocusedOctree<KeyType, T> focusTree(thisRank, numRanks, bucketSizeLocal, theta);
-    focusTree.converge(box, particleKeys, peers, assignment, tree, counts, macOffset);
+    focusTree.converge(box, particleKeys, peers, assignment, tree, counts, invThetaEff);
 
     const Octree<KeyType>& octree = focusTree.octree();
     std::vector<int> testCounts(octree.numTreeNodes(), -1);
@@ -167,7 +166,6 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
     unsigned bucketSize           = 64;
     unsigned bucketSizeLocal      = 16;
     float theta                   = 10.0;
-    float macOffset               = 0.5;
     float invThetaEff             = invThetaMinMac(theta);
 
     Box<T> box{-1, 1};
@@ -210,7 +208,7 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
     computeSfcKeys(x.data(), y.data(), z.data(), sfcKindPointer(particleKeys.data()), x.size(), box);
 
     FocusedOctree<KeyType, T> focusTree(thisRank, numRanks, bucketSizeLocal, theta);
-    focusTree.converge(box, particleKeys, peers, assignment, tree, counts, macOffset);
+    focusTree.converge(box, particleKeys, peers, assignment, tree, counts, invThetaEff);
 
     const Octree<KeyType>& octree = focusTree.octree();
 

--- a/domain/test/integration_mpi/focus_tree.cpp
+++ b/domain/test/integration_mpi/focus_tree.cpp
@@ -59,7 +59,6 @@ void globalRandomGaussian(int thisRank, int numRanks)
     unsigned bucketSize           = 64;
     unsigned bucketSizeLocal      = 16;
     float theta                   = 1.0;
-    float macOffset               = 0.5;
     float invThetaEff             = invThetaMinMac(theta);
 
     Box<T> box{-1, 1};
@@ -128,7 +127,9 @@ void globalRandomGaussian(int thisRank, int numRanks)
     int converged = 0;
     while (converged != numRanks)
     {
-        converged = focusTree.update(box, particleKeys, peers, assignment, tree, counts, macOffset);
+        converged = focusTree.updateTree(peers, assignment, tree);
+        focusTree.updateCounts(particleKeys, tree, counts);
+        focusTree.updateMinMac(box, assignment, tree, invThetaEff);
         MPI_Allreduce(MPI_IN_PLACE, &converged, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 
         // particle counts must always be valid, whatever state of convergence

--- a/domain/test/integration_mpi/focus_tree.cpp
+++ b/domain/test/integration_mpi/focus_tree.cpp
@@ -60,6 +60,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
     unsigned bucketSizeLocal      = 16;
     float theta                   = 1.0;
     float macOffset               = 0.5;
+    float invThetaEff             = invThetaMinMac(theta);
 
     Box<T> box{-1, 1};
 
@@ -79,7 +80,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
 
     /*******************************/
 
-    auto peers = findPeersMac(thisRank, assignment, domainTree, box, theta);
+    auto peers = findPeersMac(thisRank, assignment, domainTree, box, invThetaEff);
 
     // peer boundaries are required to be present in the focus tree at all times
     std::vector<KeyType> peerBoundaries;

--- a/domain/test/integration_mpi/focus_tree.cpp
+++ b/domain/test/integration_mpi/focus_tree.cpp
@@ -59,6 +59,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
     unsigned bucketSize = 64;
     unsigned bucketSizeLocal = 16;
     float theta = 1.0;
+    float macOffset = 0.5;
 
     Box<T> box{-1, 1};
 
@@ -125,7 +126,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
     int converged = 0;
     while (converged != numRanks)
     {
-        converged = focusTree.update(box, particleKeys, peers, assignment, tree, counts);
+        converged = focusTree.update(box, particleKeys, peers, assignment, tree, counts, macOffset);
         MPI_Allreduce(MPI_IN_PLACE, &converged, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 
         // particle counts must always be valid, whatever state of convergence

--- a/domain/test/performance/peers.cpp
+++ b/domain/test/performance/peers.cpp
@@ -55,9 +55,9 @@ int main()
     SpaceCurveAssignment assignment = singleRangeSfcSplit(counts, numRanks);
     int probeRank = numRanks / 2;
 
-    auto tp0 = std::chrono::high_resolution_clock::now();
-    std::vector<int> peersDtt = findPeersMac(probeRank, assignment, octree, box, 0.5);
-    auto tp1 = std::chrono::high_resolution_clock::now();
+    auto tp0                  = std::chrono::high_resolution_clock::now();
+    std::vector<int> peersDtt = findPeersMac(probeRank, assignment, octree, box, invThetaMinMac(0.5f));
+    auto tp1                  = std::chrono::high_resolution_clock::now();
 
     double t2 = std::chrono::duration<double>(tp1 - tp0).count();
     std::cout << "find peers: " << t2 << " numPeers: " << peersDtt.size() << std::endl;

--- a/domain/test/performance/peers.cpp
+++ b/domain/test/performance/peers.cpp
@@ -43,8 +43,8 @@ int main()
     Box<double> box{-1, 1};
 
     LocalIndex nParticles = 20000;
-    int bucketSize = 1;
-    int numRanks = 50;
+    int bucketSize        = 1;
+    int numRanks          = 50;
 
     auto codes = makeRandomGaussianKeys<KeyType>(nParticles);
 
@@ -53,7 +53,7 @@ int main()
     octree.update(treeLeaves.data(), nNodes(treeLeaves));
 
     SpaceCurveAssignment assignment = singleRangeSfcSplit(counts, numRanks);
-    int probeRank = numRanks / 2;
+    int probeRank                   = numRanks / 2;
 
     auto tp0                  = std::chrono::high_resolution_clock::now();
     std::vector<int> peersDtt = findPeersMac(probeRank, assignment, octree, box, invThetaMinMac(0.5f));

--- a/domain/test/unit/focus/octree_focus.cpp
+++ b/domain/test/unit/focus/octree_focus.cpp
@@ -355,7 +355,7 @@ static void computeEssentialTree()
     FocusedOctreeSingleNode<KeyType> tree(bucketSize, theta);
 
     // sorted reference tree node counts in each (except focus) octant at the 1st division level
-    std::vector<TreeNodeIndex> refCounts{92, 302, 302, 302, 1184, 1184, 1184,
+    std::vector<TreeNodeIndex> refCounts{29, 302, 302, 302, 1184, 1184, 1184,
                                          /*4131*/};
 
     KeyType focusStart = 1;

--- a/domain/test/unit/traversal/macs.cpp
+++ b/domain/test/unit/traversal/macs.cpp
@@ -229,10 +229,10 @@ TEST(Macs, minVecMacMutual)
     Vec3<T> cB{3.5, 3.5, 3.5};
     Vec3<T> sB{0.5, 0.5, 0.5};
 
-    EXPECT_TRUE(minVecMacMutual(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.39));
-    EXPECT_FALSE(minVecMacMutual(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.38));
+    EXPECT_TRUE(minVecMacMutual(cA, sA, cB, sB, Box<T>(0, 4, false), invThetaVecMac(0.39)));
+    EXPECT_FALSE(minVecMacMutual(cA, sA, cB, sB, Box<T>(0, 4, false), invThetaVecMac(0.38)));
 
-    EXPECT_FALSE(minVecMacMutual(cA, sA, cB, sB, Box<T>(0, 4, true), 1.0));
+    EXPECT_FALSE(minVecMacMutual(cA, sA, cB, sB, Box<T>(0, 4, true), invThetaVecMac(1.0)));
 }
 
 template<class KeyType, class T>

--- a/domain/test/unit/traversal/macs.cpp
+++ b/domain/test/unit/traversal/macs.cpp
@@ -294,7 +294,7 @@ static void markMacVector()
     TreeNodeIndex focusIdxStart = 4;
     TreeNodeIndex focusIdxEnd   = 22;
 
-    markVecMac(octree, centers.data(), box, leaves[focusIdxStart], leaves[focusIdxEnd], markings.data());
+    markMacs(octree, centers.data(), box, leaves[focusIdxStart], leaves[focusIdxEnd], markings.data());
 
     std::vector<char> reference = markVecMacAll2All<KeyType>(octree, centers.data(), focusIdxStart, focusIdxEnd, box);
 

--- a/domain/test/unit/traversal/macs.cpp
+++ b/domain/test/unit/traversal/macs.cpp
@@ -171,48 +171,6 @@ TEST(Macs, minDistanceSqPbc)
     }
 }
 
-TEST(Macs, minMac)
-{
-    using T = double;
-
-    {
-        Vec3<T> cA{0.5, 0.5, 0.5};
-        Vec3<T> sA{0.5, 0.5, 0.5};
-
-        Vec3<T> cB{3.5, 3.5, 3.5};
-        Vec3<T> sB{0.5, 0.5, 0.5};
-
-        EXPECT_TRUE(minMac(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.29));
-        EXPECT_FALSE(minMac(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.28));
-
-        EXPECT_FALSE(minMac(cA, sA, cB, sB, Box<T>(0, 4, true), 1.0));
-    }
-    {
-        Vec3<T> cA{0.5, 0.5, 0.5};
-        Vec3<T> sA{1.0, 1.0, 1.0};
-
-        Vec3<T> cB{3.5, 3.5, 3.5};
-        Vec3<T> sB{0.5, 0.5, 0.5};
-
-        EXPECT_TRUE(minMac(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.39));
-        EXPECT_FALSE(minMac(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.38));
-
-        EXPECT_FALSE(minMac(cA, sA, cB, sB, Box<T>(0, 4, true), 1.0));
-    }
-    {
-        Vec3<T> cA{0.5, 0.5, 0.5};
-        Vec3<T> sA{0.5, 0.5, 0.5};
-
-        Vec3<T> cB{3.5, 3.5, 3.5};
-        Vec3<T> sB{1.0, 1.0, 1.0};
-
-        EXPECT_TRUE(minMac(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.78));
-        EXPECT_FALSE(minMac(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.76));
-
-        EXPECT_FALSE(minMac(cA, sA, cB, sB, Box<T>(0, 4, true), 1.0));
-    }
-}
-
 TEST(Macs, evaluateMAC)
 {
     using T = double;
@@ -275,64 +233,6 @@ TEST(Macs, minVecMacMutual)
     EXPECT_FALSE(minVecMacMutual(cA, sA, cB, sB, Box<T>(0, 4, false), 1.0 / 0.38));
 
     EXPECT_FALSE(minVecMacMutual(cA, sA, cB, sB, Box<T>(0, 4, true), 1.0));
-}
-
-template<class KeyType, class T>
-static std::vector<char> markMacAll2All(
-    const Octree<KeyType>& octree, TreeNodeIndex firstLeaf, TreeNodeIndex lastLeaf, float invTheta, const Box<T>& box)
-{
-    gsl::span<const KeyType> leaves = octree.treeLeaves();
-    std::vector<char> markings(octree.numTreeNodes(), 0);
-
-    // loop over target cells
-    for (TreeNodeIndex i = firstLeaf; i < lastLeaf; ++i)
-    {
-        IBox targetBox                  = sfcIBox(sfcKey(leaves[i]), sfcKey(leaves[i + 1]));
-        auto [targetCenter, targetSize] = centerAndSize<KeyType>(targetBox, box);
-
-        // loop over source cells
-        for (TreeNodeIndex j = 0; j < octree.numTreeNodes(); ++j)
-        {
-            // source cells must not be in target cell range
-            if (leaves[firstLeaf] <= octree.codeStart(j) && octree.codeEnd(j) <= leaves[lastLeaf]) { continue; }
-            IBox sourceBox                  = sfcIBox(sfcKey(octree.codeStart(j)), sfcKey(octree.codeEnd(j)));
-            auto [sourceCenter, sourceSize] = centerAndSize<KeyType>(sourceBox, box);
-
-            // if source cell fails MAC w.r.t to current target, it gets marked
-            bool violatesMac = !minMac(targetCenter, targetSize, sourceCenter, sourceSize, box, invTheta);
-            if (violatesMac) { markings[j] = 1; }
-        }
-    }
-
-    return markings;
-}
-
-template<class KeyType>
-static void markMac()
-{
-    Box<double> box(0, 1);
-    std::vector<KeyType> leaves = OctreeMaker<KeyType>{}.divide().divide(0).divide(5).makeTree();
-
-    Octree<KeyType> octree;
-    octree.update(leaves.data(), nNodes(leaves));
-
-    std::vector<char> markings(octree.numTreeNodes(), 0);
-
-    float theta                 = 0.58;
-    TreeNodeIndex focusIdxStart = 0;
-    TreeNodeIndex focusIdxEnd   = 2;
-    markMac(octree, box, leaves[focusIdxStart], leaves[focusIdxEnd], 1. / theta, markings.data());
-
-    std::vector<char> reference = markMacAll2All<KeyType>(octree, focusIdxStart, focusIdxEnd, 1. / theta, box);
-
-    EXPECT_EQ(std::count(begin(markings), end(markings), 0), 9);
-    EXPECT_EQ(markings, reference);
-}
-
-TEST(Macs, markMac)
-{
-    markMac<unsigned>();
-    markMac<uint64_t>();
 }
 
 template<class KeyType, class T>

--- a/domain/test/unit/traversal/macs.cpp
+++ b/domain/test/unit/traversal/macs.cpp
@@ -213,10 +213,11 @@ TEST(Macs, minMac)
     }
 }
 
-TEST(Macs, vectorMacAndPbc)
+TEST(Macs, evaluateMAC)
 {
     using T = double;
 
+    Box<T> noPbcBox(0, 1, false);
     Box<T> box(0, 1, true);
 
     Vec3<T> tcenter{0.1, 0.1, 0.1};
@@ -226,21 +227,21 @@ TEST(Macs, vectorMacAndPbc)
     T mac = 0.03;
     {
         Vec3<T> scenter{0.2, 0.2, 0.2};
-        EXPECT_TRUE(vectorMac(scenter, mac, tcenter, tsize));
-        EXPECT_TRUE(vectorMacPbc(scenter, mac, tcenter, tsize, box));
+        EXPECT_TRUE(evaluateMacPbc(scenter, mac, tcenter, tsize, noPbcBox));
+        EXPECT_TRUE(evaluateMacPbc(scenter, mac, tcenter, tsize, box));
     }
     {
         Vec3<T> scenter{0.2101, 0.2101, 0.2101};
-        EXPECT_FALSE(vectorMac(scenter, mac, tcenter, tsize));
-        EXPECT_FALSE(vectorMacPbc(scenter, mac, tcenter, tsize, box));
+        EXPECT_FALSE(evaluateMacPbc(scenter, mac, tcenter, tsize, noPbcBox));
+        EXPECT_FALSE(evaluateMacPbc(scenter, mac, tcenter, tsize, box));
     }
     {
         Vec3<T> scenter{1.0, 1.0, 1.0};
-        EXPECT_TRUE(vectorMacPbc(scenter, mac, tcenter, tsize, box));
+        EXPECT_TRUE(evaluateMacPbc(scenter, mac, tcenter, tsize, box));
     }
     {
         Vec3<T> scenter{0.9899, 0.9899, 0.9899};
-        EXPECT_FALSE(vectorMacPbc(scenter, mac, tcenter, tsize, box));
+        EXPECT_FALSE(evaluateMacPbc(scenter, mac, tcenter, tsize, box));
     }
 }
 
@@ -357,7 +358,7 @@ static std::vector<char> markVecMacAll2All(const Octree<KeyType>& octree,
             if (leaves[firstLeaf] <= octree.codeStart(j) && octree.codeEnd(j) <= leaves[lastLeaf]) { continue; }
 
             Vec4<T> center   = centers[j];
-            bool violatesMac = vectorMacPbc(makeVec3(center), center[3], targetCenter, targetSize, box);
+            bool violatesMac = evaluateMacPbc(makeVec3(center), center[3], targetCenter, targetSize, box);
             if (violatesMac) { markings[j] = 1; }
         }
     }

--- a/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
+++ b/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
@@ -101,7 +101,7 @@ void computeGravityGroup(TreeNodeIndex groupIdx, const cstone::Octree<KeyType>& 
         const auto& com = centers[idx];
         const auto& p   = multipoles[idx];
 
-        bool violatesMac = cstone::vectorMac(makeVec3(com), com[3], targetCenter, targetSize);
+        bool violatesMac = cstone::evaluateMac(makeVec3(com), com[3], targetCenter, targetSize);
 
         if (!violatesMac)
         {


### PR DESCRIPTION
Several improvements that allow smooth large-scale gravity runs.
- focused octree outside the assigned range needs to have a slightly higher resolution than what's needed for
gravity traversal, otherwise large far-away tree cells might fail the MAC test and become halos for a single iteration because it always takes one iteration for the tree to catch up with changed particle positions
- fixed a 32-bit integer overflow during global tree build that occurred in rare cases
- optimized the mutual MAC used for peer rank detection