### PR TITLE
Particle splitting

### DIFF
--- a/.gitlab/gitlab-ci.yml
+++ b/.gitlab/gitlab-ci.yml
@@ -251,12 +251,13 @@ sph:build:cuda:sphexa:cpu:
   script:
     - echo "SLURMD_NODENAME=${SLURMD_NODENAME} SLURM_NODEID=${SLURM_NODEID} SLURM_PROCID=${SLURM_PROCID}"
     - export LD_LIBRARY_PATH=/usr/local/HDF_Group/HDF5/1.13.2/lib:$LD_LIBRARY_PATH
+    - wget --quiet ${DEPS_PATH}/in/glass.h5
     - echo "sedov:cpu"
-    - /usr/local/bin/sphexa --init sedov -s 1 -n 50
+    - /usr/local/bin/sphexa --init sedov --prop std -s 1 -n 50
     - echo "sedov+ve:cpu"
-    - /usr/local/bin/sphexa --init sedov --ve -s 1 -n 50
+    - /usr/local/bin/sphexa --init sedov --prop ve -s 1 -n 50
     - echo "noh:cpu"
-    - /usr/local/bin/sphexa --init noh -s 1 -n 50 
+    - /usr/local/bin/sphexa --init noh --glass ./glass.h5 -s 1 -n 50
   variables:
     USE_MPI: 'YES'
     SLURM_CONSTRAINT: 'gpu'
@@ -270,7 +271,7 @@ sph:build:cuda:sphexa:cpu:
 #{{{ sph:test:cuda:sphexa:gpu:
 # TODO: MPICH_RDMA_ENABLED_CUDA=1 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libcuda.so
 sph:build:cuda:sphexa:gpu:
-  needs: ['sph:pull:cuda']
+  needs: ['sph:pull:cuda' ]
   extends: .daint
   stage: SPHtest
   image: ${BUILD_CUDA}
@@ -278,16 +279,16 @@ sph:build:cuda:sphexa:gpu:
     - echo "SLURMD_NODENAME=${SLURMD_NODENAME} SLURM_NODEID=${SLURM_NODEID} SLURM_PROCID=${SLURM_PROCID}"
     - export LD_LIBRARY_PATH=/usr/local/HDF_Group/HDF5/1.13.2/lib:$LD_LIBRARY_PATH
     - ln -fs /usr/local/bin/sedov_solution .
+    - wget --quiet ${DEPS_PATH}/in/glass.h5
     - echo "# --- sedov:gpu"
-    - /usr/local/bin/sphexa-cuda --init sedov -s 200 -n 50 -w 200 --outDir /scratch/ --quiet |grep -v "Focus Tree Nodes:"
-    - python3 /usr/local/bin/compare_solutions.py -s 200 /scratch/dump_sedov.h5 > /scratch/sedov.rpt
+    - /usr/local/bin/sphexa-cuda --init sedov -s 200 -n 50 -w 200 -f x,y,z,h,m,p,rho,vx,vy,vz,temp -o /scratch/out_sedov.h5 --quiet
+    - python3 /usr/local/bin/compare_solutions.py -s 200 /scratch/out_sedov.h5 > /scratch/sedov.rpt
     #
     - echo "# --- noh:gpu"
-    - /usr/local/bin/sphexa-cuda --init noh -s 200 -n 50 -w 200 --outDir /scratch/ --quiet |grep -v "Focus Tree Nodes:"
-    - python3 /usr/local/bin/compare_noh.py -s 200 /scratch/dump_noh.h5 > /scratch/noh.rpt
+    - /usr/local/bin/sphexa-cuda --init noh --glass ./glass.h5 -s 200 -n 50 -w 200 -f x,y,z,h,m,p,rho,vx,vy,vz,temp -o /scratch/out_noh.h5 --quiet
+    - python3 /usr/local/bin/compare_noh.py -s 200 /scratch/out_noh.h5 > /scratch/noh.rpt
     - echo "# --- evrard:gpu"
-    - wget --quiet ${DEPS_PATH}/in/glass.h5
-    - /usr/local/bin/sphexa-cuda --init evrard --glass ./glass.h5 -s 10 -n 50 -w 10 --outDir /scratch/ --quiet |grep -v "Focus Tree Nodes:"
+    - /usr/local/bin/sphexa-cuda --init evrard --glass ./glass.h5 -s 10 -n 50 -w 10 --outDir /scratch/ --quiet
     - echo "# --- rpt:"
     - cat /scratch/sedov.rpt
     - cat /scratch/noh.rpt

