### PR TITLE
Neighbor count output

### DIFF
--- a/main/src/io/mpi_file_utils.hpp
+++ b/main/src/io/mpi_file_utils.hpp
@@ -54,6 +54,16 @@ inline h5part_int64_t writeH5PartField(H5PartFile* h5_file, const std::string& f
     return H5PartWriteDataInt32(h5_file, fieldName.c_str(), field);
 }
 
+inline h5part_int64_t writeH5PartField(H5PartFile* h5_file, const std::string& fieldName, const unsigned* field)
+{
+    return H5PartWriteDataInt32(h5_file, fieldName.c_str(), (const h5part_int32_t*)field);
+}
+
+inline h5part_int64_t writeH5PartField(H5PartFile* h5_file, const std::string& fieldName, const uint64_t* field)
+{
+    return H5PartWriteDataInt64(h5_file, fieldName.c_str(), (const h5part_int64_t*)field);
+}
+
 inline h5part_int64_t writeH5PartField(H5PartFile* h5_file, const std::string& fieldName, const float* field)
 {
     static_assert(std::is_same_v<float, h5part_float32_t>);

--- a/sph/include/sph/data_util.hpp
+++ b/sph/include/sph/data_util.hpp
@@ -65,7 +65,7 @@ template<class Dataset>
 auto getOutputArrays(Dataset& dataset)
 {
     auto fieldPointers = dataset.data();
-    using FieldType    = std::variant<const float*, const double*, const int*>;
+    using FieldType    = std::variant<const float*, const double*, const int*, const unsigned*, const uint64_t*>;
 
     std::vector<FieldType> outputFields;
     outputFields.reserve(dataset.outputFields.size());
@@ -97,13 +97,10 @@ void resize(Dataset& d, size_t size)
         std::visit([size, growthRate](auto& arg) { reallocate(*arg, size, growthRate); }, data_[i]);
     }
 
-    reallocate(d.codes, size, growthRate);
-    reallocate(d.neighborsCount, size, growthRate);
-
     d.devPtrs.resize(size);
 }
 
-//! resizes the neighbors list, only used in the CPU version
+//! @brief resizes the neighbors list, only used in the CPU version
 template<class Dataset>
 void resizeNeighbors(Dataset& d, size_t size)
 {


### PR DESCRIPTION
Exploits the variant fields introduced by @OsmanSeckinSimsek to list particle SFC keys and neighbor counts
as a standard particle field that can be selected for output.

The field name for the neighbor counts is `nc`, for the SFC keys, it's `keys`.