### PR TITLE
Mom ener simplify

### DIFF
--- a/main/src/sphexa/propagator.hpp
+++ b/main/src/sphexa/propagator.hpp
@@ -256,9 +256,9 @@ public:
         timer.step("mpi::synchronizeHalos");
         computeDensityVE(first, last, ngmax_, d, domain.box());
         timer.step("Density & Gradh");
-        computeEquationOfState(first, last, d);
+        computeEquationOfStateVE(first, last, d);
         timer.step("EquationOfState");
-        domain.exchangeHalos(d.vx, d.vy, d.vz, d.rho, d.p, d.c, d.kx, d.gradh);
+        domain.exchangeHalos(d.vx, d.vy, d.vz, d.p, d.c, d.kx, d.gradh);
         timer.step("mpi::synchronizeHalos");
         computeIadVE(first, last, ngmax_, d, domain.box());
         timer.step("IAD");

--- a/sph/include/sph/density_ve.hpp
+++ b/sph/include/sph/density_ve.hpp
@@ -41,25 +41,9 @@ void computeDensityVeImpl(size_t startIndex, size_t endIndex, size_t ngmax, Data
 #pragma omp parallel for
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        size_t ni = i - startIndex;
-        kernels::densityJLoop(i,
-                              sincIndex,
-                              K,
-                              box,
-                              neighbors + ngmax * ni,
-                              neighborsCount[i],
-                              x,
-                              y,
-                              z,
-                              h,
-                              m,
-                              wh,
-                              whd,
-                              rho0,
-                              wrho0,
-                              rho,
-                              kx,
-                              gradh);
+        size_t ni                          = i - startIndex;
+        util::tie(rho[i], kx[i], gradh[i]) = kernels::densityJLoop(
+            i, sincIndex, K, box, neighbors + ngmax * ni, neighborsCount[i], x, y, z, h, m, wh, whd, rho0, wrho0);
 #ifndef NDEBUG
         if (std::isnan(rho[i]))
             printf("ERROR::Density(%zu) density %f, position: (%f %f %f), h: %f\n", i, rho[i], x[i], y[i], z[i], h[i]);

--- a/sph/include/sph/density_ve.hpp
+++ b/sph/include/sph/density_ve.hpp
@@ -33,7 +33,6 @@ void computeDensityVeImpl(size_t startIndex, size_t endIndex, size_t ngmax, Data
 
     T* kx    = d.kx.data();
     T* gradh = d.gradh.data();
-    T* rho   = d.rho.data();
 
     const T K         = d.K;
     const T sincIndex = d.sincIndex;
@@ -41,12 +40,18 @@ void computeDensityVeImpl(size_t startIndex, size_t endIndex, size_t ngmax, Data
 #pragma omp parallel for
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        size_t ni                          = i - startIndex;
-        util::tie(rho[i], kx[i], gradh[i]) = kernels::densityJLoop(
+        size_t ni                  = i - startIndex;
+        util::tie(kx[i], gradh[i]) = kernels::densityJLoop(
             i, sincIndex, K, box, neighbors + ngmax * ni, neighborsCount[i], x, y, z, h, m, wh, whd, rho0, wrho0);
 #ifndef NDEBUG
-        if (std::isnan(rho[i]))
-            printf("ERROR::Density(%zu) density %f, position: (%f %f %f), h: %f\n", i, rho[i], x[i], y[i], z[i], h[i]);
+        if (std::isnan(kx[i] * rho0[i]))
+            printf("ERROR::Density(%zu) density %f, position: (%f %f %f), h: %f\n",
+                   i,
+                   kx[i] * rho0[i],
+                   x[i],
+                   y[i],
+                   z[i],
+                   h[i]);
 #endif
     }
 }

--- a/sph/include/sph/eos.hpp
+++ b/sph/include/sph/eos.hpp
@@ -50,5 +50,37 @@ void computeEquationOfState(size_t /*startIndex*/, size_t /*endIndex*/, Dataset&
     }
 }
 
+//! @brief same as computeEquationOfState, but compute as rho = kx * rho0
+template<typename Dataset>
+void computeEquationOfStateVE(size_t /*startIndex*/, size_t /*endIndex*/, Dataset& d)
+{
+    using T = typename Dataset::RealType;
+
+    // const T R     = 8.317e7;
+    const T gamma = (5.0 / 3.0);
+
+    const T* kx   = d.kx.data();
+    const T* rho0 = d.rho0.data();
+    const T* u    = d.u.data();
+    // const T* mui = d.mui.data();
+
+    const size_t numParticles = d.x.size();
+
+    // T* cv   = d.cv.data();
+    // T* temp = d.temp.data();
+    T* p = d.p.data();
+    T* c = d.c.data();
+
+#pragma omp parallel for schedule(static)
+    for (size_t i = 0; i < numParticles; ++i)
+    {
+        // cv[i]   = T(1.5) * R / mui[i];
+        // temp[i] = u[i] / cv[i];
+        T tmp = u[i] * (gamma - 1);
+        p[i]  = kx[i] * rho0[i] * tmp;
+        c[i]  = std::sqrt(tmp);
+    }
+}
+
 } // namespace sph
 } // namespace sphexa