--- a/.gitlab/rfm.py
+++ b/.gitlab/rfm.py
@@ -40,15 +40,15 @@ class analytical_solution(rfm.RunOnlyRegressionTest):
     def set_reference(self):
         reference_d = {
             'sedov': {
-                'Density':  (0.138, -0.015, 0.01, ''),
+                'Density':  (0.140, -0.015, 0.01, ''),
                 'Pressure':  (0.902, -0.01, 0.01, ''),
                 'Velocity':  (0.915, -0.01, 0.01, ''),
                 # 'Energy':  (0., -0.05, 0.05, ''),
             },
             'noh': {
-                'Density':  (0.955, -0.01, 0.01, ''),
-                'Pressure':  (0.388, -0.01, 0.01, ''),
-                'Velocity':  (0.0384, -0.05, 0.05, ''),
+                'Density':  (5.0, -0.01, 0.01, ''),
+                'Pressure':  (1.01, -0.01, 0.01, ''),
+                'Velocity':  (0.07, -0.05, 0.05, ''),
                 # 'Energy':  (0.029, -0.05, 0.05, ''),
             },
         }

--- a/main/src/init/factory.hpp
+++ b/main/src/init/factory.hpp
@@ -111,6 +111,11 @@ std::unique_ptr<ISimInitializer<Dataset>> initializerFactory(std::string testCas
 #endif
     if (std::filesystem::exists(testCase)) { return std::make_unique<FileInit<Dataset>>(testCase); }
 
+    if (std::filesystem::exists(strBeforeSign(testCase, ",")))
+    {
+        return std::make_unique<FileSplitInit<Dataset>>(testCase);
+    }
+
 #endif
 
     throw std::runtime_error("supplied value of --init " +

--- a/main/src/init/factory.hpp
+++ b/main/src/init/factory.hpp
@@ -64,19 +64,17 @@ std::unique_ptr<ISimInitializer<Dataset>> initializerFactory(std::string testCas
         else { return std::make_unique<SedovGlass<Dataset>>(glassBlock); }
 #endif
     }
-    if (testCase == "noh")
-    {
-        if (glassBlock.empty()) { return std::make_unique<NohGrid<Dataset>>(); }
-#ifdef SPH_EXA_HAVE_H5PART
-        else { return std::make_unique<NohGlassSphere<Dataset>>(glassBlock); }
-#endif
-    }
 
     std::string hdf5_missing = "without HDF5 support";
 
 #ifdef SPH_EXA_HAVE_H5PART
     hdf5_missing = "";
 
+    if (testCase == "noh")
+    {
+        if (glassBlock.empty()) { throw std::runtime_error("need a valid glass block for Noh implosion\n"); }
+        return std::make_unique<NohGlassSphere<Dataset>>(glassBlock);
+    }
     if (testCase == "isobaric-cube")
     {
         if (glassBlock.empty()) { throw std::runtime_error("need a valid glass block for isobaric cube\n"); }
@@ -109,7 +107,7 @@ std::unique_ptr<ISimInitializer<Dataset>> initializerFactory(std::string testCas
         return std::make_unique<EvrardGlassSphereCooling<Dataset>>(glassBlock);
     }
 #endif
-    if (std::filesystem::exists(testCase)) { return std::make_unique<FileInit<Dataset>>(testCase); }
+    if (std::filesystem::exists(strBeforeSign(testCase, ":"))) { return std::make_unique<FileInit<Dataset>>(testCase); }
 
     if (std::filesystem::exists(strBeforeSign(testCase, ",")))
     {

--- a/main/src/init/file_init.hpp
+++ b/main/src/init/file_init.hpp
@@ -32,9 +32,11 @@
 #pragma once
 
 #include <map>
+#include <random>
 
 #include "cstone/sfc/box.hpp"
 
+#include "io/arg_parser.hpp"
 #include "io/factory.hpp"
 #include "isim_init.hpp"
 
@@ -80,7 +82,7 @@ class FileInit : public ISimInitializer<Dataset>
 
 public:
     FileInit(std::string fname)
-        : h5_fname(fname)
+        : h5_fname(std::move(fname))
     {
     }
 
@@ -97,7 +99,143 @@ public:
         return box;
     }
 
-    const std::map<std::string, double>& constants() const override { return constants_; }
+    [[nodiscard]] const std::map<std::string, double>& constants() const override { return constants_; }
+};
+
+template<class Dataset>
+class FileSplitInit : public ISimInitializer<Dataset>
+{
+    std::map<std::string, double> constants_;
+    std::string                   h5_fname;
+
+    int numSplits;
+
+public:
+    FileSplitInit(const std::string& fname)
+        : h5_fname(strBeforeSign(fname, ",")), numSplits(numberAfterSign(fname, ","))
+    {
+    }
+
+    cstone::Box<typename Dataset::RealType> init(int rank, int /*nrank*/, size_t /*n*/, Dataset& simData) const override
+    {
+        std::unique_ptr<IFileReader> reader;
+        reader = std::make_unique<H5PartReader>(simData.comm);
+        reader->setStep(h5_fname, -1);
+
+        size_t numParticlesInFile = reader->localNumParticles();
+        size_t numParticlesSplit  = numParticlesInFile * numSplits;
+
+        using T = typename Dataset::RealType;
+        cstone::Box<T> box(0, 1);
+        box.loadOrStore(reader.get());
+
+        auto& d = simData.hydro;
+        d.loadOrStoreAttributes(reader.get());
+
+        d.numParticlesGlobal = reader->globalNumParticles() * numSplits;
+        d.iteration = 1;
+        d.ttot = 0.0;
+        d.minDt /= (100 * numSplits);
+        d.minDt_m1 /= (100 * numSplits);
+
+        d.x.resize(numParticlesSplit);
+        d.y.resize(numParticlesSplit);
+        d.z.resize(numParticlesSplit);
+        d.h.resize(numParticlesSplit);
+        {
+            std::vector<T> x0(numParticlesInFile), y0(numParticlesInFile), z0(numParticlesInFile),
+                h0(numParticlesInFile);
+            reader->readField("x", x0.data());
+            reader->readField("y", y0.data());
+            reader->readField("z", z0.data());
+            reader->readField("h", h0.data());
+
+#pragma omp parallel
+            {
+                std::mt19937 eng(rank);
+                std::uniform_real_distribution<T> rng(0, 1);
+
+                auto ballPoint = [&rng, &eng]()
+                {
+                    cstone::Vec3<T> X;
+                    do
+                    {
+                        X = cstone::Vec3<T>{rng(eng), rng(eng), rng(eng)};
+                    } while (norm2(X) > T(1));
+
+                    return X;
+                };
+
+                T hScale = T(1) / std::cbrt(numSplits);
+
+#pragma omp for schedule(static)
+                for (size_t i = 0; i < numParticlesInFile; ++i)
+                {
+                    size_t sIdx = numSplits * i;
+                    T      hi   = h0[i];
+
+                    d.x[sIdx] = x0[i];
+                    d.y[sIdx] = y0[i];
+                    d.z[sIdx] = z0[i];
+                    d.h[sIdx] = hi * hScale;
+
+                    for (size_t j = 1; j < numSplits; ++j)
+                    {
+                        // a random point within a unit sphere
+                        auto displacement = ballPoint();
+
+                        d.x[sIdx + j] = x0[i] + hi * displacement[0];
+                        d.y[sIdx + j] = y0[i] + hi * displacement[1];
+                        d.z[sIdx + j] = z0[i] + hi * displacement[2];
+                        d.h[sIdx + j] = hi * hScale;
+                    }
+                }
+            }
+        }
+
+        auto replicateField = [numParticlesInFile, numParticlesSplit, this](IFileReader* reader, const std::string& key,
+                                                                            auto& dest, T scale)
+        {
+            std::vector<T> src(numParticlesInFile);
+            reader->readField(key, src.data());
+            dest.resize(numParticlesSplit);
+#pragma omp parallel for schedule(static)
+            for (size_t i = 0; i < numParticlesInFile; ++i)
+            {
+                size_t sIdx = numSplits * i;
+                std::fill(dest.data() + sIdx, dest.data() + sIdx + numSplits, src[i] * scale);
+            }
+        };
+
+        d.resize(numParticlesSplit);
+        replicateField(reader.get(), "m", d.m, T(1) / numSplits);
+        replicateField(reader.get(), "vx", d.vx, T(1));
+        replicateField(reader.get(), "vy", d.vy, T(1));
+        replicateField(reader.get(), "vz", d.vz, T(1));
+        replicateField(reader.get(), "temp", d.temp, T(1));
+
+        std::fill(d.du_m1.begin(), d.du_m1.end(), 0);
+        std::transform(d.vx.begin(), d.vx.end(), d.x_m1.begin(), [dt = d.minDt](auto v_) { return v_ * dt;});
+        std::transform(d.vy.begin(), d.vy.end(), d.y_m1.begin(), [dt = d.minDt](auto v_) { return v_ * dt;});
+        std::transform(d.vz.begin(), d.vz.end(), d.z_m1.begin(), [dt = d.minDt](auto v_) { return v_ * dt;});
+
+        if (d.isAllocated("alpha"))
+        {
+            try {
+                replicateField(reader.get(), "alpha", d.alpha, T(1));
+            }
+            catch (std::runtime_error&)
+            {
+                std::fill(d.alpha.begin(), d.alpha.end(), d.alphamin);
+            }
+        }
+
+        reader->closeStep();
+
+        return box;
+    }
+
+    [[nodiscard]] const std::map<std::string, double>& constants() const override { return constants_; }
 };
 
 } // namespace sphexa

--- a/main/src/init/isim_init.hpp
+++ b/main/src/init/isim_init.hpp
@@ -34,6 +34,7 @@
 #include <map>
 
 #include "cstone/sfc/box.hpp"
+#include "io/ifile_io.hpp"
 
 namespace sphexa
 {
@@ -41,11 +42,29 @@ namespace sphexa
 template<class Dataset>
 class ISimInitializer
 {
+protected:
+    mutable std::map<std::string, double> settings_;
+
 public:
     virtual cstone::Box<typename Dataset::RealType> init(int rank, int numRanks, size_t, Dataset& d) const = 0;
     virtual const std::map<std::string, double>&    constants() const                                      = 0;
 
     virtual ~ISimInitializer() = default;
+
+    ISimInitializer()
+    {
+        BuiltinReader reader(settings_);
+        Dataset       defaultValues;
+        defaultValues.hydro.loadOrStoreAttributes(&reader);
+    }
+
+    void updateSettings(const std::map<std::string, double>& settings)
+    {
+        for (const auto& kv : settings)
+        {
+            settings_[kv.first] = kv.second;
+        }
+    }
 };
 
 } // namespace sphexa

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -46,23 +46,21 @@ namespace sphexa
 template<class T, class Dataset>
 void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& constants, T massPart)
 {
-    T rhoInt        = constants.at("rhoInt");
-    T rhoExt        = constants.at("rhoExt");
-    T firstTimeStep = constants.at("firstTimeStep");
-    T omega0        = constants.at("omega0");
-    T gamma         = constants.at("gamma");
-    T p             = constants.at("p");
-    T vxInt         = constants.at("vxInt");
-    T vxExt         = constants.at("vxExt");
+    T rhoInt = constants.at("rhoInt");
+    T rhoExt = constants.at("rhoExt");
+    T omega0 = constants.at("omega0");
+    T gamma  = constants.at("gamma");
+    T p      = constants.at("p");
+    T vxInt  = constants.at("vxInt");
+    T vxExt  = constants.at("vxExt");
 
     T uInt = p / ((gamma - 1.) * rhoInt);
     T uExt = p / ((gamma - 1.) * rhoExt);
     T vDif = 0.5 * (vxExt - vxInt);
     T ls   = 0.025;
 
-    size_t ng0  = 100;
-    T      hInt = 0.5 * std::cbrt(3. * ng0 * massPart / 4. / M_PI / rhoInt);
-    T      hExt = 0.5 * std::cbrt(3. * ng0 * massPart / 4. / M_PI / rhoExt);
+    T hInt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoInt);
+    T hExt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoExt);
 
     std::fill(d.m.begin(), d.m.end(), massPart);
     std::fill(d.du_m1.begin(), d.du_m1.end(), 0.0);
