### PR TITLE
Added artificial conductivity

### DIFF
--- a/sph/include/sph/kernels.hpp
+++ b/sph/include/sph/kernels.hpp
@@ -109,5 +109,39 @@ CUDA_DEVICE_FUN inline T artificial_viscosity(T alpha_i, T alpha_j, T c_i, T c_j
 
     return viscosity_ij;
 }
+/*! @brief calculate the AV heat conduction between a pair of two particles
+ *
+ * @tparam T      float or double
+ * @param p_i     baryonic pressure of particle i
+ * @param p_j     baryonic pressure of particle j
+ * @param rho_i   baryonic density of particle i
+ * @param rho_j   baryonic density of particle j
+ * @param delta_u internal energy difference between particles i and j (u_i - u_j)
+ * @param w_ij    relative velocity (v_i - v_j), projected onto the connecting axis (r_i - r_j)
+ * @return        the heat conduction AV term
+ */
+template<typename T>
+CUDA_DEVICE_FUN inline T AV_heat_conduction(T w_ij, T rho_i, T rho_j, T p_i, T p_j, T delta_u)
+{
+    constexpr T alfa_u = T(0.05);
+
+    T heat_conduction = T(0.0);
+    if (w_ij < T(0.0))
+    {
+        T vij_signal_u = T(0.0);
+
+        // with gravity
+        vij_signal_u = abs(w_ij);
+
+        // without gravity
+        //T rho_ij     = T(0.5) * (rho_i + rho_j);
+        //vij_signal_u = std::sqrt(abs(p_i - p_j) / rho_ij);
+
+        heat_conduction = alfa_u * vij_signal_u * delta_u;
+    }
+
+    return heat_conduction;
+}
+
 
 } // namespace sphexa

--- a/sph/include/sph/momentum_energy_ve.hpp
+++ b/sph/include/sph/momentum_energy_ve.hpp
@@ -25,6 +25,7 @@ void computeGradPVeImpl(size_t startIndex, size_t endIndex, size_t ngmax, Datase
     const T* vy    = d.vy.data();
     const T* vz    = d.vz.data();
     const T* c     = d.c.data();
+    const T* u     = d.u.data();
     const T* p     = d.p.data();
     const T* alpha = d.alpha.data();
     const T* gradh = d.gradh.data();
@@ -77,6 +78,7 @@ void computeGradPVeImpl(size_t startIndex, size_t endIndex, size_t ngmax, Datase
                                         m,
                                         p,
                                         c,
+                                        u,
                                         c11,
                                         c12,
                                         c13,

--- a/sph/test/kernel_ve/momentum_energy_kern.cpp
+++ b/sph/test/kernel_ve/momentum_energy_kern.cpp
@@ -70,6 +70,7 @@ TEST(MomentumEnergy, JLoop)
     std::vector<T> vz{0.091, -0.081, 0.071, -0.061, 0.055};
 
     std::vector<T> c{0.4, 0.5, 0.6, 0.7, 0.8};
+    std::vector<T> u{0.4, 0.5, 0.6, 0.7, 0.8};
     std::vector<T> p{0.2, 0.3, 0.4, 0.5, 0.6};
 
     std::vector<T> alpha{1.0, 0.05, 0.3, 0.5, 0.3};
@@ -119,6 +120,7 @@ TEST(MomentumEnergy, JLoop)
                                          m.data(),
                                          p.data(),
                                          c.data(),
+                                         u.data(),
                                          c11.data(),
                                          c12.data(),
                                          c13.data(),
@@ -143,6 +145,6 @@ TEST(MomentumEnergy, JLoop)
     EXPECT_NEAR(grad_Px, 4.6852624676440924e-1, 1e-10);
     EXPECT_NEAR(grad_Py, -8.2810161944474575e-2, 1e-10);
     EXPECT_NEAR(grad_Pz, 5.209843022360216e-1, 1e-10);
-    EXPECT_NEAR(du, -3.8445778269613888e-3, 1e-10);
-    EXPECT_NEAR(maxvsignal, 1.4112466829, 1e-10);
+    EXPECT_NEAR(du, -3.6517141514543563e-3, 1e-10);
+    EXPECT_NEAR(maxvsignal, 1.4112466828564341, 1e-10);
 }


### PR DESCRIPTION
This adds artificial conductivity to the momentum equation.
The new function is implemented in kernels.hpp. There, you'll find a few lines commented that should be active when there is gravity and the other way around when there is not.  I leave it in this way for you to think of a proper way to implement this within a template, instead of using an if-condition or a pre-compiler directive.