### PR TITLE
Consistent initial SFC ranges for all test cases and substep timing plot script

### DIFF
--- a/main/src/init/evrard_init.hpp
+++ b/main/src/init/evrard_init.hpp
@@ -143,11 +143,7 @@ public:
 
         cstone::Box<T> globalBox(-r, r, cstone::BoundaryType::open);
 
-        unsigned level             = cstone::log8ceil<KeyType>(100 * numRanks);
-        auto     initialBoundaries = cstone::initialDomainSplits<KeyType>(numRanks, level);
-        KeyType  keyStart          = initialBoundaries[rank];
-        KeyType  keyEnd            = initialBoundaries[rank + 1];
-
+        auto [keyStart, keyEnd] = equiDistantSfcSegments<KeyType>(rank, numRanks, 100);
         assembleCuboid<T>(keyStart, keyEnd, globalBox, multiplicity, xBlock, yBlock, zBlock, d.x, d.y, d.z);
         cutSphere(r, d.x, d.y, d.z);
 

--- a/main/src/init/grid.hpp
+++ b/main/src/init/grid.hpp
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include "cstone/domain/domaindecomp.hpp"
 #include "cstone/sfc/box.hpp"
 #include "cstone/sfc/sfc.hpp"
 #include "cstone/util/array.hpp"
@@ -62,6 +63,28 @@ inline auto partitionRange(size_t R, size_t i, size_t N)
         size_t end   = start + s;
         return std::make_tuple(start, end);
     }