@@ -70,13 +68,6 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
     std::fill(d.mui.begin(), d.mui.end(), 10.0);
     std::fill(d.alpha.begin(), d.alpha.end(), d.alphamax);
     std::fill(d.vz.begin(), d.vz.end(), 0.0);
-
-    d.ng0      = std::lround(constants.at("ng0"));
-    d.ngmax    = std::lround(constants.at("ngmax"));
-    d.gamma    = constants.at("gamma");
-    d.Kcour    = constants.at("Kcour");
-    d.minDt    = firstTimeStep;
-    d.minDt_m1 = firstTimeStep;
 
     auto cv = sph::idealGasCv(d.muiConst, gamma);
 
@@ -111,31 +102,33 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
             else { d.vx[i] = vxExt - vDif * std::exp((0.75 - d.y[i]) / ls); }
         }
 
-        d.x_m1[i] = d.vx[i] * firstTimeStep;
-        d.y_m1[i] = d.vy[i] * firstTimeStep;
-        d.z_m1[i] = d.vz[i] * firstTimeStep;
+        d.x_m1[i] = d.vx[i] * d.minDt;
+        d.y_m1[i] = d.vy[i] * d.minDt;
+        d.z_m1[i] = d.vz[i] * d.minDt;
     }
 }
 
 std::map<std::string, double> KelvinHelmholtzConstants()
 {
-    return {{"rhoInt", 2.},  {"rhoExt", 1.},     {"vxExt", 0.5},
-            {"vxInt", -0.5}, {"gamma", 5. / 3.}, {"firstTimeStep", 1e-7},
-            {"p", 2.5},      {"omega0", 0.01},   {"Kcour", 0.4},
-            {"ng0", 100},    {"ngmax", 150},     {"KelvinHelmholtzGrowthRate", 1}};
+    return {{"rhoInt", 2.},        {"rhoExt", 1.},           {"vxExt", 0.5},
+            {"vxInt", -0.5},       {"gamma", 5. / 3.},       {"p", 2.5},
+            {"omega0", 0.01},      {"Kcour", 0.4},           {"ng0", 100},
+            {"ngmax", 150},        {"minDt", 1e-7},          {"minDt_m1", 1e-7},
+            {"gravConstant", 0.0}, {"kelvin-helmholtz", 1.0}};
 }
 
 template<class Dataset>
 class KelvinHelmholtzGlass : public ISimInitializer<Dataset>
 {
-    std::string                   glassBlock;
-    std::map<std::string, double> constants_;
+    std::string glassBlock;
+    using Base = ISimInitializer<Dataset>;
+    using Base::settings_;
 
 public:
     KelvinHelmholtzGlass(std::string initBlock)
         : glassBlock(initBlock)
     {
-        constants_ = KelvinHelmholtzConstants();
+        Base::updateSettings(KelvinHelmholtzConstants());
     }
 
     cstone::Box<typename Dataset::RealType> init(int rank, int numRanks, size_t cbrtNumPart,
@@ -191,21 +184,26 @@ public:
 
         assembleCuboid<T>(keyStart, keyEnd, layer2, innerMulti, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
-        d.numParticlesGlobal = d.x.size();
-        MPI_Allreduce(MPI_IN_PLACE, &d.numParticlesGlobal, 1, MpiType<size_t>{}, MPI_SUM, simData.comm);
+        size_t numParticlesGlobal = d.x.size();
+        MPI_Allreduce(MPI_IN_PLACE, &numParticlesGlobal, 1, MpiType<size_t>{}, MPI_SUM, simData.comm);
         syncCoords<KeyType>(rank, numRanks, d.numParticlesGlobal, d.x, d.y, d.z, globalBox);
 
         size_t npartInner   = innerMulti[0] * innerMulti[1] * innerMulti[2] * xBlock.size();
         T      volumeHD     = 0.5 * globalBox.lx() * globalBox.ly() * globalBox.lz();
-        T      particleMass = volumeHD * constants_.at("rhoInt") / npartInner;
+        T      particleMass = volumeHD * settings_.at("rhoInt") / npartInner;
 
         d.resize(d.x.size());
-        initKelvinHelmholtzFields(d, constants_, particleMass);
+
+        settings_["numParticlesGlobal"] = double(numParticlesGlobal);
+        BuiltinWriter attributeSetter(settings_);
+        d.loadOrStoreAttributes(&attributeSetter);
+
+        initKelvinHelmholtzFields(d, settings_, particleMass);
 
         return globalBox;
     }
 
-    const std::map<std::string, double>& constants() const override { return constants_; }
+    const std::map<std::string, double>& constants() const override { return settings_; }
 };
 
 } // namespace sphexa

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -119,9 +119,10 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
 
 std::map<std::string, double> KelvinHelmholtzConstants()
 {
-    return {{"rhoInt", 2.},          {"rhoExt", 1.}, {"vxExt", 0.5},   {"vxInt", -0.5}, {"gamma", 5. / 3.},
-            {"firstTimeStep", 1e-7}, {"p", 2.5},     {"omega0", 0.01}, {"Kcour", 0.4},  {"ng0", 100},
-            {"ngmax", 150}};
+    return {{"rhoInt", 2.},  {"rhoExt", 1.},     {"vxExt", 0.5},
+            {"vxInt", -0.5}, {"gamma", 5. / 3.}, {"firstTimeStep", 1e-7},
+            {"p", 2.5},      {"omega0", 0.01},   {"Kcour", 0.4},
+            {"ng0", 100},    {"ngmax", 150},     {"KelvinHelmholtzGrowthRate", 1}};
 }
 
 template<class Dataset>

