### PR TITLE
Moved TuplePlus to util namespace for reuse

### DIFF
--- a/.gitlab/Dockerfile_2
+++ b/.gitlab/Dockerfile_2
@@ -110,6 +110,7 @@ RUN echo \
     && echo "## cmake --build + --install :" \
     && cmake --build build -j `grep processor /proc/cpuinfo | wc -l` \
     && cmake --install build \
+    && cp SPH-EXA.git/.gitlab/rfm.py /usr/local/games/rfm.py \
     && ls /usr/local/sbin
 #    -DSPH_EXA_WITH_HIP=OFF \
 #     -DCMAKE_CXX_FLAGS_DEBUG="-g -w" \

--- a/.gitlab/gitlab-ci.yml
+++ b/.gitlab/gitlab-ci.yml
@@ -290,10 +290,8 @@ sph:build:cuda:sphexa:gpu:
     - echo "# --- rpt:"
     - cat /scratch/sedov.rpt
     - cat /scratch/noh.rpt
-    # - cp /sources/.gitlab/rfm.py /usr/local/games/rfm.py
     - pwd
     - ls -la
-    - cp .gitlab/rfm.py /usr/local/games/rfm.py
     - reframe -c /usr/local/games/rfm.py -r -S rpt_path=/scratch
   variables:
     USE_MPI: 'YES'

--- a/domain/include/cstone/util/tuple.hpp
+++ b/domain/include/cstone/util/tuple.hpp
@@ -87,7 +87,7 @@ namespace util
 template<class... Ts>
 using tuple = std::tuple<Ts...>;
 
-template<size_t N, class T>
+template<std::size_t N, class T>
 constexpr auto get(T&& tup) noexcept
 {
     return std::get<N>(tup);
@@ -101,3 +101,31 @@ constexpr tuple<Ts&...> tie(Ts&... args) noexcept
 
 } // namespace util
 #endif
+
+namespace util
+{
+
+template<class Tuple>
+struct TuplePlusImpl
+{
+    template<std::size_t... Is>
+    HOST_DEVICE_FUN Tuple operator()(const Tuple& a, const Tuple& b, std::index_sequence<Is...>)
+    {
+        return Tuple((util::get<Is>(a) + util::get<Is>(b))...);
+    }
+};
+
+/*! @brief generic tuple addition functor that works for both thrust and std tuples
+ *
+ * @tparam Tuple   the kind of tuple to be added, e.g. thrust::tuple<int, double>
+ */
+template<class Tuple>
+struct TuplePlus
+{
+    HOST_DEVICE_FUN Tuple operator()(const Tuple& a, const Tuple& b)
+    {
+        return TuplePlusImpl<Tuple>{}(a, b, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+    }
+};
+
+} // namespace util

--- a/main/src/observables/conserved_gpu.cu
+++ b/main/src/observables/conserved_gpu.cu
@@ -33,6 +33,8 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform_reduce.h>
 
+#include "cstone/util/tuple.hpp"
+
 #include "conserved_gpu.h"
 
 namespace sphexa
@@ -41,9 +43,21 @@ namespace sphexa
 using cstone::Vec3;
 using thrust::get;
 
+/*! @brief Functor to compute kinetic and internal energy and linear and angular momentum
+ *
+ * @tparam Tc   type of x,y,z coordinates
+ * @tparam Tm   type of mass
+ * @tparam Tv   type of velocities
+ * @tparam Tt   type of temperature
+ */
 template<class Tc, class Tm, class Tv, class Tt>
 struct EMom
 {
+    /*! @brief compute energies and momenta for a single particle
+     *
+     * @param p   Tuple<x,y,z,m,vx,vy,vz,temp> with data for one particle
+     * @return    Tuple<kinetic energy, internal energy, linear momentum, angular momentum>
+     */
     HOST_DEVICE_FUN
     thrust::tuple<double, double, Vec3<double>, Vec3<double>>
     operator()(const thrust::tuple<Tc, Tc, Tc, Tm, Tv, Tv, Tv, Tt>& p)
@@ -58,22 +72,6 @@ struct EMom
     Tt cv;
 };
 
-template<class... Ts, size_t... Is>
-HOST_DEVICE_FUN thrust::tuple<Ts...> plus_impl(const thrust::tuple<Ts...>& a, const thrust::tuple<Ts...>& b,
-                                               std::index_sequence<Is...>)
-{
-    return thrust::make_tuple((thrust::get<Is>(a) + thrust::get<Is>(b))...);
-}
-
-template<class... Ts>
-struct TuplePlus
-{
-    HOST_DEVICE_FUN thrust::tuple<Ts...> operator()(const thrust::tuple<Ts...>& a, const thrust::tuple<Ts...>& b)
-    {
-        return plus_impl(a, b, std::make_index_sequence<sizeof...(Ts)>{});
-    }
-};
-
 template<class Tc, class Tv, class Tt, class Tm>
 std::tuple<double, double, Vec3<double>, Vec3<double>>
 conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz,
@@ -84,9 +82,12 @@ conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* v
     auto it2 = thrust::make_zip_iterator(
         thrust::make_tuple(x + last, y + last, z + last, m + last, vx + last, vy + last, vz + last, temp + last));
 
-    auto plus   = TuplePlus<double, double, Vec3<double>, Vec3<double>>{};
-    auto init   = thrust::make_tuple(0.0, 0.0, Vec3<double>{0, 0, 0}, Vec3<double>{0, 0, 0});
+    auto plus = util::TuplePlus<thrust::tuple<double, double, Vec3<double>, Vec3<double>>>{};
+    auto init = thrust::make_tuple(0.0, 0.0, Vec3<double>{0, 0, 0}, Vec3<double>{0, 0, 0});
+
+    //! apply EMom to each particle and reduce results into a single sum
     auto result = thrust::transform_reduce(thrust::device, it1, it2, EMom<Tc, Tm, Tv, Tt>{cv}, init, plus);
+
     return {0.5 * get<0>(result), get<1>(result), get<2>(result), get<3>(result)};
 }
 

--- a/main/src/observables/conserved_gpu.h
+++ b/main/src/observables/conserved_gpu.h
@@ -38,6 +38,21 @@
 namespace sphexa
 {
 
+/*! @brief compute conserved energies and momenta on the GPU
+ *
+ * @param[in] cv         heat capacity
+ * @param[in] x          x-coordinates
+ * @param[in] y          y-coordinates
+ * @param[in] z          z-coordinates
+ * @param[in] vx         x-velocities
+ * @param[in] vy         v-velocities
+ * @param[in] vz         z-velocities
+ * @param[in] temp       temperatures
+ * @param[in] m          masses
+ * @param[in] first      first particle index to include in the sum
+ * @param[in] last       last particle index to include in the sum
+ * @return               A tuple with the total kinetic energy, internal energy, linear momentum and angular momentum
+ */
 template<class Tc, class Tv, class Tt, class Tm>
 extern std::tuple<double, double, cstone::Vec3<double>, cstone::Vec3<double>>
 conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz,


### PR DESCRIPTION
`TuplePlus` can be included with `cstone/util/tuple.hpp`. It works for arbitrary `thrust` and `std` tuples in host and device code.