+}
+
+/*! @brief Returns a unique SFC segment for each rank
+ *
+ * @tparam KeyType
+ * @param  rank              executing rank id
+ * @param  numRanks          total number of ranks
+ * @param  numLeavesPerRank  desired number of leaves per rank in the global tree
+ * @return                   tuple with start end end keys of the segment
+ *
+ * The desired number of leaves per rank in the global tree determines the minium level of the global
+ * tree. Each segment will be rounded to the closest leaf node of that level so as to avoid segments
+ * that need a very deep tree to resolve the segment boundaries.
+ */
+template<class KeyType>
+auto equiDistantSfcSegments(int rank, int numRanks, cstone::TreeNodeIndex numLeavesPerRank)
+{
+    unsigned level             = cstone::log8ceil<KeyType>(numLeavesPerRank * numRanks);
+    auto     initialBoundaries = cstone::initialDomainSplits<KeyType>(numRanks, level);
+    KeyType  keyStart          = initialBoundaries[rank];
+    KeyType  keyEnd            = initialBoundaries[rank + 1];
+    return std::make_tuple(keyStart, keyEnd);
 }
 
 /*! @brief create regular cubic grid centered on (0,0,0), spanning [-r, r)^3, in the x,y,z arrays

--- a/main/src/init/isobaric_cube_init.hpp
+++ b/main/src/init/isobaric_cube_init.hpp
@@ -259,7 +259,7 @@ public:
         d.numParticlesGlobal           = multi1D * multi1D * multi1D * blockSize;
 
         cstone::Box<T> globalBox(-2 * r, 2 * r, cstone::BoundaryType::periodic);
-        auto [keyStart, keyEnd] = partitionRange(cstone::nodeRange<KeyType>(0), rank, numRanks);
+        auto [keyStart, keyEnd] = equiDistantSfcSegments<KeyType>(rank, numRanks, 100);
         assembleCuboid<T>(keyStart, keyEnd, globalBox, multiplicity, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
         T s = computeStretchFactor(r, 2 * r, rhoInt / rhoExt);

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -71,6 +71,8 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
     std::fill(d.alpha.begin(), d.alpha.end(), d.alphamax);
     std::fill(d.vz.begin(), d.vz.end(), 0.0);
 
+    d.gamma    = constants.at("gamma");
+    d.Kcour    = constants.at("Kcour");
     d.minDt    = firstTimeStep;
     d.minDt_m1 = firstTimeStep;
 
@@ -104,8 +106,8 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
 
 std::map<std::string, double> KelvinHelmholtzConstants()
 {
-    return {{"rhoInt", 2.},     {"rhoExt", 1.},          {"vxExt", 0.5}, {"vxInt", -0.5},
-            {"gamma", 5. / 3.}, {"firstTimeStep", 1e-7}, {"p", 2.5},     {"omega0", 0.01}};
+    return {{"rhoInt", 2.},          {"rhoExt", 1.}, {"vxExt", 0.5},   {"vxInt", -0.5}, {"gamma", 5. / 3.},
+            {"firstTimeStep", 1e-7}, {"p", 2.5},     {"omega0", 0.01}, {"Kcour", 0.4}};
 }
 
 template<class Dataset>
@@ -134,7 +136,7 @@ public:
         sortBySfcKey<KeyType>(xBlock, yBlock, zBlock);
 
         cstone::Box<T> globalBox(0, 1, 0, 1, 0, 0.0625, pbc, pbc, pbc);
-        auto [keyStart, keyEnd] = partitionRange(cstone::nodeRange<KeyType>(0), rank, numRanks);
+        auto [keyStart, keyEnd] = equiDistantSfcSegments<KeyType>(rank, numRanks, 100);
 
         int               multi1D    = std::rint(cbrtNumPart / std::cbrt(xBlock.size()));
         cstone::Vec3<int> innerMulti = {16 * multi1D, 8 * multi1D, multi1D};

--- a/main/src/init/noh_init.hpp
+++ b/main/src/init/noh_init.hpp
@@ -153,7 +153,7 @@ public:
         T              r = constants_.at("r1");
         cstone::Box<T> globalBox(-r, r, cstone::BoundaryType::open);
 
-        auto [keyStart, keyEnd] = partitionRange(cstone::nodeRange<KeyType>(0), rank, numRanks);
+        auto [keyStart, keyEnd] = equiDistantSfcSegments<KeyType>(rank, numRanks, 100);
         assembleCuboid<T>(keyStart, keyEnd, globalBox, multiplicity, xBlock, yBlock, zBlock, d.x, d.y, d.z);
         cutSphere(r, d.x, d.y, d.z);
 

--- a/main/src/init/sedov_init.hpp
+++ b/main/src/init/sedov_init.hpp
@@ -173,11 +173,7 @@ public:
         T              r = constants_.at("r1");
         cstone::Box<T> globalBox(-r, r, cstone::BoundaryType::periodic);
 
-        unsigned level             = cstone::log8ceil<KeyType>(100 * numRanks);
-        auto     initialBoundaries = cstone::initialDomainSplits<KeyType>(numRanks, level);
-        KeyType  keyStart          = initialBoundaries[rank];
-        KeyType  keyEnd            = initialBoundaries[rank + 1];
-
+        auto [keyStart, keyEnd] = equiDistantSfcSegments<KeyType>(rank, numRanks, 100);
         assembleCuboid<T>(keyStart, keyEnd, globalBox, multiplicity, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
         d.resize(d.x.size());

--- a/main/src/init/turbulence_init.hpp
+++ b/main/src/init/turbulence_init.hpp
@@ -116,11 +116,7 @@ public:
 
         cstone::Box<T> globalBox(-0.5, 0.5, cstone::BoundaryType::periodic);
 
-        unsigned level             = cstone::log8ceil<KeyType>(100 * numRanks);
-        auto     initialBoundaries = cstone::initialDomainSplits<KeyType>(numRanks, level);
-        KeyType  keyStart          = initialBoundaries[rank];
-        KeyType  keyEnd            = initialBoundaries[rank + 1];
-
+        auto [keyStart, keyEnd] = equiDistantSfcSegments<KeyType>(rank, numRanks, 100);
         assembleCuboid<T>(keyStart, keyEnd, globalBox, multiplicity, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
         d.resize(d.x.size());

--- a/main/src/init/wind_shock_init.hpp
+++ b/main/src/init/wind_shock_init.hpp
@@ -176,13 +176,13 @@ public:
         fileutils::readTemplateBlock(glassBlock, xBlock, yBlock, zBlock);
         size_t blockSize = xBlock.size();
 
-        int               multi1D      = std::rint(cbrtNumPart / std::cbrt(blockSize));
+        int               multi1D          = std::rint(cbrtNumPart / std::cbrt(blockSize));
         cstone::Vec3<int> surroundingMulti = {4 * multi1D, multi1D, multi1D};
 
         auto           pbc = cstone::BoundaryType::periodic;
         cstone::Box<T> globalBox(0, 8 * r, 0, 2 * r, 0, 2 * r, pbc, pbc, pbc);
 
-        auto [keyStart, keyEnd] = partitionRange(cstone::nodeRange<KeyType>(0), rank, numRanks);
+        auto [keyStart, keyEnd] = equiDistantSfcSegments<KeyType>(rank, numRanks, 100);
         assembleCuboid<T>(keyStart, keyEnd, globalBox, surroundingMulti, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
         auto cutSphereOut = [r, rSphere](auto x, auto y, auto z)
@@ -196,8 +196,8 @@ public:
 
         // create the high-density blob
         cstone::Vec3<int> blobMulti = {multi1D, multi1D, multi1D};
-        std::vector<T> xBlob, yBlob, zBlob;
-        cstone::Box<T> boxS(r - blobMultiplier * rSphere, r + blobMultiplier * rSphere);
+        std::vector<T>    xBlob, yBlob, zBlob;
+        cstone::Box<T>    boxS(r - blobMultiplier * rSphere, r + blobMultiplier * rSphere);
         assembleCuboid<T>(keyStart, keyEnd, boxS, blobMulti, xBlock, yBlock, zBlock, xBlob, yBlob, zBlob);
         auto keepSphere = [r, rSphere](auto x, auto y, auto z)
         {

--- a/scripts/substep_timings.py
+++ b/scripts/substep_timings.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+"""Plot timings of time-step components as stacked bars
+
+This script takes an output file of an SPH-EXA simulation and plots
+one bar for each time step. Each bar consists of stacked bars for the
+substeps of time step, such as domain::sync, halo exchange, SPH, gravity, ...
+
+Parameters to tweak: range for rolling averages and maximum step number to plot
+
+Author: Sebastian Keller, <sebastian.f.keller@gmail.com>
+"""
+
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+clrs = ['darkred',     # domain-sync, 
+        #'yellow',      # FindNeighbors, 
+        'grey',        # XMass, 
+        'red',         # syncHalos, 
+        'purple',      # Norm&Grad, 
+        #'green',       # EOS, 
+        'red',         # syncHalos, 
+        'lime',        # IAD, 
+        'red',         # syncHalos,
+        'olivedrab',   # AVSwitches, 
+        'red',         # syncHalos, 
+        'forestgreen', # momentumEnergy 
+        'navy',        # Upsweep,
+        'black',       # Gravity,
+        'firebrick',   # Timestep,
+        #'gold',        # updateQuantities, 
+        #'chocolate',   # updateSmoothingLength
+        #'lightblue'    # TotalTimestep 
+        ]
+
+def extractValue(linestring, qname):
+    i1 = linestring.find(qname)
+    if i1 > -1:
+        i2 = linestring.find(" ", i1 + len(qname))
+        return float(linestring[i2:].split()[0].strip('s').strip(','))
+    else:
+        return None
+
+def extractQuantity(lines, qname):
+    return np.array([ extractValue(l, qname) for l in lines if extractValue(l, qname) is not None ])
+
+
+def extractFromFile(fname, quantities):
+    lines = open(fname, 'r').readlines()
+    results = {}
+    for qname in quantities:
+        dataset = extractQuantity(lines, qname)
+        if qname == "synchronizeHalos":
+            mult = 4
+            syncHalos = dataset.reshape(mult, int(dataset.shape[0] / mult + 0.5))
+            for i in range(mult):
+                results[qname + str(i)] = syncHalos[i,:]
+        else:
+            results[qname] = dataset
+
+    return results
+
+def rollingAverage(dataset, numAvg):
+    kernel = np.ones(numAvg) / numAvg
+    return np.convolve(dataset, kernel, mode="valid")
+
+def plot(data, quantities):
+
+    fig, ax = plt.subplots(figsize=(10,7.5))
+
+    xdata  = np.arange(len(data[quantities[0]]))
+    bottom = np.zeros(len(xdata))
+
+    for i,q in enumerate(quantities):
+        plt.bar(xdata, data[q], bottom=bottom, width=1.0, label=q, color=clrs[i])
+        bottom += data[q]
+
+    ax.legend(loc = "upper center", ncol=5)
+    plt.show()
+
+if __name__ == "__main__":
+    fname      = sys.argv[1]
+    quantities = ["domain::sync", "XMass", "synchronizeHalos", "Gradh", "IadVelocityDivCurl",
+                  "AVswitches", "MomentumAndEnergy", "Upsweep", "Gravity", "Timestep"]
+    plotOrder = ["domain::sync", "XMass", "synchronizeHalos0", "Gradh", "synchronizeHalos1", "IadVelocityDivCurl",
+                  "synchronizeHalos2", "AVswitches", "synchronizeHalos3", "MomentumAndEnergy", "Upsweep", "Gravity", "Timestep"]
+
+    results = extractFromFile(fname, quantities)
+
+    # rolling average range in steps
+    numSmooth = 5
+    # maximum time step to include in the plot
+    maxPlotStep = len(results["domain::sync"])
+
+    resultsSmoothed = {}
+    for k,v in results.items():
+        print(k, v.shape)
+        resultsSmoothed[k] = rollingAverage(v, numSmooth)[:maxPlotStep]
+
+    plot(resultsSmoothed, plotOrder)

--- a/sph/include/sph/hydro_ve/momentum_energy_kern.hpp
+++ b/sph/include/sph/hydro_ve/momentum_energy_kern.hpp
@@ -105,7 +105,7 @@ momentumAndEnergyJLoop(cstone::LocalIndex i, T sincIndex, T K, const cstone::Box
     auto c23i = c23[i];
     auto c33i = c33[i];
 
-    util::array<T, 6> gradV_i;
+    [[maybe_unused]] util::array<T, 6> gradV_i;
     if constexpr (avClean) { gradV_i = {dV11[i], dV12[i], dV13[i], dV22[i], dV23[i], dV33[i]}; }
 
     // +1 is because we need to add selfparticle to neighborsCount


### PR DESCRIPTION
* Sneak in a maybe_unused attribute in momentum_energy_kern.hpp to silence a compiler warning.
* Set Kcour = 0.4 for Kelvin-Helmholtz
* add substep timing plot script
* Set the initial SFC range for all test cases with the same function `equiDistantantSfcRange` that is better than `partitionRange` used everywhere except for sedov, turbulence and evrard.