--- a/main/src/init/sedov_constants.hpp
+++ b/main/src/init/sedov_constants.hpp
@@ -8,10 +8,11 @@ namespace sphexa
 
 std::map<std::string, double> sedovConstants()
 {
-    std::map<std::string, double> ret{
-        {"dim", 3},          {"gamma", 5. / 3.},      {"omega", 0.}, {"r0", 0.},   {"r1", 0.5}, {"mTotal", 1.},
-        {"energyTotal", 1.}, {"width", 0.1},          {"rho0", 1.},  {"u0", 1e-8}, {"p0", 0.},  {"vr0", 0.},
-        {"cs0", 0.},         {"firstTimeStep", 1e-6}, {"mui", 10}};
+    std::map<std::string, double> ret{{"dim", 3},   {"gamma", 5. / 3.}, {"omega", 0.},       {"r0", 0.},
+                                      {"r1", 0.5},  {"mTotal", 1.},     {"energyTotal", 1.}, {"width", 0.1},
+                                      {"rho0", 1.}, {"u0", 1e-8},       {"p0", 0.},          {"vr0", 0.},
+                                      {"cs0", 0.},  {"minDt", 1e-6},    {"minDt_m1", 1e-6},  {"gravConstant", 0.0},
+                                      {"ng0", 100}, {"ngmax", 150},     {"mui", 10}};
 
     ret["ener0"] = ret["energyTotal"] / std::pow(M_PI, 1.5) / 1. / std::pow(ret["width"], 3.0);
     return ret;

--- a/main/src/io/arg_parser.hpp
+++ b/main/src/io/arg_parser.hpp
@@ -116,4 +116,23 @@ bool isPeriodicOutputStep(size_t step, const std::string& frequencyStr)
     return strIsIntegral(frequencyStr) && frequency != 0 && (step % frequency == 0);
 }
 
