### PR TITLE
Fast let init

### DIFF
--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -104,12 +104,12 @@ public:
         }
         oldBoundaries.back() = nodeRange<KeyType>(0);
 
-        updateOctreeGlobal(keyView.begin(), keyView.end(), bucketSize_, tree_, nodeCounts_, numRanks_);
+        updateOctreeGlobal(keyView.begin(), keyView.end(), bucketSize_, tree_, nodeCounts_);
 
         if (firstCall_)
         {
             firstCall_ = false;
-            while (!updateOctreeGlobal(keyView.begin(), keyView.end(), bucketSize_, tree_, nodeCounts_, numRanks_))
+            while (!updateOctreeGlobal(keyView.begin(), keyView.end(), bucketSize_, tree_, nodeCounts_))
                 ;
         }
 

--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -61,9 +61,11 @@ public:
         , bucketSize_(bucketSize)
         , box_(box)
     {
-        std::vector<KeyType> init{0, nodeRange<KeyType>(0)};
+        unsigned level            = log8ceil<KeyType>(100 * nRanks);
+        auto initialBoundaries    = initialDomainSplits<KeyType>(nRanks, level);
+        std::vector<KeyType> init = computeSpanningTree<KeyType>(initialBoundaries);
         tree_.update(init.data(), nNodes(init));
-        nodeCounts_ = std::vector<unsigned>{bucketSize_ + 1};
+        nodeCounts_ = std::vector<unsigned>(nNodes(init), bucketSize_ - 1);
     }
 
     /*! @brief Update the global tree

--- a/domain/include/cstone/domain/assignment_gpu.cuh
+++ b/domain/include/cstone/domain/assignment_gpu.cuh
@@ -66,9 +66,11 @@ public:
         , bucketSize_(bucketSize)
         , box_(box)
     {
-        std::vector<KeyType> init{0, nodeRange<KeyType>(0)};
+        unsigned level            = log8ceil<KeyType>(100 * nRanks);
+        auto initialBoundaries    = initialDomainSplits<KeyType>(nRanks, level);
+        std::vector<KeyType> init = computeSpanningTree<KeyType>(initialBoundaries);
         tree_.update(init.data(), nNodes(init));
-        nodeCounts_ = std::vector<unsigned>{bucketSize_ + 1};
+        nodeCounts_ = std::vector<unsigned>(nNodes(init), bucketSize_ - 1);
     }
 
     /*! @brief Update the global tree

--- a/domain/include/cstone/domain/assignment_gpu.cuh
+++ b/domain/include/cstone/domain/assignment_gpu.cuh
@@ -108,13 +108,13 @@ public:
         }
         oldBoundaries.back() = nodeRange<KeyType>(0);
 
-        updateOctreeGlobalGpu(keyView.begin(), keyView.end(), bucketSize_, tree_, d_csTree_, nodeCounts_, d_nodeCounts_,
-                              numRanks_);
+        updateOctreeGlobalGpu(keyView.begin(), keyView.end(), bucketSize_, tree_, d_csTree_, nodeCounts_,
+                              d_nodeCounts_);
         if (firstCall_)
         {
             firstCall_ = false;
             while (!updateOctreeGlobalGpu(keyView.begin(), keyView.end(), bucketSize_, tree_, d_csTree_, nodeCounts_,
-                                          d_nodeCounts_, numRanks_))
+                                          d_nodeCounts_))
                 ;
         }
 

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -263,6 +263,10 @@ public:
 
         if (firstCall_)
         {
+            // first rough convergence to avoid computing expansion centers of large nodes with a lot of particles
+            focusTree_.converge(box(), keyView, peers, global_.assignment(), global_.treeLeaves(), global_.nodeCounts(),
+                                1.0, std::get<0>(scratch));
+
             int converged = 0;
             while (converged != numRanks_)
             {

--- a/domain/include/cstone/domain/domaindecomp.hpp
+++ b/domain/include/cstone/domain/domaindecomp.hpp
@@ -373,4 +373,29 @@ size_t computeTotalSendBytes(const SendList& sendList,
     return totalSendBytes;
 }
 
+/*! @brief return @p numRanks equal length SFC segments for initial domain decomposition
+ *
+ * @tparam KeyType
+ * @param numRanks    number of segments
+ * @param level       maximum tree depths or (=number of non-zero leading octal digits)
+ * @return            the segments
+ *
+ * Example: returns [0 2525200000 5252500000 10000000000] for numRanks = 3 and level = 5
+ */
+template<class KeyType>
+std::vector<KeyType> initialDomainSplits(int numRanks, int level)
+{
+    std::vector<KeyType> ret(numRanks + 1);
+    KeyType delta = nodeRange<KeyType>(0) / numRanks;
+
+    ret.front() = 0;
+    for (int i = 1; i < numRanks; ++i)
+    {
+        ret[i] = enclosingBoxCode(KeyType(i) * delta, level);
+    }
+    ret.back() = nodeRange<KeyType>(0);
+
+    return ret;
+}
+
 } // namespace cstone