--- a/sph/include/sph/kernel_ve/density_kern.hpp
+++ b/sph/include/sph/kernel_ve/density_kern.hpp
@@ -43,7 +43,7 @@ namespace kernels
 {
 
 template<typename T>
-CUDA_DEVICE_HOST_FUN inline util::tuple<T, T, T>
+CUDA_DEVICE_HOST_FUN inline util::tuple<T, T>
 densityJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const int* neighbors, int neighborsCount, const T* x,
              const T* y, const T* z, const T* h, const T* m, const T* wh, const T* whd, const T* rho0, const T* wrho0)
 {
@@ -76,16 +76,13 @@ densityJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const int* neig
     }
 
     kxi *= K * h3Inv;
-
     whomegai = K * (whomegai - T(3) * xmassi) * h3Inv * hInv;
     whomegai = whomegai * rho0i + (kxi - K * xmassi * h3Inv) * wrho0i;
 
     T dhdrho = -hi / (kxi * rho0i * T(3)); // This /3 is the dimension hard-coded.
-
-    T rhoi   = kxi * rho0i;
     T gradhi = T(1) - dhdrho * whomegai;
 
-    return {rhoi, kxi, gradhi};
+    return {kxi, gradhi};
 }
 
 } // namespace kernels

--- a/sph/include/sph/kernel_ve/density_kern.hpp
+++ b/sph/include/sph/kernel_ve/density_kern.hpp
@@ -43,10 +43,9 @@ namespace kernels
 {
 
 template<typename T>
-CUDA_DEVICE_HOST_FUN inline void densityJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const int* neighbors,
-                                              int neighborsCount, const T* x, const T* y, const T* z, const T* h,
-                                              const T* m, const T* wh, const T* whd, const T* rho0, const T* wrho0,
-                                              T* ro, T* kx, T* gradh)
+CUDA_DEVICE_HOST_FUN inline util::tuple<T, T, T>
+densityJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const int* neighbors, int neighborsCount, const T* x,
+             const T* y, const T* z, const T* h, const T* m, const T* wh, const T* whd, const T* rho0, const T* wrho0)
 {
     T xi     = x[i];
     T yi     = y[i];
@@ -56,10 +55,10 @@ CUDA_DEVICE_HOST_FUN inline void densityJLoop(int i, T sincIndex, T K, const cst
     T wrho0i = wrho0[i];
     T xmassi = m[i] / rho0i;
 
-    T hInv  = 1.0 / hi;
+    T hInv  = T(1) / hi;
     T h3Inv = hInv * hInv * hInv;
 
-    T kxi      = 0.0;
+    T kxi      = xmassi;
     T whomegai = 0.0;
 
     for (int pj = 0; pj < neighborsCount; ++pj)
@@ -69,20 +68,24 @@ CUDA_DEVICE_HOST_FUN inline void densityJLoop(int i, T sincIndex, T K, const cst
         T   vloc   = dist * hInv;
         T   w      = ::sphexa::math::pow(lt::wharmonic_lt_with_derivative(wh, whd, vloc), sincIndex);
         T   dw     = wharmonic_derivative(vloc, w) * sincIndex;
-        T   dterh  = -(3.0 * w + vloc * dw);
+        T   dterh  = -(T(3) * w + vloc * dw);
         T   xmassj = m[j] / rho0[j];
 
         kxi += w * xmassj;
         whomegai += dterh * xmassj;
     }
 
-    kx[i]    = K * (kxi + xmassi) * h3Inv;
-    whomegai = K * (whomegai - 3.0 * xmassi) * h3Inv * hInv;
+    kxi *= K * h3Inv;
 
-    ro[i]    = kx[i] * m[i] / xmassi;
-    whomegai = whomegai * m[i] / xmassi + (ro[i] / rho0i - K * xmassi * h3Inv) * wrho0i;
-    T dhdrho = -hi / ro[i] / 3.0; // This /3 is the dimension hard-coded.
-    gradh[i] = 1.0 - dhdrho * whomegai;
+    whomegai = K * (whomegai - T(3) * xmassi) * h3Inv * hInv;
+    whomegai = whomegai * rho0i + (kxi - K * xmassi * h3Inv) * wrho0i;
+
+    T dhdrho = -hi / (kxi * rho0i * T(3)); // This /3 is the dimension hard-coded.
+
+    T rhoi   = kxi * rho0i;
+    T gradhi = T(1) - dhdrho * whomegai;
+
+    return {rhoi, kxi, gradhi};
 }
 
 } // namespace kernels

