### PR TITLE
Protection of node counts against overflow

### DIFF
--- a/domain/include/cstone/focus/exchange_focus.hpp
+++ b/domain/include/cstone/focus/exchange_focus.hpp
@@ -91,7 +91,8 @@ void countRequestParticles(gsl::span<const KeyType> leaves,
         assert(startKey == leaves[startIdx]);
         assert(endKey == leaves[endIdx]);
 
-        requestCounts[internalIdx] = std::accumulate(counts.begin() + startIdx, counts.begin() + endIdx, 0u);
+        uint64_t internalCount     = std::accumulate(counts.begin() + startIdx, counts.begin() + endIdx, uint64_t(0));
+        requestCounts[internalIdx] = std::min(uint64_t(std::numeric_limits<unsigned>::max()), internalCount);
     }
 }
 

--- a/domain/include/cstone/focus/octree_focus.hpp
+++ b/domain/include/cstone/focus/octree_focus.hpp
@@ -270,7 +270,7 @@ public:
 
         counts_.resize(tree_.numNodes);
         scatter(leafToInternal(tree_), leafCounts_.data(), counts_.data());
-        upsweep(tree_.levelRange, tree_.childOffsets, counts_.data(), SumCombination<unsigned>{});
+        upsweep(tree_.levelRange, tree_.childOffsets, counts_.data(), NodeCount<unsigned>{});
 
         return converged;
     }

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -205,7 +205,7 @@ public:
         // 1st upsweep with local data
         counts_.resize(treeData_.numNodes);
         scatter<TreeNodeIndex>(leafToInternal(treeData_), leafCounts_.data(), counts_.data());
-        upsweep(treeData_.levelRange, treeData_.childOffsets, counts_.data(), SumCombination<unsigned>{});
+        upsweep(treeData_.levelRange, treeData_.childOffsets, counts_.data(), NodeCount<unsigned>{});
 
         // global counts
         auto globalCountIndices = invertRanges(0, assignment_, nNodes(leaves_));
@@ -228,7 +228,7 @@ public:
                                treeData_.levelRange, leafToInternal(treeData_), gsl::span<unsigned>(counts_), countTag);
 
         // 2nd upsweep with peer and global data present
-        upsweep(treeData_.levelRange, treeData_.childOffsets, counts_.data(), SumCombination<unsigned>{});
+        upsweep(treeData_.levelRange, treeData_.childOffsets, counts_.data(), NodeCount<unsigned>{});
         gather(leafToInternal(treeData_), counts_.data(), leafCounts_.data());
 
         if constexpr (HaveGpu<Accelerator>{})

--- a/domain/include/cstone/tree/octree.hpp
+++ b/domain/include/cstone/tree/octree.hpp
@@ -556,4 +556,18 @@ struct SumCombination
     }
 };
 
+template<class CountType>
+struct NodeCount
+{
+    CountType operator()(TreeNodeIndex /*nodeIdx*/, TreeNodeIndex c, const CountType* Q)
+    {
+        uint64_t sum = Q[c];
+        for (TreeNodeIndex octant = 1; octant < 8; ++octant)
+        {
+            sum += Q[c + octant];
+        }
+        return stl::min(uint64_t(std::numeric_limits<CountType>::max()), sum);
+    }
+};
+
 } // namespace cstone

--- a/domain/test/integration_mpi/exchange_general.cpp
+++ b/domain/test/integration_mpi/exchange_general.cpp
@@ -103,7 +103,7 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
     focusTree.converge(box, particleKeys, peers, assignment, tree, counts, invThetaEff);
 
     auto octree = focusTree.octreeViewAcc();
-    std::vector<int> testCounts(octree.numNodes, -1);
+    std::vector<unsigned> testCounts(octree.numNodes, -1);
 
     for (TreeNodeIndex i = 0; i < octree.numNodes; ++i)
     {
@@ -120,18 +120,16 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
     }
 
     upsweep({octree.levelRange, maxTreeLevel<KeyType>{} + 2}, {octree.childOffsets, size_t(octree.numNodes)},
-            testCounts.data(), SumCombination<int>{});
+            testCounts.data(), NodeCount<unsigned>{});
 
-    std::vector<int> globalCounts(domainTree.numTreeNodes());
-
-    focusTree.template peerExchange<int>(testCounts, static_cast<int>(P2pTags::focusPeerCounts) + 2);
+    focusTree.template peerExchange<unsigned>(testCounts, static_cast<int>(P2pTags::focusPeerCounts) + 2);
 
     auto upsweepFunction = [](auto levelRange, auto childOffsets, auto M)
-    { upsweep(levelRange, childOffsets, M, SumCombination<int>{}); };
-    globalFocusExchange<int>(domainTree, focusTree, testCounts, upsweepFunction);
+    { upsweep(levelRange, childOffsets, M, NodeCount<unsigned>{}); };
+    globalFocusExchange<unsigned>(domainTree, focusTree, testCounts, upsweepFunction);
 
     upsweep({octree.levelRange, maxTreeLevel<KeyType>{} + 2}, {octree.childOffsets, size_t(octree.numNodes)},
-            testCounts.data(), SumCombination<int>{});
+            testCounts.data(), NodeCount<unsigned>{});
 
     {
         for (size_t i = 0; i < testCounts.size(); ++i)
@@ -141,7 +139,7 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
 
             unsigned referenceCount = calculateNodeCount(nodeStart, nodeEnd, coords.particleKeys().data(),
                                                          coords.particleKeys().data() + coords.particleKeys().size(),
-                                                         std::numeric_limits<int>::max());
+                                                         std::numeric_limits<unsigned>::max());
             EXPECT_EQ(testCounts[i], referenceCount);
         }
     }

--- a/domain/test/unit/focus/octree_focus.cpp
+++ b/domain/test/unit/focus/octree_focus.cpp
@@ -48,7 +48,7 @@ static auto computeNodeOps(const Octree<KeyType>& octree,
 {
     std::vector<unsigned> counts(octree.numTreeNodes());
     scatter(octree.internalOrder(), leafCounts.data(), counts.data());
-    upsweep(octree.levelRange(), octree.childOffsets(), counts.data(), SumCombination<unsigned>{});
+    upsweep(octree.levelRange(), octree.childOffsets(), counts.data(), NodeCount<unsigned>{});
 
     std::vector<char> macs(octree.numTreeNodes());
     scatter(octree.internalOrder(), csMacs.data() + octree.numInternalNodes(), macs.data());

--- a/domain/test/unit/tree/octree.cpp
+++ b/domain/test/unit/tree/octree.cpp
@@ -331,7 +331,7 @@ static void upsweepSumIrregularL3()
     std::vector<unsigned> nodeCounts(octree.numTreeNodes());
 
     scatter(octree.internalOrder(), leafCounts.data(), nodeCounts.data());
-    upsweep(octree.levelRange(), octree.childOffsets(), nodeCounts.data(), SumCombination<unsigned>{});
+    upsweep(octree.levelRange(), octree.childOffsets(), nodeCounts.data(), NodeCount<unsigned>{});
 
     //                                      L1                       L2
     //                                                               00                       30


### PR DESCRIPTION
Overflow may happen for the top-level internal node counts of the global and focused trees.
Normally not a problem as only counts of leaves, in focus and close to surface are accessed.
For better testing, we assign a well-defined capped value instead of letting the count overflow.