### PR TITLE
Restore rho output

### DIFF
--- a/main/src/io/mpi_file_utils.hpp
+++ b/main/src/io/mpi_file_utils.hpp
@@ -134,7 +134,7 @@ void writeH5Part(Dataset& d, size_t firstIndex, size_t lastIndex, const cstone::
     auto fieldPointers = getOutputArrays(d);
     for (size_t fidx = 0; fidx < fieldPointers.size(); ++fidx)
     {
-        const std::string& fieldName = Dataset::fieldNames[d.outputFields[fidx]];
+        const std::string& fieldName = d.outputFieldNames[fidx];
         std::visit([&h5_file, &fieldName, firstIndex](auto& arg)
                    { writeH5PartField(h5_file, fieldName, arg + firstIndex); },
                    fieldPointers[fidx]);

--- a/main/src/sphexa/propagator.hpp
+++ b/main/src/sphexa/propagator.hpp
@@ -76,7 +76,7 @@ protected:
     size_t rank_;
     //! maximum number of neighbors per particle
     size_t ngmax_;
-    //! average number of neighbors per particle
+    //! target number of neighbors per particle
     size_t ng0_;
 
     bool doGravity_;

--- a/main/src/sphexa/propagator.hpp
+++ b/main/src/sphexa/propagator.hpp
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <iostream>
+#include <variant>
 
 #include "cstone/domain/domain.hpp"
 #include "sph/sph.hpp"
@@ -63,6 +64,8 @@ public:
     virtual void sync(DomainType& domain, ParticleDataType& d) = 0;
 
     virtual void step(DomainType& domain, ParticleDataType& d) = 0;
+
+    virtual void prepareOutput(ParticleDataType& d, size_t startIndex, size_t endIndex){};
 
     virtual ~Propagator() = default;
 
@@ -324,6 +327,29 @@ public:
 
         timer.stop();
         this->printIterationTimings(domain, d);
+    }
+
+    void prepareOutput(ParticleDataType& d, size_t startIndex, size_t endIndex) override
+    {
+        auto fieldPointers = getOutputArrays(d);
+
+        for (size_t outIdx = 0; outIdx < fieldPointers.size(); ++outIdx)
+        {
+            if (d.outputFieldNames[outIdx] == "rho")
+            {
+                auto computeRho =
+                    [startIndex, endIndex, kx = d.kx.data(), m = d.m.data(), xm = d.xm.data()](auto* varField)
+                {
+#pragma omp parallel for schedule(static)
+                    for (size_t i = startIndex; i < endIndex; ++i)
+                    {
+                        varField[i] = kx[i] * m[i] / xm[i];
+                    }
+                };
+
+                std::visit(computeRho, fieldPointers[outIdx]);
+            }
+        }
     }
 };
 

