### PR TITLE
Timestep control

### DIFF
--- a/domain/include/cstone/primitives/primitives_gpu.cu
+++ b/domain/include/cstone/primitives/primitives_gpu.cu
@@ -131,6 +131,31 @@ std::tuple<T, T> MinMaxGpu<T>::operator()(const T* first, const T* last)
 template class MinMaxGpu<double>;
 template class MinMaxGpu<float>;
 
+using thrust::get;
+
+template<class T>
+struct NormSquare3D
+{
+    HOST_DEVICE_FUN T operator()(const thrust::tuple<T, T, T>& X)
+    {
+        return get<0>(X) * get<0>(X) + get<1>(X) * get<1>(X) + get<2>(X) * get<2>(X);
+    }
+};
+
+template<class T>
+T maxNormSquareGpu(const T* x, const T* y, const T* z, size_t numElements)
+{
+    auto it1 = thrust::make_zip_iterator(x, y, z);
+    auto it2 = thrust::make_zip_iterator(x + numElements, y + numElements, z + numElements);
+
+    T init = 0;
+
+    return thrust::transform_reduce(thrust::device, it1, it2, NormSquare3D<T>{}, init, thrust::maximum<T>{});
+}
+
+template float maxNormSquareGpu(const float*, const float*, const float*, size_t);
+template double maxNormSquareGpu(const double*, const double*, const double*, size_t);
+
 template<class T>
 size_t lowerBoundGpu(const T* first, const T* last, T value)
 {

--- a/domain/include/cstone/primitives/primitives_gpu.h
+++ b/domain/include/cstone/primitives/primitives_gpu.h
@@ -52,6 +52,9 @@ struct MinMaxGpu
 };
 
 template<class T>
+T maxNormSquareGpu(const T* x, const T* y, const T* z, size_t numElements);
+
+template<class T>
 extern size_t lowerBoundGpu(const T* first, const T* last, T value);
 
 template<class T, class IndexType>

--- a/main/src/init/factory.hpp
+++ b/main/src/init/factory.hpp
@@ -95,7 +95,7 @@ std::unique_ptr<ISimInitializer<Dataset>> initializerFactory(std::string testCas
     if (testCase == "nbody")
     {
         if (glassBlock.empty()) { throw std::runtime_error("need a valid glass block for nbody\n"); }
-        return std::make_unique<SedovGlass<Dataset>>(glassBlock);
+        return std::make_unique<EvrardGlassSphere<Dataset>>(glassBlock);
     }
     if (testCase == "turbulence")
     {

--- a/main/src/observables/conserved_gpu.cu
+++ b/main/src/observables/conserved_gpu.cu
@@ -59,8 +59,7 @@ struct EMom
      * @return    Tuple<kinetic energy, internal energy, linear momentum, angular momentum>
      */
     HOST_DEVICE_FUN
-    thrust::tuple<double, Vec3<double>, Vec3<double>>
-    operator()(const thrust::tuple<Tc, Tc, Tc, Tm, Tv, Tv, Tv>& p)
+    thrust::tuple<double, Vec3<double>, Vec3<double>> operator()(const thrust::tuple<Tc, Tc, Tc, Tm, Tv, Tv, Tv>& p)
     {
         Vec3<double> X{get<0>(p), get<1>(p), get<2>(p)};
         Vec3<double> V{get<4>(p), get<5>(p), get<6>(p)};

--- a/main/src/observables/factory.hpp
+++ b/main/src/observables/factory.hpp
@@ -137,9 +137,6 @@ std::unique_ptr<IObservables<Dataset>> observablesFactory(const std::string& tes
 #endif
 
     if (testCase == "turbulence") { return std::make_unique<TurbulenceMachRMS<Dataset>>(constantsFile); }
-
-    if (testCase == "nbody") { return std::make_unique<IObservables<Dataset>>(); }
-
     if (testCase == "kelvin-helmholtz") { return std::make_unique<TimeEnergyGrowth<Dataset>>(constantsFile); }
 
     return std::make_unique<TimeAndEnergy<Dataset>>(constantsFile);

--- a/main/src/propagator/nbody.hpp
+++ b/main/src/propagator/nbody.hpp
@@ -143,7 +143,7 @@ public:
                       << stats[3] << std::endl;
         }
 
-        d.minDt_loc = INFINITY;
+        d.minDtCourant = INFINITY;
         computeTimestep(first, last, d);
         computePositions(first, last, d, domain.box());
         timer.step("UpdateQuantities");

--- a/main/src/propagator/std_hydro.hpp
+++ b/main/src/propagator/std_hydro.hpp
@@ -165,7 +165,7 @@ public:
             timer.step("Gravity");
         }
 
-        computeTimestep(d);
+        computeTimestep(first, last, d);
         timer.step("Timestep");
         computePositions(first, last, d, domain.box());
         timer.step("UpdateQuantities");

--- a/main/src/propagator/std_hydro_grackle.hpp
+++ b/main/src/propagator/std_hydro_grackle.hpp
@@ -190,7 +190,7 @@ public:
             timer.step("Gravity");
         }
 
-        computeTimestep(d);
+        computeTimestep(first, last, d);
         timer.step("Timestep");
 
 #pragma omp parallel for schedule(static)

--- a/main/src/propagator/turb_ve.hpp
+++ b/main/src/propagator/turb_ve.hpp
@@ -76,7 +76,7 @@ public:
         size_t first = domain.startIndex();
         size_t last  = domain.endIndex();
 
-        computeTimestep(d);
+        computeTimestep(first, last, d);
         timer.step("Timestep");
         driveTurbulence(first, last, d, turbulenceData);
         timer.step("Turbulence Stirring");

--- a/main/src/propagator/ve_hydro.hpp
+++ b/main/src/propagator/ve_hydro.hpp
@@ -170,6 +170,7 @@ public:
         d.acquire("divv", "curlv");
         d.devData.acquire("divv", "curlv");
         computeIadDivvCurlv(first, last, d, domain.box());
+        d.minDtRho = rhoTimestep(first, last, d);
         timer.step("IadVelocityDivCurl");
 
         domain.exchangeHalos(get<"c11", "c12", "c13", "c22", "c23", "c33", "divv">(d), get<"az">(d), get<"du">(d));

--- a/main/src/propagator/ve_hydro.hpp
+++ b/main/src/propagator/ve_hydro.hpp
@@ -209,7 +209,7 @@ public:
         size_t first = domain.startIndex();
         size_t last  = domain.endIndex();
 
-        computeTimestep(d);
+        computeTimestep(first, last, d);
         timer.step("Timestep");
         computePositions(first, last, d, domain.box());
         timer.step("UpdateQuantities");

--- a/sph/include/sph/hydro_std/momentum_energy.hpp
+++ b/sph/include/sph/hydro_std/momentum_energy.hpp
@@ -91,7 +91,7 @@ void computeMomentumEnergyStdImpl(size_t startIndex, size_t endIndex, Dataset& d
         minDt  = std::min(minDt, dt_i);
     }
 
-    d.minDt_loc = minDt;
+    d.minDtCourant = minDt;
 }
 
 template<class T, class Dataset>