+std::string strBeforeSign(const std::string& str, const std::string& sign)
+{
+    auto commaPos = str.find_first_of(sign);
+    return str.substr(0, commaPos);
+}
+
+//! @brief If the input string ends with @p sign followed by an integer, return the integer, otherwise return 0
+int numberAfterSign(const std::string& str, const std::string& sign)
+{
+    auto commaPos = str.find_first_of(sign);
+    if (commaPos == std::string::npos) { return 0; }
+
+    std::string afterComma = str.substr(commaPos + sign.size());
+
+    int ret = 0;
+    if (strIsIntegral(afterComma)) { ret = std::stoi(afterComma); }
+    return ret;
+}
+
 } // namespace sphexa

--- a/main/src/io/arg_parser.hpp
+++ b/main/src/io/arg_parser.hpp
@@ -122,15 +122,15 @@ std::string strBeforeSign(const std::string& str, const std::string& sign)
     return str.substr(0, commaPos);
 }
 
-//! @brief If the input string ends with @p sign followed by an integer, return the integer, otherwise return 0
+//! @brief If the input string ends with @p sign followed by an integer, return the integer, otherwise return -1
 int numberAfterSign(const std::string& str, const std::string& sign)
 {
     auto commaPos = str.find_first_of(sign);
-    if (commaPos == std::string::npos) { return 0; }
+    if (commaPos == std::string::npos) { return -1; }
 
     std::string afterComma = str.substr(commaPos + sign.size());
 
-    int ret = 0;
+    int ret = -1;
     if (strIsIntegral(afterComma)) { ret = std::stoi(afterComma); }
     return ret;
 }