--- a/domain/test/unit/domain/domaindecomp.cpp
+++ b/domain/test/unit/domain/domaindecomp.cpp
@@ -159,3 +159,17 @@ TEST(DomainDecomposition, computeByteOffsets)
 
     EXPECT_EQ(offsets[3], 8064 + 4096 + 8064);
 }
+
+template<class KeyType>
+static void initialSplits()
+{
+    auto ret = initialDomainSplits<KeyType>(3, 5);
+    EXPECT_EQ(ret.front(), 0);
+    EXPECT_EQ(ret.back(), nodeRange<KeyType>(0));
+}
+
+TEST(DomainDecomposition, initialDomainSplit)
+{
+    initialSplits<unsigned>();
+    initialSplits<uint64_t>();
+}

--- a/main/src/init/evrard_init.hpp
+++ b/main/src/init/evrard_init.hpp
@@ -143,7 +143,11 @@ public:
 
         cstone::Box<T> globalBox(-r, r, cstone::BoundaryType::open);
 
-        auto [keyStart, keyEnd] = partitionRange(cstone::nodeRange<KeyType>(0), rank, numRanks);
+        unsigned level             = cstone::log8ceil<KeyType>(100 * numRanks);
+        auto     initialBoundaries = cstone::initialDomainSplits<KeyType>(numRanks, level);
+        KeyType  keyStart          = initialBoundaries[rank];
+        KeyType  keyEnd            = initialBoundaries[rank + 1];
+
         assembleCube<T>(keyStart, keyEnd, globalBox, multiplicity, xBlock, yBlock, zBlock, d.x, d.y, d.z);
         cutSphere(r, d.x, d.y, d.z);
 

--- a/main/src/init/sedov_init.hpp
+++ b/main/src/init/sedov_init.hpp
@@ -168,7 +168,11 @@ public:
         T              r = constants_.at("r1");
         cstone::Box<T> globalBox(-r, r, cstone::BoundaryType::periodic);
 
-        auto [keyStart, keyEnd] = partitionRange(cstone::nodeRange<KeyType>(0), rank, numRanks);
+        unsigned level             = cstone::log8ceil<KeyType>(100 * numRanks);
+        auto     initialBoundaries = cstone::initialDomainSplits<KeyType>(numRanks, level);
+        KeyType  keyStart          = initialBoundaries[rank];
+        KeyType  keyEnd            = initialBoundaries[rank + 1];
+
         assembleCube<T>(keyStart, keyEnd, globalBox, multiplicity, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
         d.resize(d.x.size());

--- a/main/src/init/turbulence_init.hpp
+++ b/main/src/init/turbulence_init.hpp
@@ -114,7 +114,12 @@ public:
         d.numParticlesGlobal = multiplicity * multiplicity * multiplicity * blockSize;
 
         cstone::Box<T> globalBox(-0.5, 0.5, cstone::BoundaryType::periodic);
-        auto [keyStart, keyEnd] = partitionRange(cstone::nodeRange<KeyType>(0), rank, numRanks);
+
+        unsigned level             = cstone::log8ceil<KeyType>(100 * numRanks);
+        auto     initialBoundaries = cstone::initialDomainSplits<KeyType>(numRanks, level);
+        KeyType  keyStart          = initialBoundaries[rank];
+        KeyType  keyEnd            = initialBoundaries[rank + 1];
+
         assembleCube<T>(keyStart, keyEnd, globalBox, multiplicity, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
         d.resize(d.x.size());


### PR DESCRIPTION
This provides a better initial guess for the global tree with non-overlapping sub-domain boundaries.
Before, the global tree was initialized as just the root node on all ranks.