--- a/sph/include/sph/hydro_std/momentum_energy_gpu.cu
+++ b/sph/include/sph/hydro_std/momentum_energy_gpu.cu
@@ -135,7 +135,7 @@ void computeMomentumEnergyStdGpu(size_t startIndex, size_t endIndex, Dataset& d,
 
     float minDt;
     checkGpuErrors(cudaMemcpyFromSymbol(&minDt, minDt_device, sizeof(minDt)));
-    d.minDt_loc = minDt;
+    d.minDtCourant = minDt;
 }
 
 template void computeMomentumEnergyStdGpu(size_t, size_t, sphexa::ParticlesData<double, unsigned, cstone::GpuTag>& d,

--- a/sph/include/sph/hydro_ve/momentum_energy.hpp
+++ b/sph/include/sph/hydro_ve/momentum_energy.hpp
@@ -104,7 +104,7 @@ void computeMomentumEnergyImpl(size_t startIndex, size_t endIndex, Dataset& d, c
         minDt  = std::min(minDt, dt_i);
     }
 
-    d.minDt_loc = minDt;
+    d.minDtCourant = minDt;
 }
 
 template<bool avClean, class T, class Dataset>

--- a/sph/include/sph/hydro_ve/momentum_energy_gpu.cu
+++ b/sph/include/sph/hydro_ve/momentum_energy_gpu.cu
@@ -142,7 +142,7 @@ void computeMomentumEnergy(size_t startIndex, size_t endIndex, Dataset& d,
 
     float minDt;
     checkGpuErrors(cudaMemcpyFromSymbol(&minDt, minDt_ve_device, sizeof(minDt)));
-    d.minDt_loc = minDt;
+    d.minDtCourant = minDt;
 }
 
 #define MOM_ENERGY(avc, real, key)                                                                                     \

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -92,8 +92,11 @@ public:
 
     //! current and previous (global) time-steps
     T minDt, minDt_m1;