--- a/main/src/observables/factory.hpp
+++ b/main/src/observables/factory.hpp
@@ -27,6 +27,7 @@
  * @brief Select/calculate data to be printed to constants.txt each iteration
  *
  * @author Lukas Schmidt
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
 #pragma once
@@ -35,6 +36,12 @@
 #include <string>
 
 #include "cstone/sfc/box.hpp"
+#include "io/ifile_io.hpp"
+
+#ifdef SPH_EXA_HAVE_H5PART
+#include "io/ifile_io_hdf5.hpp"
+#endif
+
 #include "iobservables.hpp"
 #include "time_energy_growth.hpp"
 #include "time_energies.hpp"
@@ -45,79 +52,41 @@
 namespace sphexa
 {
 
-#ifdef SPH_EXA_HAVE_H5PART
-
-//! @brief reads a specified attribute if exists and has the specified type
-template<class AttrType>
-void findH5Attribute(const std::string& fname, const std::string& attributeToRead, std::span<AttrType> attribute,
-                     h5part_int64_t h5Type)
+static bool haveAttribute(IFileReader* reader, const std::string& attributeToRead)
 {
-    if (std::filesystem::exists(fname))
+    if (reader)
     {
-        H5PartFile* h5_file       = H5PartOpenFile(fname.c_str(), H5PART_READ);
-        size_t      numAttributes = H5PartGetNumFileAttribs(h5_file);
-
-        h5part_int64_t maxlen = 256;
-        char           attributeName[maxlen];
-
-        h5part_int64_t attributeType;
-        h5part_int64_t attributeLength;
-
-        for (h5part_int64_t i = 0; i < numAttributes; i++)
-        {
-            H5PartGetFileAttribInfo(h5_file, i, attributeName, maxlen, &attributeType, &attributeLength);
-            if (attributeName == attributeToRead && attributeType == h5Type)
-            {
-                if (attributeLength <= attribute.size())
-                {
-                    H5PartReadFileAttrib(h5_file, attributeName, attribute.data());
-                }
-                else
-                {
-                    std::cout << "WARNING: Could not read attribute " << attributeToRead << "; attribute length is "
-                              << attributeLength << "in file, but only a buffer of length " << attribute.size()
-                              << " was provided" << std::endl;
-                }
-                break;
-            }
-        }
-        H5PartCloseFile(h5_file);
-    }
-}
-
-#else
-
-[[maybe_unused]] static bool haveH5Attribute(const std::string& fname, const std::string& attributeToRead)
-{
-    if (std::filesystem::exists(fname))
-    {
-        std::cout << "WARNING: Could not read attribute " + attributeToRead + ". HDF5 support missing\n";
+        auto attributes = reader->fileAttributes();
+        return std::count(attributes.begin(), attributes.end(), attributeToRead);
     }
 
     return false;
 }
 
-#endif
-
 template<class Dataset>
 std::unique_ptr<IObservables<Dataset>> observablesFactory(const std::string& testCase, std::ofstream& constantsFile)
 {
+    std::unique_ptr<IFileReader> reader;
+    std::string                  testCaseStripped = strBeforeSign(testCase, ",");
+
 #ifdef SPH_EXA_HAVE_H5PART
-
-    std::string    khGrowthRate = "KelvinHelmholtzGrowthRate";
-    h5part_int64_t khAttribute  = 0;
-    findH5Attribute<h5part_int64_t>(testCase, khGrowthRate, {&khAttribute, 1}, H5PART_INT64);
-    if (khAttribute != 0) { return std::make_unique<TimeEnergyGrowth<Dataset>>(constantsFile); }
-
-    std::string gravWaves            = "observeGravWaves";
-    double      gravWaveAttribute[3] = {0.0, 0.0, 0.0};
-    findH5Attribute<h5part_float64_t>(testCase, gravWaves, {gravWaveAttribute, 3}, H5PART_FLOAT64);
-    if (gravWaveAttribute[0] != 0.0)
+    if (std::filesystem::exists(testCaseStripped))
     {
-        return std::make_unique<GravWaves<Dataset>>(constantsFile, gravWaveAttribute[1], gravWaveAttribute[2]);
+        reader = std::make_unique<H5PartReader>(MPI_COMM_WORLD);
+        reader->setStep(testCaseStripped, -1);
+    }
+#endif
+
+    std::string gravWaves = "observeGravWaves";
+    if (haveAttribute(reader.get(), gravWaves))
+    {
+        double gravWaveThetaPhi[2] = {0.0, 0.0};
+        reader->fileAttribute(gravWaves, gravWaveThetaPhi, 2);
+        return std::make_unique<GravWaves<Dataset>>(constantsFile, gravWaveThetaPhi[0], gravWaveThetaPhi[1]);
     }
 
-    if (testCase == "wind-shock")
+#ifdef SPH_EXA_HAVE_H5PART
+    if (testCase == "wind-shock" || haveAttribute(reader.get(), "wind-shock"))
     {
         double rhoInt       = WindShockConstants().at("rhoInt");
         double uExt         = WindShockConstants().at("uExt");
@@ -127,9 +96,16 @@ std::unique_ptr<IObservables<Dataset>> observablesFactory(const std::string& tes
     }
 #endif
 
-    if (testCase == "turbulence") { return std::make_unique<TurbulenceMachRMS<Dataset>>(constantsFile); }
-    if (testCase == "kelvin-helmholtz") { return std::make_unique<TimeEnergyGrowth<Dataset>>(constantsFile); }
+    if (testCase == "turbulence" || haveAttribute(reader.get(), "turbulence"))
+    {
+        return std::make_unique<TurbulenceMachRMS<Dataset>>(constantsFile);
+    }
+    if (testCase == "kelvin-helmholtz" || haveAttribute(reader.get(), "kelvin-helmholtz"))
+    {
+        return std::make_unique<TimeEnergyGrowth<Dataset>>(constantsFile);
+    }
 
+    if (reader) { reader->closeStep(); }
     return std::make_unique<TimeAndEnergy<Dataset>>(constantsFile);
 }
 

--- a/main/src/propagator/turb_ve.hpp
+++ b/main/src/propagator/turb_ve.hpp
@@ -91,8 +91,9 @@ public:
 
     void save(IFileWriter* writer) override { turbulenceData.loadOrStore(writer); }
 
-    void load(const std::string& path, MPI_Comm comm) override
+    void load(const std::string& initCond, MPI_Comm comm) override
     {
+        std::string path = strBeforeSign(initCond, ",");
         // The file does not exist, we're starting from scratch. Nothing to do.
         if (!std::filesystem::exists(path)) { return; }
 

--- a/main/test/io/arg_parser.cpp
+++ b/main/test/io/arg_parser.cpp
@@ -79,10 +79,10 @@ TEST(IO, isPeriodicOutputStep)
 
 TEST(IO, numberAfterSign)
 {
-    EXPECT_EQ(numberAfterSign("chkp.h5", ","), 0);
+    EXPECT_EQ(numberAfterSign("chkp.h5", ","), -1);
     EXPECT_EQ(numberAfterSign("chkp.h5,1", ","), 1);
     EXPECT_EQ(numberAfterSign("chkp.h5,42", ","), 42);
-    EXPECT_EQ(numberAfterSign("chkp.h5,42,42", ","), 0);
+    EXPECT_EQ(numberAfterSign("chkp.h5,42,42", ","), -1);
 
     EXPECT_EQ(numberAfterSign("chkp.h5-O_O-42", "-O_O-"), 42);
 }

--- a/main/test/io/arg_parser.cpp
+++ b/main/test/io/arg_parser.cpp
@@ -76,3 +76,13 @@ TEST(IO, isPeriodicOutputStep)
     EXPECT_TRUE(isPeriodicOutputStep(84, "42"));
     EXPECT_FALSE(isPeriodicOutputStep(42, "42.0"));
 }
+
+TEST(IO, numberAfterSign)
+{
+    EXPECT_EQ(numberAfterSign("chkp.h5", ","), 0);
+    EXPECT_EQ(numberAfterSign("chkp.h5,1", ","), 1);
+    EXPECT_EQ(numberAfterSign("chkp.h5,42", ","), 42);
+    EXPECT_EQ(numberAfterSign("chkp.h5,42,42", ","), 0);
+
+    EXPECT_EQ(numberAfterSign("chkp.h5-O_O-42", "-O_O-"), 42);
+}

--- a/sph/include/sph/hydro_ve/eos.hpp
+++ b/sph/include/sph/hydro_ve/eos.hpp
@@ -83,7 +83,7 @@ void computeEOS(size_t startIndex, size_t endIndex, Dataset& d)
     {
         cuda::computeEOS(startIndex, endIndex, d.muiConst, d.gamma, rawPtr(d.devData.temp), rawPtr(d.devData.m),
                          rawPtr(d.devData.kx), rawPtr(d.devData.xm), rawPtr(d.devData.gradh), rawPtr(d.devData.prho),
-                         rawPtr(d.devData.c), rawPtr(d.devData.rho));
+                         rawPtr(d.devData.c), rawPtr(d.devData.rho), rawPtr(d.devData.p));
     }
     else { computeEOS_Impl(startIndex, endIndex, d); }
 }