--- a/sph/include/sph/kernel_ve/momentum_energy_kern.hpp
+++ b/sph/include/sph/kernel_ve/momentum_energy_kern.hpp
@@ -46,10 +46,10 @@ template<typename T>
 CUDA_DEVICE_HOST_FUN inline void
 momentumAndEnergyJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const int* neighbors, int neighborsCount,
                        const T* x, const T* y, const T* z, const T* vx, const T* vy, const T* vz, const T* h,
-                       const T* m, const T* ro, const T* p, const T* c, const T* c11, const T* c12, const T* c13,
-                       const T* c22, const T* c23, const T* c33, const T Atmin, const T Atmax, const T ramp,
-                       const T* wh, const T* whd, const T* kx, const T* rho0, const T* alpha, const T* gradh,
-                       T* grad_P_x, T* grad_P_y, T* grad_P_z, T* du, T* maxvsignal)
+                       const T* m, const T* p, const T* c, const T* c11, const T* c12, const T* c13, const T* c22,
+                       const T* c23, const T* c33, const T Atmin, const T Atmax, const T ramp, const T* wh,
+                       const T* whd, const T* kx, const T* rho0, const T* alpha, const T* gradh, T* grad_P_x,
+                       T* grad_P_y, T* grad_P_z, T* du, T* maxvsignal)
 {
     T xi  = x[i];
     T yi  = y[i];
@@ -58,11 +58,12 @@ momentumAndEnergyJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const
     T vyi = vy[i];
     T vzi = vz[i];
 
-    T mi  = m[i];
-    T hi  = h[i];
-    T roi = ro[i];
-    T ci  = c[i];
-    T kxi = kx[i];
+    T mi    = m[i];
+    T hi    = h[i];
+    T ci    = c[i];
+    T kxi   = kx[i];
+    T rho0i = rho0[i];
+    T roi   = kxi * rho0i;
 
     T alpha_i = alpha[i];
 
@@ -130,9 +131,10 @@ momentumAndEnergyJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const
         T termA2_j = -(c12j * rx + c22j * ry + c23j * rz) * Wj;
         T termA3_j = -(c13j * rx + c23j * ry + c33j * rz) * Wj;
 
-        T roj = ro[j];
-        T cj  = c[j];
-        T kxj = kx[j];
+        T cj    = c[j];
+        T kxj   = kx[j];
+        T rho0j = rho0[j];
+        T roj   = kxj * rho0j;
 
         T alpha_j = alpha[j];
 
@@ -147,7 +149,7 @@ momentumAndEnergyJLoop(int i, T sincIndex, T K, const cstone::Box<T>& box, const
         T mj = m[j];
 
         T proj   = p[j] / (kxj * mj * mj * gradh[j]);
-        T xmassj = mj / rho0[j];
+        T xmassj = mj / rho0j;
 
         T a_mom, b_mom, sigma_ij;
         T Atwood = (abs(roi - roj)) / (roi + roj);

--- a/sph/include/sph/kernel_ve/rho_zero_kern.hpp
+++ b/sph/include/sph/kernel_ve/rho_zero_kern.hpp
@@ -64,7 +64,7 @@ CUDA_DEVICE_HOST_FUN inline void rho0JLoop(int i, T sincIndex, T K, const cstone
         T   vloc  = dist * hInv;
         T   w     = ::sphexa::math::pow(lt::wharmonic_lt_with_derivative(wh, whd, vloc), sincIndex);
         T   dw    = wharmonic_derivative(vloc, w) * sincIndex;
-        T   dterh = -(3.0 * w + vloc * dw);
+        T   dterh = -(T(3) * w + vloc * dw);
 
         rho0i += w * m[j];
         wrho0i += dterh * m[j];
@@ -72,7 +72,7 @@ CUDA_DEVICE_HOST_FUN inline void rho0JLoop(int i, T sincIndex, T K, const cstone
 
     // XXXX Define new arrays rho0, wrho0, xmass for all particles
     rho0[i]  = K * (rho0i + m[i]) * h3Inv;
-    wrho0[i] = K * (wrho0i - 3.0 * m[i]) * h3Inv * hInv;
+    wrho0[i] = K * (wrho0i - T(3) * m[i]) * h3Inv * hInv;
 }
 
 } // namespace kernels

--- a/sph/include/sph/momentum_energy_ve.hpp
+++ b/sph/include/sph/momentum_energy_ve.hpp
@@ -24,7 +24,6 @@ void computeGradPVeImpl(size_t startIndex, size_t endIndex, size_t ngmax, Datase
     const T* vx    = d.vx.data();
     const T* vy    = d.vy.data();
     const T* vz    = d.vz.data();
-    const T* rho   = d.rho.data();
     const T* c     = d.c.data();
     const T* p     = d.p.data();
     const T* alpha = d.alpha.data();
@@ -76,7 +75,6 @@ void computeGradPVeImpl(size_t startIndex, size_t endIndex, size_t ngmax, Datase
                                         vz,
                                         h,
                                         m,
-                                        rho,
                                         p,
                                         c,
                                         c11,

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -158,8 +158,7 @@ public:
 
     void setDependentFieldsVE()
     {
-        std::vector<std::string> fields{"rho",
-                                        "p",
+        std::vector<std::string> fields{"p",
                                         "c",
                                         "grad_P_x",
                                         "grad_P_y",

--- a/sph/test/kernel_ve/density_kern.cpp
+++ b/sph/test/kernel_ve/density_kern.cpp
@@ -63,9 +63,6 @@ TEST(Density, JLoop)
     std::vector<T> m{1.0, 1.0, 1.0, 1.0, 1.0};
     std::vector<T> rho0{1.1, 1.2, 1.3, 1.4, 1.5};
     std::vector<T> wrho0{1.1, 1.2, 1.3, 1.4, 1.5};
-    std::vector<T> rho{-1.0, -1.0, -1.0, -1.0, -1.0};
-    std::vector<T> kx{-1.0, -1.0, -1.0, -1.0, -1.0};
-    std::vector<T> gradh{-1.0, -1.0, -1.0, -1.0, -1.0};
 
     /* distances of particle zero to particle j
      *
@@ -74,27 +71,24 @@ TEST(Density, JLoop)
      * j = 3   5.71577
      * j = 4   7.62102
      */
-    sph::kernels::densityJLoop(0,
-                               sincIndex,
-                               K,
-                               box,
-                               neighbors.data(),
-                               neighborsCount,
-                               x.data(),
-                               y.data(),
-                               z.data(),
-                               h.data(),
-                               m.data(),
-                               wh.data(),
-                               whd.data(),
-                               rho0.data(),
-                               wrho0.data(),
-                               rho.data(),
-                               kx.data(),
-                               gradh.data());
-    EXPECT_NEAR(rho[0], 1.67849454056818e-2, 1e-10);
-    EXPECT_NEAR(gradh[0], 1.2501347388453987, 1e-10);
-    EXPECT_NEAR(kx[0], 1.5259041277892543e-2, 1e-10);
+    auto [rho, kx, gradh] = sph::kernels::densityJLoop(0,
+                                                       sincIndex,
+                                                       K,
+                                                       box,
+                                                       neighbors.data(),
+                                                       neighborsCount,
+                                                       x.data(),
+                                                       y.data(),
+                                                       z.data(),
+                                                       h.data(),
+                                                       m.data(),
+                                                       wh.data(),
+                                                       whd.data(),
+                                                       rho0.data(),
+                                                       wrho0.data());
+    EXPECT_NEAR(rho, 1.67849454056818e-2, 1e-10);
+    EXPECT_NEAR(gradh, 1.2501347388453987, 1e-10);
+    EXPECT_NEAR(kx, 1.5259041277892543e-2, 1e-10);
 }
 
 TEST(Density, JLoopPBC)
@@ -123,9 +117,6 @@ TEST(Density, JLoopPBC)
     std::vector<T> m{1.1, 1.2, 1.3, 1.4, 1.5};
     std::vector<T> rho0{1.0, 1.0, 1.0, 1.0, 1.0};
     std::vector<T> wrho0{0.0, 0.0, 0.0, 0.0, 0.0};
-    std::vector<T> rho{-1.0, -1.0, -1.0, -1.0, -1.0};
-    std::vector<T> kx{-1.0, -1.0, -1.0, -1.0, -1.0};
-    std::vector<T> gradh{-1.0, -1.0, -1.0, -1.0, -1.0};
     /* distances of particle 0 to particle j
      *
      *         direct      PBC
@@ -135,24 +126,21 @@ TEST(Density, JLoopPBC)
      * j = 4  15.9367    2.26495
      */
 
-    sph::kernels::densityJLoop(0,
-                               sincIndex,
-                               K,
-                               box,
-                               neighbors.data(),
-                               neighborsCount,
-                               x.data(),
-                               y.data(),
-                               z.data(),
-                               h.data(),
-                               m.data(),
-                               wh.data(),
-                               whd.data(),
-                               rho0.data(),
-                               wrho0.data(),
-                               rho.data(),
-                               kx.data(),
-                               gradh.data());
+    auto [rho, gradh, kx] = sph::kernels::densityJLoop(0,
+                                                       sincIndex,
+                                                       K,
+                                                       box,
+                                                       neighbors.data(),
+                                                       neighborsCount,
+                                                       x.data(),
+                                                       y.data(),
+                                                       z.data(),
+                                                       h.data(),
+                                                       m.data(),
+                                                       wh.data(),
+                                                       whd.data(),
+                                                       rho0.data(),
+                                                       wrho0.data());
 
-    EXPECT_NEAR(rho[0], 0.17929212293724384, 1e-10);
+    EXPECT_NEAR(rho, 0.17929212293724384, 1e-10);
 }

--- a/sph/test/kernel_ve/density_kern.cpp
+++ b/sph/test/kernel_ve/density_kern.cpp
@@ -71,22 +71,22 @@ TEST(Density, JLoop)
      * j = 3   5.71577
      * j = 4   7.62102
      */
-    auto [rho, kx, gradh] = sph::kernels::densityJLoop(0,
-                                                       sincIndex,
-                                                       K,
-                                                       box,
-                                                       neighbors.data(),
-                                                       neighborsCount,
-                                                       x.data(),
-                                                       y.data(),
-                                                       z.data(),
-                                                       h.data(),
-                                                       m.data(),
-                                                       wh.data(),
-                                                       whd.data(),
-                                                       rho0.data(),
-                                                       wrho0.data());
-    EXPECT_NEAR(rho, 1.67849454056818e-2, 1e-10);
+    auto [kx, gradh] = sph::kernels::densityJLoop(0,
+                                                  sincIndex,
+                                                  K,
+                                                  box,
+                                                  neighbors.data(),
+                                                  neighborsCount,
+                                                  x.data(),
+                                                  y.data(),
+                                                  z.data(),
+                                                  h.data(),
+                                                  m.data(),
+                                                  wh.data(),
+                                                  whd.data(),
+                                                  rho0.data(),
+                                                  wrho0.data());
+    EXPECT_NEAR(kx * rho0[0], 1.67849454056818e-2, 1e-10);
     EXPECT_NEAR(gradh, 1.2501347388453987, 1e-10);
     EXPECT_NEAR(kx, 1.5259041277892543e-2, 1e-10);
 }
@@ -126,21 +126,21 @@ TEST(Density, JLoopPBC)
      * j = 4  15.9367    2.26495
      */
 
-    auto [rho, gradh, kx] = sph::kernels::densityJLoop(0,
-                                                       sincIndex,
-                                                       K,
-                                                       box,
-                                                       neighbors.data(),
-                                                       neighborsCount,
-                                                       x.data(),
-                                                       y.data(),
-                                                       z.data(),
-                                                       h.data(),
-                                                       m.data(),
-                                                       wh.data(),
-                                                       whd.data(),
-                                                       rho0.data(),
-                                                       wrho0.data());
+    auto [kx, gradh] = sph::kernels::densityJLoop(0,
+                                                  sincIndex,
+                                                  K,
+                                                  box,
+                                                  neighbors.data(),
+                                                  neighborsCount,
+                                                  x.data(),
+                                                  y.data(),
+                                                  z.data(),
+                                                  h.data(),
+                                                  m.data(),
+                                                  wh.data(),
+                                                  whd.data(),
+                                                  rho0.data(),
+                                                  wrho0.data());
 
-    EXPECT_NEAR(rho, 0.17929212293724384, 1e-10);
+    EXPECT_NEAR(kx * rho0[0], 0.17929212293724384, 1e-10);
 }

--- a/sph/test/kernel_ve/momentum_energy_kern.cpp
+++ b/sph/test/kernel_ve/momentum_energy_kern.cpp
@@ -63,7 +63,6 @@ TEST(MomentumEnergy, JLoop)
     std::vector<T> z{1.2, 2.3, 1.4, 1.5, 1.6};
     std::vector<T> h{5.0, 5.1, 5.2, 5.3, 5.4};
     std::vector<T> m{1.0, 1.0, 1.0, 1.0, 1.0};
-    std::vector<T> rho{0.014, 0.015, 0.016, 0.017, 0.018};
     std::vector<T> gradh{1.25, 1., 0.8, 1.1, 0.51};
 
     std::vector<T> vx{0.010, -0.020, 0.030, -0.040, 0.050};
@@ -118,7 +117,6 @@ TEST(MomentumEnergy, JLoop)
                                          vz.data(),
                                          h.data(),
                                          m.data(),
-                                         rho.data(),
                                          p.data(),
                                          c.data(),
                                          c11.data(),
@@ -142,10 +140,10 @@ TEST(MomentumEnergy, JLoop)
                                          &du,
                                          &maxvsignal);
 
-    EXPECT_NEAR(grad_Px, -4.7423317200544224e-1, 1e-10);
-    EXPECT_NEAR(grad_Py, 8.737996639917453e-2, 1e-10);
-    EXPECT_NEAR(grad_Pz, -5.303834041425971e-1, 1e-10);
-    EXPECT_NEAR(du, -3.8485025262537881e-3, 1e-10);
+    EXPECT_NEAR(grad_Px, -0.46852624676440913, 1e-10);
+    EXPECT_NEAR(grad_Py, 0.08281016194447452, 1e-10);
+    EXPECT_NEAR(grad_Pz, -0.52098430223602143, 1e-10);
+    EXPECT_NEAR(du, -0.0038445778269613888, 1e-10);
     EXPECT_NEAR(maxvsignal, 1.4112466829, 1e-10);
 }
 


### PR DESCRIPTION
Storage of the field "rho" is avoided as we can compute rho by multiplying kx and rho0