### PR TITLE
traversal.hpp: Fix root cell descent logic.

### DIFF
--- a/domain/include/cstone/traversal/traversal.hpp
+++ b/domain/include/cstone/traversal/traversal.hpp
@@ -68,7 +68,10 @@ namespace cstone
 template<class C, class A>
 HOST_DEVICE_FUN void singleTraversal(const TreeNodeIndex* childOffsets, C&& continuationCriterion, A&& endpointAction)
 {
-    if (!continuationCriterion(0) || childOffsets[0] == 0)
+    bool descend = continuationCriterion(0);
+    if (!descend) return;
+
+    if (childOffsets[0] == 0)
     {
         // root node is already the endpoint
         endpointAction(0);


### PR DESCRIPTION
In singleTraversal(), endpointAction() is called even if continuationCriterion() returns false. This differs from the handling of all other nodes, and is problematic when the continuationCriterion() fails because a multipole interaction was performed between the root node and a replica.