--- a/sph/include/sph/hydro_ve/eos_gpu.cu
+++ b/sph/include/sph/hydro_ve/eos_gpu.cu
@@ -43,32 +43,36 @@ namespace cuda
 
 template<class Tt, class Tm, class Thydro>
 __global__ void cudaEOS(size_t firstParticle, size_t lastParticle, Tt mui, Tt gamma, const Tt* temp, const Tm* m,
-                        const Thydro* kx, const Thydro* xm, const Thydro* gradh, Thydro* prho, Thydro* c, Thydro* rho)
+                        const Thydro* kx, const Thydro* xm, const Thydro* gradh, Thydro* prho, Thydro* c, Thydro* rho,
+                        Thydro* p)
 {
     unsigned i = firstParticle + blockDim.x * blockIdx.x + threadIdx.x;
     if (i >= lastParticle) return;
 
-    Thydro p;
-    Thydro rho_i       = kx[i] * m[i] / xm[i];
-    util::tie(p, c[i]) = idealGasEOS(temp[i], rho_i, mui, gamma);
-    prho[i]            = p / (kx[i] * m[i] * m[i] * gradh[i]);
+    Thydro p_i;
+    Thydro rho_i         = kx[i] * m[i] / xm[i];
+    util::tie(p_i, c[i]) = idealGasEOS(temp[i], rho_i, mui, gamma);
+    prho[i]              = p_i / (kx[i] * m[i] * m[i] * gradh[i]);
     if (rho) { rho[i] = rho_i; }
+    if (p) { p[i] = p_i; }
 }
 
 template<class Tt, class Tm, class Thydro>
 void computeEOS(size_t firstParticle, size_t lastParticle, Tt mui, Tt gamma, const Tt* temp, const Tm* m,
-                const Thydro* kx, const Thydro* xm, const Thydro* gradh, Thydro* prho, Thydro* c, Thydro* rho)
+                const Thydro* kx, const Thydro* xm, const Thydro* gradh, Thydro* prho, Thydro* c, Thydro* rho,
+                Thydro* p)
 {
     unsigned numThreads = 256;
     unsigned numBlocks  = iceil(lastParticle - firstParticle, numThreads);
-    cudaEOS<<<numBlocks, numThreads>>>(firstParticle, lastParticle, mui, gamma, temp, m, kx, xm, gradh, prho, c, rho);
+    cudaEOS<<<numBlocks, numThreads>>>(firstParticle, lastParticle, mui, gamma, temp, m, kx, xm, gradh, prho, c, rho,
+                                       p);
     checkGpuErrors(cudaDeviceSynchronize());
 }
 
 #define COMPUTE_EOS(Ttemp, Tm, Thydro)                                                                                 \
     template void computeEOS(size_t firstParticle, size_t lastParticle, Ttemp mui, Ttemp gamma, const Ttemp* temp,     \
                              const Tm* m, const Thydro* kx, const Thydro* xm, const Thydro* gradh, Thydro* prho,       \
-                             Thydro* c, Thydro* rho)
+                             Thydro* c, Thydro* rho, Thydro* p)
 
 COMPUTE_EOS(double, double, double);
 COMPUTE_EOS(double, float, double);

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -90,7 +90,7 @@ public:
     T linmom{0.0}, angmom{0.0};
 
     //! current and previous (global) time-steps
