### PR TITLE
fixes for hipcc

### DIFF
--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -261,7 +261,7 @@ public:
         std::vector<LocalIndex> layout(leafCounts_.size() + 1, 0);
         TreeNodeIndex firstIdx = assignment_[myRank_].start();
         TreeNodeIndex lastIdx  = assignment_[myRank_].end();
-        std::exclusive_scan(leafCounts_.begin() + firstIdx, leafCounts_.begin() + lastIdx + 1,
+        stl::exclusive_scan(leafCounts_.begin() + firstIdx, leafCounts_.begin() + lastIdx + 1,
                             layout.begin() + firstIdx, 0);
 
         globalCenters_.resize(globalTree.numTreeNodes());

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -261,7 +261,7 @@ public:
         std::vector<LocalIndex> layout(leafCounts_.size() + 1, 0);
         TreeNodeIndex firstIdx = assignment_[myRank_].start();
         TreeNodeIndex lastIdx  = assignment_[myRank_].end();
-        stl::exclusive_scan(leafCounts_.begin() + firstIdx, leafCounts_.begin() + lastIdx + 1,
+        std::exclusive_scan(leafCounts_.begin() + firstIdx, leafCounts_.begin() + lastIdx + 1,
                             layout.begin() + firstIdx, 0);
 
         globalCenters_.resize(globalTree.numTreeNodes());

--- a/main/src/util/utils.hpp
+++ b/main/src/util/utils.hpp
@@ -27,7 +27,7 @@ auto initMpi()
                omp_get_max_threads(),
                _OPENMP);
 #else
-        printf("# %d MPI-%d.%d process(es) with 1 OpenMP thread/process\n", mpi_ranks, mpi_version, mpi_subversion);
+        printf("# %d MPI-%d.%d process(es) with 1 OpenMP thread/process\n", numRanks, mpi_version, mpi_subversion);
 #endif
     }
     return std::make_tuple(rank, numRanks);

--- a/sph/include/sph/kernels.hpp
+++ b/sph/include/sph/kernels.hpp
@@ -64,7 +64,7 @@ CUDA_DEVICE_HOST_FUN inline T wharmonic_derivative(T v, T powsincv)
  * in the Evrard collapse test case in the wake of the shock wave.
  */
 template<typename T>
-CUDA_DEVICE_FUN inline T artificial_viscosity_old(T ro_i, T ro_j, T h_i, T h_j, T c_i, T c_j, T rv, T r_square)
+CUDA_DEVICE_HOST_FUN inline T artificial_viscosity_old(T ro_i, T ro_j, T h_i, T h_j, T c_i, T c_j, T rv, T r_square)
 {
     constexpr T alpha   = 1.0;
     constexpr T beta    = 2.0;
@@ -95,7 +95,7 @@ CUDA_DEVICE_FUN inline T artificial_viscosity_old(T ro_i, T ro_j, T h_i, T h_j, 
  * @return        the viscosity
  */
 template<typename T>
-CUDA_DEVICE_FUN inline T artificial_viscosity(T alpha_i, T alpha_j, T c_i, T c_j, T w_ij)
+CUDA_DEVICE_HOST_FUN inline T artificial_viscosity(T alpha_i, T alpha_j, T c_i, T c_j, T w_ij)
 {
     // alpha is const for now, but will be different for each particle when using viscosity switching
     constexpr T beta = 2.0;


### PR DESCRIPTION
- ~octree_focus_mpi.hpp: namespace "std" has no member "exclusive_scan" -> stl~
- utils.hpp: use of undeclared identifier 'mpi_ranks' -> numranks
- kernels.hpp: undefined symbol: double sph::artificial_viscosity -> CUDA_DEVICE_HOST_FUN