### PR TITLE
Allow some attributes to be initialized by default values

### DIFF
--- a/main/src/io/ifile_io_hdf5.hpp
+++ b/main/src/io/ifile_io_hdf5.hpp
@@ -175,8 +175,10 @@ public:
 
     int64_t stepAttributeSize(const std::string& key) override
     {
-        auto           attributes = fileutils::stepAttributeNames(h5File_);
-        size_t         attrIndex  = std::find(attributes.begin(), attributes.end(), key) - attributes.begin();
+        auto   attributes = fileutils::stepAttributeNames(h5File_);
+        size_t attrIndex  = std::find(attributes.begin(), attributes.end(), key) - attributes.begin();
+        if (attrIndex == attributes.size()) { throw std::out_of_range("Attribute " + key + " does not exist\n"); }
+
         h5part_int64_t typeId, attrSize;
         char           dummy[256];
         H5PartGetStepAttribInfo(h5File_, attrIndex, dummy, 256, &typeId, &attrSize);
@@ -187,7 +189,7 @@ public:
     {
         if (size != fileAttributeSize(key)) { throw std::runtime_error("File attribute size is inconsistent: " + key); }
         auto err = std::visit([this, &key](auto arg) { return H5PartReadFileAttrib(h5File_, key.c_str(), arg); }, val);
-        if (err != H5PART_SUCCESS) { throw std::runtime_error("Could not read file attribute: " + key); }
+        if (err != H5PART_SUCCESS) { throw std::out_of_range("Could not read file attribute: " + key); }
     }
 
     void stepAttribute(const std::string& key, FieldType val, int64_t size) override

--- a/main/src/io/mpi_file_utils.hpp
+++ b/main/src/io/mpi_file_utils.hpp
@@ -234,56 +234,56 @@ inline h5part_int64_t writeH5PartField(H5PartFile* h5_file, const std::string& f
 
 /* write step attributes */
 
-void sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const double* value, size_t numElements)
+auto sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const double* value, size_t numElements)
 {
-    H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_FLOAT64, value, numElements);
+    return H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_FLOAT64, value, numElements);
 }
 
-void sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const float* value, size_t numElements)
+auto sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const float* value, size_t numElements)
 {
-    H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_FLOAT32, value, numElements);
+    return H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_FLOAT32, value, numElements);
 }
 
-void sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const char* value, size_t numElements)
+auto sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const char* value, size_t numElements)
 {
-    H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_CHAR, value, numElements);
+    return H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_CHAR, value, numElements);
 }
 
-void sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const int* value, size_t numElements)
+auto sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const int* value, size_t numElements)
 {
-    H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_INT32, value, numElements);
+    return H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_INT32, value, numElements);
 }
 
-void sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const int64_t* value, size_t numElements)
+auto sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const int64_t* value, size_t numElements)
 {
-    H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_INT64, value, numElements);
+    return H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_INT64, value, numElements);
 }
 
-void sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const unsigned* value, size_t numElements)
+auto sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const unsigned* value, size_t numElements)
 {
-    H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_INT32, value, numElements);
+    return H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_INT32, value, numElements);
 }
 
-void sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const uint64_t* value, size_t numElements)
+auto sphexaWriteStepAttrib(H5PartFile* h5_file, const std::string& name, const uint64_t* value, size_t numElements)
 {
-    H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_INT64, value, numElements);
+    return H5PartWriteStepAttrib(h5_file, name.c_str(), H5PART_INT64, value, numElements);
 }
 
 /* write file attributes */
 
-void sphexaWriteFileAttrib(H5PartFile* h5_file, const std::string& name, const double* value, size_t numElements)
+auto sphexaWriteFileAttrib(H5PartFile* h5_file, const std::string& name, const double* value, size_t numElements)
 {
-    H5PartWriteFileAttrib(h5_file, name.c_str(), H5PART_FLOAT64, value, numElements);
+    return H5PartWriteFileAttrib(h5_file, name.c_str(), H5PART_FLOAT64, value, numElements);
 }
 
-void sphexaWriteFileAttrib(H5PartFile* h5_file, const std::string& name, const float* value, size_t numElements)
+auto sphexaWriteFileAttrib(H5PartFile* h5_file, const std::string& name, const float* value, size_t numElements)
 {
-    H5PartWriteFileAttrib(h5_file, name.c_str(), H5PART_FLOAT32, value, numElements);
+    return H5PartWriteFileAttrib(h5_file, name.c_str(), H5PART_FLOAT32, value, numElements);
 }
 
-void sphexaWriteFileAttrib(H5PartFile* h5_file, const std::string& name, const char* value, size_t numElements)
+auto sphexaWriteFileAttrib(H5PartFile* h5_file, const std::string& name, const char* value, size_t numElements)
 {
-    H5PartWriteFileAttrib(h5_file, name.c_str(), H5PART_CHAR, value, numElements);
+    return H5PartWriteFileAttrib(h5_file, name.c_str(), H5PART_CHAR, value, numElements);
 }
 
 //! @brief Open in parallel mode if supported, otherwise serial if numRanks == 1

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -110,17 +110,31 @@ public:
     template<class Archive>
     void loadOrStoreAttributes(Archive* ar)
     {
+        //! @brief load or store an attribute, skips non-existing attributes on load.
+        auto optionalIO = [ar](const std::string& attribute, auto* location, size_t attrSize)
+        {
+            try
+            {
+                ar->stepAttribute(attribute, location, attrSize);
+            }
+            catch (std::out_of_range&)
+            {
+                std::cout << "Attribute " << attribute << " not set in file, setting to default value " << *location
+                          << std::endl;
+            }
+        };
+
         ar->stepAttribute("iteration", &iteration, 1);
         ar->stepAttribute("numParticlesGlobal", &numParticlesGlobal, 1);
-        ar->stepAttribute("ng0", &ng0, 1);
-        ar->stepAttribute("ngmax", &ngmax, 1);
+        optionalIO("ng0", &ng0, 1);
+        optionalIO("ngmax", &ngmax, 1);
         ar->stepAttribute("time", &ttot, 1);
         ar->stepAttribute("minDt", &minDt, 1);
         ar->stepAttribute("minDt_m1", &minDt_m1, 1);
         ar->stepAttribute("gravConstant", &g, 1);
-        ar->stepAttribute("gamma", &gamma, 1);
-        ar->stepAttribute("muiConst", &muiConst, 1);
-        ar->stepAttribute("Kcour", &Kcour, 1);
+        optionalIO("gamma", &gamma, 1);
+        optionalIO("muiConst", &muiConst, 1);
+        optionalIO("Kcour", &Kcour, 1);
     }
 
     /*! @brief Particle fields


### PR DESCRIPTION
When initializing from a file, some attributes are now allowed to be absent and can be initialized
be the default given in `ParticlesData`.
This should make the preparation of input files a bit easier by not requiring some attributes that are typically not changed very often.