-    //! temporary MPI rank local timestep;
-    T minDt_loc;
+
+    //! temporary MPI rank local timesteps;
+    T minDtCourant;
+    //! @brief Fraction of Courant condition for timestep
+    T Kcour{0.2};
 
     //! @brief gravitational constant
     T g{0.0};
@@ -107,9 +110,6 @@ public:
 
     //! @brief mean molecular weight of ions for models that use one value for all particles
     T muiConst{10.0};
-
-    //! @brief Fraction of Courant condition for timestep
-    T Kcour{0.2};
 
     template<class Archive>
     void loadOrStoreAttributes(Archive* ar)

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -94,9 +94,11 @@ public:
     T minDt, minDt_m1;
 
     //! temporary MPI rank local timesteps;
-    T minDtCourant;
+    T minDtCourant{INFINITY}, minDtRho{INFINITY};
     //! @brief Fraction of Courant condition for timestep
     T Kcour{0.2};
+    //! @brief Fraction of 1/|divv| condition for timestep
+    T Krho{0.06};
 
     //! @brief gravitational constant
     T g{0.0};
@@ -135,12 +137,13 @@ public:
         ar->stepAttribute("time", &ttot, 1);
         ar->stepAttribute("minDt", &minDt, 1);
         ar->stepAttribute("minDt_m1", &minDt_m1, 1);
+        optionalIO("Kcour", &Kcour, 1);
+        optionalIO("Krho", &Krho, 1);
         ar->stepAttribute("gravConstant", &g, 1);
         optionalIO("gamma", &gamma, 1);
         optionalIO("eps", &eps, 1);
         optionalIO("etaAcc", &etaAcc, 1);
         optionalIO("muiConst", &muiConst, 1);
-        optionalIO("Kcour", &Kcour, 1);
     }
 
     /*! @brief Particle fields

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -97,6 +97,10 @@ public:
 
     //! @brief gravitational constant
     T g{0.0};
+    //! @brief gravitational smoothing
+    T eps{0.005};
+    //! @brief acceleration based time-step control
+    T etaAcc{0.2};
 
     //! @brief adiabatic index
     T gamma{5.0 / 3.0};
@@ -133,6 +137,8 @@ public:
         ar->stepAttribute("minDt_m1", &minDt_m1, 1);
         ar->stepAttribute("gravConstant", &g, 1);
         optionalIO("gamma", &gamma, 1);
+        optionalIO("eps", &eps, 1);
+        optionalIO("etaAcc", &etaAcc, 1);
         optionalIO("muiConst", &muiConst, 1);
         optionalIO("Kcour", &Kcour, 1);
     }

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -114,7 +114,13 @@ void computePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const 
         util::tie(d.x[i], d.y[i], d.z[i])          = util::tie(X[0], X[1], X[2]);
         util::tie(d.x_m1[i], d.y_m1[i], d.z_m1[i]) = util::tie(X_m1[0], X_m1[1], X_m1[2]);
         util::tie(d.vx[i], d.vy[i], d.vz[i])       = util::tie(V[0], V[1], V[2]);
+    }
 
+    if (d.temp.empty()) { return; }
+
+#pragma omp parallel for schedule(static)
+    for (size_t i = startIndex; i < endIndex; i++)
+    {
         T cv       = haveMui ? idealGasCv(d.mui[i], d.gamma) : constCv;
         T u_old    = cv * d.temp[i];
         d.temp[i]  = energyUpdate(u_old, dt, dt_m1, d.du[i], d.du_m1[i]) / cv;

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -68,10 +68,13 @@ __global__ void computePositionsKernel(size_t first, size_t last, double dt, dou
     util::tie(x_m1[i], y_m1[i], z_m1[i]) = util::tie(X_m1[0], X_m1[1], X_m1[2]);
     util::tie(vx[i], vy[i], vz[i])       = util::tie(V[0], V[1], V[2]);
 
-    Thydro cv    = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
-    auto   u_old = temp[i] * cv;
-    temp[i]      = energyUpdate(u_old, dt, dt_m1, du[i], du_m1[i]) / cv;
-    du_m1[i]     = du[i];
+    if (temp != nullptr)
+    {
+        Thydro cv    = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
+        auto   u_old = temp[i] * cv;
+        temp[i]      = energyUpdate(u_old, dt, dt_m1, du[i], du_m1[i]) / cv;
+        du_m1[i]     = du[i];
+    }
 }
 
 template<class Tc, class Tv, class Ta, class Tm1, class Tt, class Thydro>


### PR DESCRIPTION
* When gravity is active: limit time-steps based on particle accelerations
* Enabled time-step integration for the nbody propagator which can now be used for a gravity-only simulation
* VE-propagator: limit time-steps also based on the divergence of velocity