### PR TITLE
Hotfix kcour

### DIFF
--- a/main/src/init/turbulence_init.hpp
+++ b/main/src/init/turbulence_init.hpp
@@ -60,7 +60,8 @@ std::map<std::string, double> TurbulenceConstants()
             {"anglesExp", 2.0},
             {"gamma", 1.001},
             {"mui", 10.},
-            {"u0", 1000.}};
+            {"u0", 1000.},
+            {"Kcour", 0.4}};
 }
 
 template<class Dataset>
@@ -74,6 +75,7 @@ void initTurbulenceHydroFields(Dataset& d, const std::map<std::string, double>& 
 
     d.gamma    = constants.at("gamma");
     d.muiConst = constants.at("mui");
+    d.Kcour    = constants.at("Kcour");
     d.minDt    = firstTimeStep;
     d.minDt_m1 = firstTimeStep;
 

--- a/sph/include/sph/kernels.hpp
+++ b/sph/include/sph/kernels.hpp
@@ -21,11 +21,11 @@ HOST_DEVICE_FUN inline T compute_3d_k(T n)
 
 //! @brief compute time-step based on the signal velocity
 template<class T1, class T2, class T3>
-HOST_DEVICE_FUN inline auto tsKCourant(T1 maxvsignal, T2 h, T3 c, double kcour)
+HOST_DEVICE_FUN inline auto tsKCourant(T1 maxvsignal, T2 h, T3 c, double Kcour)
 {
     using T = std::common_type_t<T1, T2, T3>;
     T v     = maxvsignal > T(0) ? maxvsignal : c;
-    return T(kcour * h / v);
+    return T(Kcour * h / v);
 }
 
 //! @brief sinc(PI/2 * v)

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -90,8 +90,12 @@ public:
 
     //! @brief adiabatic index
     T gamma{5.0 / 3.0};
+
     //! @brief mean molecular weight of ions for models that use one value for all particles
     T muiConst{10.0};
+
+    //! @brief Fraction of Courant condition for timestep
+    T Kcour{0.2};
 
     /*! @brief Particle fields
      *
@@ -196,7 +200,6 @@ public:
     std::vector<std::string> outputFieldNames;
 
     constexpr static T sincIndex     = 6.0;
-    constexpr static T Kcour         = 0.2;
     constexpr static T maxDtIncrease = 1.1;
 
     // Min. Atwood number in ramp function in momentum equation (crossed/uncrossed selection)


### PR DESCRIPTION
I set KCour as a variable instead of const expr in particle data. Now it can be defined in the init file. If is not, then takes the standard 0,2 value.