### PR TITLE
Build octrees based on continuum particle distributions

### DIFF
--- a/domain/include/cstone/tree/continuum.hpp
+++ b/domain/include/cstone/tree/continuum.hpp
@@ -1,0 +1,117 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 CSCS, ETH Zurich, University of Basel, University of Zurich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief Generation of octrees in cornerstone format based on particle concentration functions
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#pragma once
+
+#include "cstone/sfc/box.hpp"
+#include "cstone/sfc/sfc.hpp"
+#include "cstone/tree/csarray.hpp"
+
+namespace cstone
+{
+
+//! @brief estimate particle count of the given node based on the concentration continuum and node volume
+template<class KeyType, class T, class F>
+HOST_DEVICE_FUN unsigned continuumCount(KeyType nodeStart, KeyType nodeEnd, const Box<T>& box, F&& concentration)
+{
+    IBox nodeBox        = sfcIBox(sfcKey(nodeStart), sfcKey(nodeEnd));
+    auto [center, size] = centerAndSize<KeyType>(nodeBox, box);
+
+    T volume = size[0] * size[1] * size[2];
+
+    double count = 0;
+    for (int ix = -1; ix <= 1; ix += 2)
+        for (int iy = -1; iy <= 1; iy += 2)
+            for (int iz = -1; iz <= 1; iz += 2)
+            {
+                auto corner = center + 0.5 * Vec3<T>{ix * size[0], iy * size[1], iz * size[2]};
+                T c         = concentration(corner[0], corner[1], corner[2]);
+                count += c * volume;
+            }
+
+    return stl::min(unsigned(std::round(count)), std::numeric_limits<unsigned>::max());
+}
+
+template<class KeyType, class T, class F>
+void computeContinuumCounts(
+    const KeyType* tree, unsigned* counts, TreeNodeIndex numNodes, const Box<T>& box, F&& concentration)
+{
+#pragma ompe parallel for schedule(static)
+    for (TreeNodeIndex i = 0; i < numNodes; ++i)
+    {
+        counts[i] = continuumCount(tree[i], tree[i + 1], box, concentration);
+    }
+}
+
+template<class F, class T, class KeyType>
+bool updateContinuumCsarray(F&& concentration,
+                            const Box<T>& box,
+                            unsigned bucketSize,
+                            std::vector<KeyType>& tree,
+                            std::vector<unsigned>& counts)
+{
+    std::vector<TreeNodeIndex> nodeOps(nNodes(tree) + 1);
+    bool converged = rebalanceDecision(tree.data(), counts.data(), nNodes(tree), bucketSize, nodeOps.data());
+
+    std::vector<KeyType> newTree;
+    rebalanceTree(tree, newTree, nodeOps.data());
+    swap(tree, newTree);
+
+    counts.resize(nNodes(tree));
+    computeContinuumCounts(tree.data(), counts.data(), nNodes(tree), box, concentration);
+
+    return converged;
+}
+
+/*! @brief Build an a cornerstone array based on continuum particle concentration
+ *
+ * @tparam KeyType         32- or 64-bit unsigned integer
+ * @tparam F               functor object
+ * @tparam T               float or double
+ * @param concentration    concentration function mapping (x,y,z) in @p box to a particle concentration
+ * @param box              global coordinate bounding box
+ * @param bucketSize       max number of particles per (leaf) node
+ * @return                 tuple(csarray, counts)
+ */
+template<class KeyType, class F, class T>
+std::tuple<std::vector<KeyType>, std::vector<unsigned>>
+computeContinuumCsarray(F&& concentration, const Box<T>& box, unsigned bucketSize)
+{
+    std::vector<KeyType> tree{0, nodeRange<KeyType>(0)};
+    std::vector<unsigned> counts{bucketSize + 1};
+
+    int maxIteration = 10;
+    while (!updateContinuumCsarray(concentration, box, bucketSize, tree, counts) && maxIteration--)
+        ;
+
+    return std::make_tuple(std::move(tree), std::move(counts));
+}
+
+} // namespace cstone

--- a/domain/test/unit/CMakeLists.txt
+++ b/domain/test/unit/CMakeLists.txt
@@ -22,6 +22,7 @@ set(UNIT_TESTS
         traversal/traversal.cpp
         tree/btree.cpp
         tree/csarray.cpp
+        tree/continuum.cpp
         tree/octree.cpp
         tree/cs_util.cpp
         util/array.cpp

--- a/domain/test/unit/sfc/box.cpp
+++ b/domain/test/unit/sfc/box.cpp
@@ -103,3 +103,36 @@ TEST(SfcBox, putInBox)
         EXPECT_NEAR(Xpbc[2], -0.9, 1e-10);
     }
 }
