### PR TITLE
adapted to latest changes for ci-ext, with dynamic rebuilt of the base image

### DIFF
--- a/.gitlab/Dockerfile_2
+++ b/.gitlab/Dockerfile_2
@@ -1,7 +1,5 @@
-FROM jfrog.svc.cscs.ch/contbuild/testing/anfink/44692846847247/sph-exa_base:cuda
-# FROM jfrog.svc.cscs.ch/contbuild/testing/anfink/9590261141699040/sph-exa_base:cuda
-# FROM jfrog.svc.cscs.ch/contbuild/testing/pasc/sphexa/sph-exa_base:cuda
-# FROM art.cscs.ch/contbuild/testing/jg/sph-exa_base:cuda
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 #{{{ readme
 # rm -fr SPH-EXA.git ;cp -a SPH-EXA.git.ori SPH-EXA.git
 # sudo docker build -f Dockerfile_2 -t deleteme:latest .

--- a/.gitlab/Dockerfile_hip_2
+++ b/.gitlab/Dockerfile_hip_2
@@ -1,5 +1,5 @@
-FROM jfrog.svc.cscs.ch/contbuild/testing/anfink/44692846847247/sph-exa_base:hip
-# FROM jfrog.svc.cscs.ch/contbuild/testing/anfink/9590261141699040/sph-exa_base:hip
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 
 #{{{ readme
 # rm -fr SPH-EXA.git ;cp -a SPH-EXA.git.ori SPH-EXA.git

--- a/.gitlab/gitlab-ci.yml
+++ b/.gitlab/gitlab-ci.yml
@@ -1,107 +1,88 @@
-# https://gitlab.com/cscs-ci/ci-testing/webhook-ci/gitlab-runner-docker-jfrog.git
+# https://gitlab.com/cscs-ci/ci-testing/webhook-ci/gitlab-runner-k8s-container-builder.git
 include:
-  - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.cscs.yml'
+  - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
 
 stages:
-  - SPHbase     # no srun (tags=docker_jfrog)
-  - SPHbuild    # no srun (tags=docker_jfrog)
+  - SPHbase     # no srun (extends=.container-builder-dynamic-name)
+  - SPHbuild    # no srun (extends=.container-builder)
   - SPHpull     # on daint
   - SPHtest     # on daint
 
 #{{{ variables
 variables:
-  docker_jfrog_tag: 'docker_jfrog'
-  BASE_CUDA: "${CSCS_REGISTRY_PATH}/sph-exa_base:cuda"
-  BASE_HIP: "${CSCS_REGISTRY_PATH}/sph-exa_base:hip"
-  BASE_SKIP: "${CSCS_REGISTRY_PATH}/sph-exa_base:skip"
-  BUILD_CUDA: "${CSCS_REGISTRY_PATH}/sph-exa_build:cuda"
-  # jfrog.svc.cscs.ch/contbuild/testing/anfink/44692846847247 sph-exa_build:cuda
-  # jfrog.svc.cscs.ch/contbuild/testing/anfink/4264416954089684 :1.0
+  # version-tag will be added by .container-builder-dynamic-name, see https://gitlab.com/cscs-ci/ci-testing/containerised_ci_doc/-/blob/main/dependency_management.md
+  BASE_CUDA: "${CSCS_REGISTRY_PATH}/base/sph-exa_base-cuda"
+  BASE_HIP: "${CSCS_REGISTRY_PATH}/base/sph-exa_base-hip"
+  BUILD_CUDA: "${CSCS_REGISTRY_PATH}/sph-exa_build:cuda-$CI_COMMIT_SHORT_SHA"
   # BUILD_CUDA1: "${CSCS_REGISTRY_PATH}/sph-exa_build:1.0"
-  BUILD_HIP: "${CSCS_REGISTRY_PATH}/sph-exa_build:hip"
+  BUILD_HIP: "${CSCS_REGISTRY_PATH}/sph-exa_build:hip-$CI_COMMIT_SHORT_SHA"
   DEPS_PATH: 'ftp://ftp.cscs.ch/out/jgp/hpc/containers'
   VERBOSE: 'YES'
   #no: SYSTEM_NAME: '.dom'
   # REBUILD_BASE_IMAGE: 'YES'
   # SARUS_VERBOSE: 'YES'
-  # CSCS_REGISTRY_PATH=contbuild/testing/anfink/9590261141699040/
-#}}} 
+#}}}
 
 #{{{ sph:base:cuda:
 sph:base:cuda:
-  tags:
-    - ${docker_jfrog_tag}
+  extends: .container-builder-dynamic-name
   stage: SPHbase
-  script:
-    - echo "DOCKERFILE=$DOCKERFILE"
-    - echo "PERSIST_IMAGE_NAME=${PERSIST_IMAGE_NAME}"
   variables:
     # tried with if/else, no success -> must comment/uncomment
     # ---
     # DOCKERFILE: '.gitlab/Dockerfile_1'
     # PERSIST_IMAGE_NAME: "${BASE_CUDA}"
     # ---
