### PR TITLE
Simplified GravityWrapper template args

### DIFF
--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -77,6 +77,9 @@ class Domain
         typename AccelSwitchType<Accelerator, SfcSorter, GpuSfcSorter>::template type<LocalIndex, BufferType>;
 
 public:
+    //! @brief floating point type used for the coordinate bounding box and geometric/mass centers of tree nodes
+    using RealType = T;
+
     /*! @brief construct empty Domain
      *
      * @param rank            executing rank

--- a/main/src/propagator/nbody.hpp
+++ b/main/src/propagator/nbody.hpp
@@ -58,10 +58,10 @@ class NbodyProp final : public Propagator<DomainType, DataType>
     using Tmass         = typename DataType::HydroData::Tmass;
     using MultipoleType = ryoanji::CartesianQuadrupole<Tmass>;
 
-    using Acc = typename DataType::AcceleratorType;
-    using MHolder_t =
-        typename cstone::AccelSwitchType<Acc, MultipoleHolderCpu,
-                                         MultipoleHolderGpu>::template type<MultipoleType, KeyType, T, T, Tmass, T, T>;
+    using Acc       = typename DataType::AcceleratorType;
+    using MHolder_t = typename cstone::AccelSwitchType<Acc, MultipoleHolderCpu, MultipoleHolderGpu>::template type<
+        MultipoleType, DomainType, typename DataType::HydroData>;
+
     MHolder_t mHolder_;
 
     /*! @brief the list of conserved particles fields with values preserved between iterations

--- a/main/src/propagator/std_hydro.hpp
+++ b/main/src/propagator/std_hydro.hpp
@@ -59,10 +59,10 @@ protected:
     using Tmass         = typename DataType::HydroData::Tmass;
     using MultipoleType = ryoanji::CartesianQuadrupole<Tmass>;
 
-    using Acc = typename DataType::AcceleratorType;
-    using MHolder_t =
-        typename cstone::AccelSwitchType<Acc, MultipoleHolderCpu,
-                                         MultipoleHolderGpu>::template type<MultipoleType, KeyType, T, T, Tmass, T, T>;
+    using Acc       = typename DataType::AcceleratorType;
+    using MHolder_t = typename cstone::AccelSwitchType<Acc, MultipoleHolderCpu, MultipoleHolderGpu>::template type<
+        MultipoleType, DomainType, typename DataType::HydroData>;
+
     MHolder_t mHolder_;
 
     /*! @brief the list of conserved particles fields with values preserved between iterations

--- a/main/src/propagator/ve_hydro.hpp
+++ b/main/src/propagator/ve_hydro.hpp
@@ -59,10 +59,9 @@ protected:
     using Tmass         = typename DataType::HydroData::Tmass;
     using MultipoleType = ryoanji::CartesianQuadrupole<Tmass>;
 
-    using Acc = typename DataType::AcceleratorType;
-    using MHolder_t =
-        typename cstone::AccelSwitchType<Acc, MultipoleHolderCpu,
-                                         MultipoleHolderGpu>::template type<MultipoleType, KeyType, T, T, Tmass, T, T>;
+    using Acc       = typename DataType::AcceleratorType;
+    using MHolder_t = typename cstone::AccelSwitchType<Acc, MultipoleHolderCpu, MultipoleHolderGpu>::template type<
+        MultipoleType, DomainType, typename DataType::HydroData>;
 
     MHolder_t mHolder_;
 


### PR DESCRIPTION
Since GravityWrapper is part of the front-end, we might as well deduce the types of individual particle fields from
the DomainType and ParticlesDataTypes to make it easier to maintain.

With this PR, GravityWrapper will make the correct call into Ryoanji when the types of particle fields are changed in ParticlesData, eschewing the need to also reflect these changes in the Propagator.