+
+TEST(SfcBox, createIBox)
+{
+    {
+        using T                = double;
+        using KeyType          = uint32_t;
+        constexpr int maxCoord = 1u << maxTreeLevel<KeyType>{};
+
+        Box<T> box(0, 1);
+
+        T r = T(1.0) / maxCoord;
+        T c = 1.0 - 0.5 * r;
+        T s = 0.5 * r;
+        Vec3<T> aCenter{c, c, c};
+        Vec3<T> aSize{s, s, s};
+
+        IBox probe = createIBox<KeyType>(aCenter, aSize, box);
+        IBox ref{maxCoord - 1, maxCoord};
+        EXPECT_EQ(ref, probe);
+    }
+    {
+        using T       = double;
+        using KeyType = uint64_t;
+
+        Box<T> box(-1, 1, -2, 2, -3, 3);
+        Vec3<T> aCenter{0.1, 0.2, 0.3};
+        Vec3<T> aSize{0.01, 0.02, 0.03};
+
+        IBox probe = createIBox<KeyType>(aCenter, aSize, box);
+        IBox ref{1142947, 1163920};
+        EXPECT_EQ(ref, probe);
+    }
+}

--- a/domain/test/unit/tree/continuum.cpp
+++ b/domain/test/unit/tree/continuum.cpp
@@ -1,0 +1,79 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 CSCS, ETH Zurich, University of Basel, University of Zurich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief Test continuum octree generation
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#include "gtest/gtest.h"
+
+#include "cstone/tree/continuum.hpp"
+#include "cstone/tree/cs_util.hpp"
+
+using namespace cstone;
+
+TEST(CsConcentration, concentrationCountConstant)
+{
+    using T       = double;
+    using KeyType = uint32_t;
+
+    Box<T> box(-1, 1);
+    size_t N0 = 1000;
+
+    auto constRho = [N0](T, T, T) { return T(N0) / 8.0; };
+
+    size_t count = continuumCount(KeyType(0), nodeRange<KeyType>(0), box, constRho);
+
+    EXPECT_EQ(count, N0);
+}
+
+TEST(CsConcentration, computeTreeOneOverR)
+{
+    using T       = double;
+    using KeyType = uint64_t;
+
+    unsigned bucketSize = 64;
+    Box<T> box(-1, 1);
+    T eps     = box.lx() / (1u << maxTreeLevel<KeyType>{});
+    size_t N0 = 1000000;
+
+    auto oneOverR = [N0, eps](T x, T y, T z)
+    {
+        T r = std::max(std::sqrt(norm2(Vec3<T>{x, y, z})), eps);
+        if (r > 1.0) { return 0.0; }
+        else { return T(N0) / (2 * M_PI * r); }
+    };
+
+    auto [tree, counts] = computeContinuumCsarray<KeyType>(oneOverR, box, bucketSize);
+    size_t totalCount   = std::accumulate(counts.begin(), counts.end(), 0lu);
+
+    for (auto c : counts)
+    {
+        EXPECT_LT(c, 1.5 * bucketSize);
+    }
+
+    EXPECT_NEAR(totalCount, N0, N0 * 0.03);
+}

--- a/main/src/init/grid.hpp
+++ b/main/src/init/grid.hpp
@@ -168,7 +168,6 @@ template<class T>
 cstone::Vec3<T> scaleBlockToGlobal(cstone::Vec3<T> uX, cstone::Vec3<int> gridIdx, cstone::Vec3<int> m,
                                    const cstone::Box<T>& globalBox)
 {
-
     cstone::Vec3<T> blockOrigin{gridIdx[0] * globalBox.lx() / m[0], gridIdx[1] * globalBox.ly() / m[1],
                                 gridIdx[2] * globalBox.lz() / m[2]};
     cstone::Vec3<T> globalOrigin{globalBox.xmin(), globalBox.ymin(), globalBox.zmin()};


### PR DESCRIPTION
This is useful for building initial octrees for initial conditions with known analytic particle density distributions.
For Evrard, this new functionality can accurately predict balanced SFC partitions before any particles are
created.