-    DOCKERFILE: '.gitlab/Dockerfile_skip'
-    PERSIST_IMAGE_NAME: "${BASE_SKIP}"
+    DOCKERFILE: '.gitlab/Dockerfile_1'
+    PERSIST_IMAGE_NAME: "${BASE_CUDA}"
+    WATCH_FILECHANGES: '.gitlab/Dockerfile_1'
+
 #}}}
 #{{{ sph:base:hip:
 sph:base:hip:
-  tags:
-    - ${docker_jfrog_tag}
+  extends: .container-builder-dynamic-name
   stage: SPHbase
-  script:
-    - echo "DOCKERFILE=$DOCKERFILE"
-    - echo "PERSIST_IMAGE_NAME=${PERSIST_IMAGE_NAME}"
   variables:
     # tried with if/else, no success -> must comment/uncomment
     # ---
     # DOCKERFILE: '.gitlab/Dockerfile_hip_1'
     # PERSIST_IMAGE_NAME: "${BASE_HIP}"
     # ---
-    DOCKERFILE: '.gitlab/Dockerfile_skip'
-    PERSIST_IMAGE_NAME: "${BASE_SKIP}"
+    DOCKERFILE: '.gitlab/Dockerfile_hip_1'
+    PERSIST_IMAGE_NAME: "${BASE_HIP}"
+    WATCH_FILECHANGES: '.gitlab/Dockerfile_hip_1'
 #}}}
 
 #{{{ sph:build:cuda:
 sph:build:cuda:
   needs: ['sph:base:cuda']
-  tags:
-    - ${docker_jfrog_tag}
+  extends: .container-builder
   stage: SPHbuild
-  script:
+  before_script:
     - echo "PERSIST_IMAGE_NAME=$PERSIST_IMAGE_NAME"
-  # image: "${BASE_CUDA}"    
-  # /sources
   variables:
     # JG: 'YES'
     DOCKERFILE: '.gitlab/Dockerfile_2'
     PERSIST_IMAGE_NAME: "${BUILD_CUDA}"
-    PULL_IMAGE: 'YES'
-    CSCS_REGISTRY_LOGIN: 'YES'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=$BASE_IMAGE"]'
 #}}}
 #{{{ sph:build:hip:
 sph:build:hip:
   needs: ['sph:base:hip']
-  tags:
-    - ${docker_jfrog_tag}
+  extends: .container-builder
   stage: SPHbuild
-  script:
+  before_script:
     - echo "PERSIST_IMAGE_NAME=$PERSIST_IMAGE_NAME"
-  # image: "${BASE_CUDA}"    
-  # /sources
   variables:
     DOCKERFILE: '.gitlab/Dockerfile_hip_2'
     PERSIST_IMAGE_NAME: "${BUILD_HIP}"
-    PULL_IMAGE: 'YES'
-    CSCS_REGISTRY_LOGIN: 'YES'
-#}}}    
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=$BASE_IMAGE"]'
+#}}}
 
 #{{{ sph:pull:cuda:
 sph:pull:cuda:
   needs: ['sph:build:cuda']
-  # tags:
-  #   - ${docker_jfrog_tag}
-  extends: .daint
+  extends: .container-runner-daint-gpu
   stage: SPHpull
   image: ${BUILD_CUDA}
   script:
@@ -110,14 +91,13 @@ sph:pull:cuda:
     - echo "  PERSIST_IMAGE_NAME=${PERSIST_IMAGE_NAME}"
   variables:
     PULL_IMAGE: 'YES'
-    CSCS_REGISTRY_LOGIN: 'YES'
     PERSIST_IMAGE_NAME: "${BUILD_CUDA}"
 #}}}
 
 #{{{ sph:test:cuda:1:
 sph:build:cuda:1:
   needs: ['sph:pull:cuda']
-  extends: .daint
+  extends: .container-runner-daint-gpu
   stage: SPHtest
   image: ${BUILD_CUDA}
   script:
@@ -136,18 +116,16 @@ sph:build:cuda:1:
     - /usr/local/sbin/performance/peers_perf
   variables:
     USE_MPI: 'NO'
-    SLURM_CONSTRAINT: 'gpu'
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 1
     PULL_IMAGE: 'NO'
-    # CSCS_REGISTRY_LOGIN: 'YES'
     # SLURM_PARTITION
     # SLURM_TIMELIMIT    
 #}}}
 #{{{ sph:test:cuda:2:
 sph:build:cuda:2:
   needs: ['sph:pull:cuda']
-  extends: .daint
+  extends: .container-runner-daint-gpu
   stage: SPHtest
   image: ${BUILD_CUDA}
   script:
@@ -160,18 +138,16 @@ sph:build:cuda:2:
     # - /usr/local/sbin/integration_mpi/exchange_halos_gpu # needs 2 gpus
   variables:
     USE_MPI: 'YES'
-    SLURM_CONSTRAINT: 'gpu'
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 2
     PULL_IMAGE: 'NO'