--- a/main/src/sphexa/propagator.hpp
+++ b/main/src/sphexa/propagator.hpp
@@ -130,9 +130,9 @@ template<class DomainType, class ParticleDataType>
 class HydroProp final : public Propagator<DomainType, ParticleDataType>
 {
     using Base = Propagator<DomainType, ParticleDataType>;
+    using Base::doGravity_;
     using Base::ng0_;
     using Base::ngmax_;
-    using Base::doGravity_;
     using Base::timer;
 
     using T             = typename ParticleDataType::RealType;
@@ -227,9 +227,9 @@ template<class DomainType, class ParticleDataType>
 class HydroVeProp final : public Propagator<DomainType, ParticleDataType>
 {
     using Base = Propagator<DomainType, ParticleDataType>;
+    using Base::doGravity_;
     using Base::ng0_;
     using Base::ngmax_;
-    using Base::doGravity_;
     using Base::timer;
 
     using T             = typename ParticleDataType::RealType;
@@ -238,8 +238,8 @@ class HydroVeProp final : public Propagator<DomainType, ParticleDataType>
 
     using Acc = typename ParticleDataType::AcceleratorType;
     using MHolder_t =
-    typename detail::AccelSwitchType<Acc, MultipoleHolderCpu, MultipoleHolderGpu>::template type<MultipoleType,
-        KeyType, T, T, T>;
+        typename detail::AccelSwitchType<Acc, MultipoleHolderCpu, MultipoleHolderGpu>::template type<MultipoleType,
+                                                                                                     KeyType, T, T, T>;
 
     MHolder_t mHolder_;
 

--- a/main/src/sphexa/propagator.hpp
+++ b/main/src/sphexa/propagator.hpp
@@ -50,14 +50,17 @@ template<class DomainType, class ParticleDataType>
 class Propagator
 {
 public:
-    Propagator(size_t ngmax, size_t ng0, std::ostream& output, size_t rank)
+    Propagator(size_t ngmax, size_t ng0, std::ostream& output, size_t rank, bool doGrav)
         : timer(output, rank)
         , out(output)
         , rank_(rank)
         , ngmax_(ngmax)
         , ng0_(ng0)
+        , doGravity_(doGrav)
     {
     }
+
+    virtual void sync(DomainType& domain, ParticleDataType& d) = 0;
 
     virtual void step(DomainType& domain, ParticleDataType& d) = 0;
 
@@ -72,6 +75,8 @@ protected:
     size_t ngmax_;
     //! average number of neighbors per particle
     size_t ng0_;
+
+    bool doGravity_;
 
     void printIterationTimings(const DomainType& domain, const ParticleDataType& d)
     {
@@ -127,6 +132,7 @@ class HydroProp final : public Propagator<DomainType, ParticleDataType>
     using Base = Propagator<DomainType, ParticleDataType>;
     using Base::ng0_;
     using Base::ngmax_;
+    using Base::doGravity_;
     using Base::timer;
 
     using T             = typename ParticleDataType::RealType;
@@ -137,25 +143,27 @@ class HydroProp final : public Propagator<DomainType, ParticleDataType>
     using MHolder_t =
         typename detail::AccelSwitchType<Acc, MultipoleHolderCpu, MultipoleHolderGpu>::template type<MultipoleType,
                                                                                                      KeyType, T, T, T>;
-
     MHolder_t mHolder_;
 
 public:
-    HydroProp(size_t ngmax, size_t ng0, std::ostream& output, size_t rank)
-        : Base(ngmax, ng0, output, rank)
+    HydroProp(size_t ngmax, size_t ng0, std::ostream& output, size_t rank, bool doGravity)
+        : Base(ngmax, ng0, output, rank, doGravity)
     {
     }
 
-    void step(DomainType& domain, ParticleDataType& d) override
+    void sync(DomainType& domain, ParticleDataType& d) override
     {
-        bool doGrav = (d.g != 0.0);
-
-        timer.start();
-        if (doGrav)
+        if (doGravity_)
         {
             domain.syncGrav(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1);
         }
         else { domain.sync(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1); }
+    }
+
+    void step(DomainType& domain, ParticleDataType& d) override
+    {
+        timer.start();
+        sync(domain, d);
         timer.step("domain::sync");
 
         resize(d, domain.nParticlesWithHalos());
@@ -183,7 +191,7 @@ public:
         timer.step("MomentumEnergyIAD");
 
         d.egrav = 0.0;
-        if (doGrav)
+        if (doGravity_)
         {
             mHolder_.upsweep(d, domain);
             timer.step("Upsweep");
@@ -221,21 +229,44 @@ class HydroVeProp final : public Propagator<DomainType, ParticleDataType>
     using Base = Propagator<DomainType, ParticleDataType>;
     using Base::ng0_;
     using Base::ngmax_;
+    using Base::doGravity_;
     using Base::timer;
 
+    using T             = typename ParticleDataType::RealType;
+    using KeyType       = typename ParticleDataType::KeyType;
+    using MultipoleType = ryoanji::CartesianQuadrupole<float>;
+
+    using Acc = typename ParticleDataType::AcceleratorType;
+    using MHolder_t =
+    typename detail::AccelSwitchType<Acc, MultipoleHolderCpu, MultipoleHolderGpu>::template type<MultipoleType,
+        KeyType, T, T, T>;
+
+    MHolder_t mHolder_;
+
 public:
-    HydroVeProp(size_t ngmax, size_t ng0, std::ostream& output, size_t rank)
-        : Base(ngmax, ng0, output, rank)
+    HydroVeProp(size_t ngmax, size_t ng0, std::ostream& output, size_t rank, bool doGravity)
+        : Base(ngmax, ng0, output, rank, doGravity)
     {
+    }
+
+    void sync(DomainType& domain, ParticleDataType& d) override
+    {
+        if (doGravity_)
+        {
+            domain.syncGrav(
+                d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1, d.alpha);
+        }
+        else
+        {
+            domain.sync(
+                d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1, d.alpha);
+        }
     }
 
     void step(DomainType& domain, ParticleDataType& d) override
     {
-        using T       = typename ParticleDataType::RealType;
-        using KeyType = typename ParticleDataType::KeyType;
-
         timer.start();
-        domain.sync(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1, d.alpha);
+        sync(domain, d);
         timer.step("domain::sync");
 
         resize(d, domain.nParticlesWithHalos());
@@ -270,6 +301,18 @@ public:
         timer.step("mpi::synchronizeHalos");
         computeGradPVE(first, last, ngmax_, d, domain.box());
         timer.step("MomentumAndEnergy");
+
+        d.egrav = 0.0;
+        if (doGravity_)
+        {
+            mHolder_.upsweep(d, domain);
+            timer.step("Upsweep");
+            mHolder_.traverse(d, domain);
+            // temporary sign fix, see note in ParticlesData
+            d.egrav = (d.g > 0.0) ? d.egrav : -d.egrav;
+            timer.step("Gravity");
+        }
+
         computeTimestep(first, last, d);
         timer.step("Timestep");
         computePositions(first, last, d, domain.box());
@@ -285,11 +328,11 @@ public:
 };
 
 template<class DomainType, class ParticleDataType>
-std::unique_ptr<Propagator<DomainType, ParticleDataType>> propagatorFactory(bool ve, size_t ngmax, size_t ng0,
-                                                                            std::ostream& output, size_t rank)
+std::unique_ptr<Propagator<DomainType, ParticleDataType>>
+propagatorFactory(bool ve, size_t ngmax, size_t ng0, std::ostream& output, size_t rank, bool doGravity)
 {
-    if (ve) { return std::make_unique<HydroVeProp<DomainType, ParticleDataType>>(ngmax, ng0, output, rank); }
-    else { return std::make_unique<HydroProp<DomainType, ParticleDataType>>(ngmax, ng0, output, rank); }
+    if (ve) { return std::make_unique<HydroVeProp<DomainType, ParticleDataType>>(ngmax, ng0, output, rank, doGravity); }
+    else { return std::make_unique<HydroProp<DomainType, ParticleDataType>>(ngmax, ng0, output, rank, doGravity); }
 }
 
 } // namespace sphexa

--- a/main/src/sphexa/sphexa.cpp
+++ b/main/src/sphexa/sphexa.cpp
@@ -133,15 +133,9 @@ int main(int argc, char** argv)
     // we want about 100 global nodes per rank to decompose the domain with +-1% accuracy
     size_t bucketSize = std::max(bucketSizeFocus, d.numParticlesGlobal / (100 * numRanks));
     Domain domain(rank, numRanks, bucketSize, bucketSizeFocus, theta, box);
-    auto   propagator = propagatorFactory<Domain, Dataset>(ve, ngmax, ng0, output, rank);
+    auto   propagator = propagatorFactory<Domain, Dataset>(ve, ngmax, ng0, output, rank, haveGrav);
 
-    if (ve)
-        domain.sync(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1, d.alpha);
-    else if (haveGrav)
-        domain.syncGrav(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1);
-    else
-        domain.sync(d.codes, d.x, d.y, d.z, d.h, d.m, d.u, d.vx, d.vy, d.vz, d.x_m1, d.y_m1, d.z_m1, d.du_m1);
-
+    propagator->sync(domain, d);
     if (rank == 0) std::cout << "Domain synchronized, nLocalParticles " << d.x.size() << std::endl;
 
     viz::init_catalyst(argc, argv);

--- a/main/src/sphexa/sphexa.cpp
+++ b/main/src/sphexa/sphexa.cpp
@@ -156,6 +156,7 @@ int main(int argc, char** argv)
             isPeriodicOutputTime(d.ttot - d.minDt, d.ttot, writeFrequencyStr) ||
             isExtraOutputStep(d.iteration, d.ttot - d.minDt, d.ttot, writeExtra))
         {
+            propagator->prepareOutput(d, domain.startIndex(), domain.endIndex());
             fileWriter->dump(d, domain.startIndex(), domain.endIndex(), box, outFile);
         }
 

--- a/main/src/sphexa/sphexa.cpp
+++ b/main/src/sphexa/sphexa.cpp
@@ -162,7 +162,7 @@ int main(int argc, char** argv)
         if (d.iteration % 50 == 0) { viz::execute(d, domain.startIndex(), domain.endIndex()); }
     }
 
-    totalTimer.step("Total execution time of " + std::to_string(d.iteration - startIteration + 1) + " iterations of " +
+    totalTimer.step("Total execution time of " + std::to_string(d.iteration - startIteration) + " iterations of " +
                     initCond + " up to t = " + std::to_string(d.ttot));
 
     constantsFile.close();

--- a/sph/include/sph/data_util.hpp
+++ b/sph/include/sph/data_util.hpp
@@ -65,12 +65,12 @@ template<class Dataset>
 auto getOutputArrays(Dataset& dataset)
 {
     auto fieldPointers = dataset.data();
-    using FieldType    = std::variant<const float*, const double*, const int*, const unsigned*, const uint64_t*>;
+    using FieldType    = std::variant<float*, double*, int*, unsigned*, uint64_t*>;
 
     std::vector<FieldType> outputFields;
-    outputFields.reserve(dataset.outputFields.size());
+    outputFields.reserve(dataset.outputFieldIndices.size());
 
-    for (int i : dataset.outputFields)
+    for (int i : dataset.outputFieldIndices)
     {
         std::visit([&outputFields](auto& arg) { outputFields.push_back(arg->data()); }, fieldPointers[i]);
     }
@@ -107,6 +107,54 @@ void resizeNeighbors(Dataset& d, size_t size)
     double growthRate = 1.05;
     //! If we have a GPU, neighbors are calculated on-the-fly, so we don't need space to store them
     reallocate(d.neighbors, HaveGpu<typename Dataset::AcceleratorType>{} ? 0 : size, growthRate);
+}
+
+/*! @brief Determine storage location for field with index @p what
+ *
+ * @tparam FieldPointers
+ * @param  what             the field index to store
+ * @param  outputFields     indices of output fields
+ * @param  conservedFields  indices of conserved fields
+ * @param  dependentFields  indices of dependent fields
+ * @param  fieldPointers    the array of variants returned by ParticlesData::data()
+ * @return                  @p what if @p what is either conserved or dependent
+ *                          otherwise the first field in @p dependentFields whose type matches the type of @p what
+ *                          and which is not listed in @p outputFields
+ *
+ * Field indices are relative to the names table in ParticlesData::fieldNames.
+ *
+ * Example usage: With volume elements, rho is not an active field. Instead, rho can be computed as rho = kx * m / xm.
+ * When output of rho is requested, we look for a field which we can fill with the values of kx * m / xm.
+ * Since outputs happen an the end of the iteration, we may use any dependent field (not conserved between iterations)
+ * which is not itself contained in the list of output fields.
+ */
+template<class FieldPointers>
+int findFieldIdx(int what, gsl::span<const int> outputFields, gsl::span<const int> conservedFields,
+                 gsl::span<const int> dependentFields, const FieldPointers& fieldPointers)
+{
+    bool fieldIsActive = (std::find(conservedFields.begin(), conservedFields.end(), what) != conservedFields.end()) ||
+                         (std::find(dependentFields.begin(), dependentFields.end(), what) != dependentFields.end());
+
+    if (fieldIsActive) { return what; }
+
+    for (int field : dependentFields)
+    {
+        bool fieldIsNotOutput = std::find(outputFields.begin(), outputFields.end(), field) == outputFields.end();
+
+        auto checkTypesMatch = [](const auto* varPtr1, const auto* varPtr2)
+        {
+            using VectorType1 = std::decay_t<decltype(*varPtr1)>;
+            using VectorType2 = std::decay_t<decltype(*varPtr2)>;
+
+            return std::is_same_v<typename VectorType1::value_type, typename VectorType2::value_type>;
+        };
+
+        bool typesMatch = std::visit(checkTypesMatch, fieldPointers[what], fieldPointers[field]);
+
+        if (fieldIsNotOutput && typesMatch) { return field; }
+    }
+
+    return fieldPointers.size();
 }
 
 } // namespace sphexa

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -98,7 +98,7 @@ public:
     std::vector<T>       dt, dt_m1;                    // timestep
     std::vector<T>       c11, c12, c13, c22, c23, c33; // IAD components
     std::vector<T>       alpha;                        // AV coeficient
-    std::vector<T>       xm;                           // Classical SPH density
+    std::vector<T>       xm;                           // Volume element definition
     std::vector<T>       kx;                           // Volume element normalization
     std::vector<T>       gradh;                        // grad(h) term
     std::vector<KeyType> codes;                        // Particle space-filling-curve keys

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -47,9 +47,6 @@
 namespace sphexa
 {
 
-template<class Array>
-std::vector<int> fieldStringsToInt(const Array&, const std::vector<std::string>&);
-
 template<typename T, typename I, class AccType>
 class ParticlesData
 {
@@ -102,7 +99,6 @@ public:
     std::vector<T>       c11, c12, c13, c22, c23, c33; // IAD components
     std::vector<T>       alpha;                        // AV coeficient
     std::vector<T>       xm;                           // Classical SPH density
-    std::vector<T>       wrho0;                        // Classical SPH gradient of density
     std::vector<T>       kx;                           // Volume element normalization
     std::vector<T>       gradh;                        // grad(h) term
     std::vector<KeyType> codes;                        // Particle space-filling-curve keys
@@ -211,7 +207,20 @@ public:
 
     void setOutputFields(const std::vector<std::string>& outFields)
     {
-        outputFields = fieldStringsToInt(fieldNames, outFields);
+        outputFieldNames   = outFields;
+        outputFieldIndices = fieldStringsToInt(fieldNames, outFields);
+
+        for (int& outIndex : outputFieldIndices)
+        {
+            int originalIndex = outIndex;
+            outIndex          = findFieldIdx(outIndex, outputFieldIndices, conservedFields, dependentFields, data());
+
+            if (outIndex == fieldNames.size())
+            {
+                throw std::runtime_error(std::string("Could not find output location for field ") +
+                                         fieldNames[originalIndex]);
+            }
+        }
     }
 
     //! @brief particle fields to conserve between iterations, needed for checkpoints and domain exchange
@@ -219,7 +228,8 @@ public:
     //! @brief particle fields recomputed every step from conserved fields
     std::vector<int> dependentFields;
     //! @brief particle fields selected for file output
-    std::vector<int> outputFields;
+    std::vector<int>         outputFieldIndices;
+    std::vector<std::string> outputFieldNames;
 
 #ifdef USE_MPI
     MPI_Comm comm;


### PR DESCRIPTION
This allows to output "rho" as usual also with volume elements, even though it is not an active field.
Whenever an output is triggered, the implementation computes rho as rho = kx * m / xmass.