-    T minDt, minDt_m1;
+    T minDt{1e-12}, minDt_m1{1e-12};
 
     //! temporary MPI rank local timesteps;
     T minDtCourant{INFINITY}, minDtRho{INFINITY};
@@ -112,6 +112,7 @@ public:
     //! @brief mean molecular weight of ions for models that use one value for all particles
     T muiConst{10.0};
 
+    //! @brief Unified interface to attribute initialization, reading and writing
     template<class Archive>
     void loadOrStoreAttributes(Archive* ar)
     {

--- a/sph/include/sph/sph_gpu.hpp
+++ b/sph/include/sph/sph_gpu.hpp
@@ -41,7 +41,7 @@ extern void computeEOS_HydroStd(size_t, size_t, Tu, Tu, const Tu*, const Trho*, 
 
 template<class Tu, class Tm, class Thydro>
 extern void computeEOS(size_t, size_t, Tu, Tu, const Tu*, const Tm*, const Thydro*, const Thydro*, const Thydro*,
-                       Thydro*, Thydro*, Thydro*);
+                       Thydro*, Thydro*, Thydro*, Thydro*);
 
 } // namespace cuda
 


### PR DESCRIPTION
* Can be used with `--init chkp.h5,2` to initialize from `chkp.h5` and splitting all particles in two.
* Fixed certain settings like `ng0` and `ngmax` and observable selections that were not properly remembered.