-    CSCS_REGISTRY_LOGIN: 'YES'
     # SLURM_PARTITION
     # SLURM_TIMELIMIT    
 #}}}
 #{{{ sph:test:cuda:2cn:
 # sph:build:cuda:2cn:
 #   needs: ['sph:pull:cuda']
-#   extends: .daint
+#   extends: .container-runner-daint-gpu
 #   stage: SPHtest
 #   image: ${BUILD_CUDA}
 #   script:
@@ -181,18 +157,16 @@ sph:build:cuda:2:
 #     - /usr/local/sbin/integration_mpi/exchange_domain_gpu
 #   variables:
 #     USE_MPI: 'YES'
-#     SLURM_CONSTRAINT: 'gpu'
 #     SLURM_JOB_NUM_NODES: 2
 #     SLURM_NTASKS: 2
 #     PULL_IMAGE: 'NO'
-#     CSCS_REGISTRY_LOGIN: 'YES'
 #     SLURM_PARTITION: 'debug'
 #     # SLURM_TIMELIMIT
 #}}}
 #{{{ sph:test:cuda:5:
 sph:build:cuda:5:
   needs: ['sph:pull:cuda']
-  extends: .daint
+  extends: .container-runner-daint-gpu
   stage: SPHtest
   image: ${BUILD_CUDA}
   script:
@@ -207,18 +181,16 @@ sph:build:cuda:5:
     - /usr/local/sbin/ryoanji/global_upsweep_cpu
   variables:
     USE_MPI: 'YES'
-    SLURM_CONSTRAINT: 'gpu'
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 5
     PULL_IMAGE: 'NO'
-    CSCS_REGISTRY_LOGIN: 'YES'
     # SLURM_PARTITION
     # SLURM_TIMELIMIT    
 #}}}
 #{{{ sph:test:cuda:p100:
 sph:build:cuda:p100:
   needs: ['sph:pull:cuda']
-  extends: .daint
+  extends: .container-runner-daint-gpu
   stage: SPHtest
   image: ${BUILD_CUDA}
   script:
@@ -234,18 +206,16 @@ sph:build:cuda:p100:
     - /usr/local/sbin/ryoanji/ryoanji_demo/ryoanji_demo 
   variables:
     USE_MPI: 'NO'
-    SLURM_CONSTRAINT: 'gpu'
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 1
     PULL_IMAGE: 'NO'
-    CSCS_REGISTRY_LOGIN: 'YES'
     # SLURM_PARTITION
     # SLURM_TIMELIMIT    
 #}}}
 #{{{ sph:test:cuda:sphexa:cpu:
 sph:build:cuda:sphexa:cpu:
   needs: ['sph:pull:cuda']
-  extends: .daint
+  extends: .container-runner-daint-gpu
   stage: SPHtest
   image: ${BUILD_CUDA}
   script:
@@ -260,11 +230,9 @@ sph:build:cuda:sphexa:cpu:
     - /usr/local/bin/sphexa --init noh --glass ./glass.h5 -s 1 -n 50
   variables:
     USE_MPI: 'YES'
-    SLURM_CONSTRAINT: 'gpu'
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 1
     PULL_IMAGE: 'NO'
-    CSCS_REGISTRY_LOGIN: 'YES'
     # SLURM_PARTITION
     # SLURM_TIMELIMIT    
 #}}}
@@ -272,7 +240,7 @@ sph:build:cuda:sphexa:cpu:
 # TODO: MPICH_RDMA_ENABLED_CUDA=1 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libcuda.so
 sph:build:cuda:sphexa:gpu:
   needs: ['sph:pull:cuda' ]
-  extends: .daint
+  extends: .container-runner-daint-gpu
   stage: SPHtest
   image: ${BUILD_CUDA}
   script:
@@ -297,11 +265,9 @@ sph:build:cuda:sphexa:gpu:
     - reframe -c /usr/local/games/rfm.py -r -S rpt_path=/scratch
   variables:
     USE_MPI: 'YES'
-    SLURM_CONSTRAINT: 'gpu'
     SLURM_JOB_NUM_NODES: 1
     SLURM_NTASKS: 1
     PULL_IMAGE: 'NO'
-    CSCS_REGISTRY_LOGIN: 'YES'
     # SLURM_PARTITION
     # SLURM_TIMELIMIT    
 #}}}


### PR DESCRIPTION
This PR adapts to the latest changes for CI-Ext.
- A base image is being rebuilt automatically when `Dockerfile_1` or `Dockerfile_hip_1` changes (see https://gitlab.com/cscs-ci/ci-testing/containerised_ci_doc/-/blob/main/dependency_management.md, for an explenation how it works).
- `CSCS_REGISTRY_LOGIN` is deprecated and not used in the runner anymore.
- Moved from `docker_jfrog` to the k8s container builder.
- Add commit-sha to container name to avoid a race condition when multiple branches/prs are building
- Moved from `.daint` to the more explicit name `.container-runner-daint-gpu`