### PR TITLE
Update cooling

### DIFF
--- a/domain/include/cstone/domain/domaindecomp_mpi.hpp
+++ b/domain/include/cstone/domain/domaindecomp_mpi.hpp
@@ -32,6 +32,7 @@
 #pragma once
 
 #include <cstring>
+#include <climits>
 
 #include "buffer_description.hpp"
 #include "cstone/primitives/mpi_wrappers.hpp"

--- a/extern/grackle/CMakeLists.txt
+++ b/extern/grackle/CMakeLists.txt
@@ -37,7 +37,7 @@ set(grackle_SRCS
 add_library(grackle ${grackle_SRCS})
 
 set(PRECISION_DEFINE GRACKLE_FLOAT_8)
-configure_file(${PROJECT_SOURCE_DIR}/config/grackle_float.in.h ${CMAKE_BINARY_DIR}/extern/grackle/grackle_deps/grackle_float.h)
+configure_file(${PROJECT_SOURCE_DIR}/config/grackle_float.h.in ${CMAKE_BINARY_DIR}/extern/grackle/grackle_deps/grackle_float.h)
 
 target_include_directories(grackle PUBLIC ${PROJECT_SOURCE_DIR}/grackle_repo/src/clib)
 target_include_directories(grackle PUBLIC ${PROJECT_BINARY_DIR}/grackle_deps)

--- a/extern/grackle/CMakeLists.txt
+++ b/extern/grackle/CMakeLists.txt
@@ -4,47 +4,53 @@ project(grackle C Fortran)
 find_package(HDF5 REQUIRED)
 
 set(grackle_SRCS
-    grackle_deps/auto_show_config.c
-    grackle_deps/auto_show_flags.c
-    grackle_deps/auto_show_version.c
-    grackle_repo/src/clib/calculate_cooling_time.c
-    grackle_repo/src/clib/calculate_dust_temperature.c
-    grackle_repo/src/clib/calculate_gamma.c
-    grackle_repo/src/clib/calculate_pressure.c
-    grackle_repo/src/clib/calculate_temperature.c
-    grackle_repo/src/clib/grackle_units.c
+        grackle_deps/auto_show_config.c
+        grackle_deps/auto_show_flags.c
+        grackle_deps/auto_show_version.c
+        grackle_repo/src/clib/calculate_cooling_time.c
+        grackle_repo/src/clib/calculate_dust_temperature.c
+        grackle_repo/src/clib/calculate_gamma.c
+        grackle_repo/src/clib/calculate_pressure.c
+        grackle_repo/src/clib/calculate_temperature.c
+        grackle_repo/src/clib/grackle_units.c
         grackle_repo/src/clib/index_helper.c
-    grackle_repo/src/clib/initialize_chemistry_data.c
-    grackle_repo/src/clib/initialize_cloudy_data.c
-    grackle_repo/src/clib/initialize_UVbackground_data.c
-    grackle_repo/src/clib/set_default_chemistry_parameters.c
-    grackle_repo/src/clib/solve_chemistry.c
-    grackle_repo/src/clib/update_UVbackground_rates.c
-    grackle_repo/src/clib/rate_functions.c
-    grackle_repo/src/clib/initialize_rates.c
-    grackle_repo/src/clib/calc_temp1d_cloudy_g.F
-    grackle_repo/src/clib/calc_temp_cloudy_g.F
-    grackle_repo/src/clib/calc_tdust_1d_g.F
-    grackle_repo/src/clib/calc_tdust_3d_g.F
-    grackle_repo/src/clib/cool1d_cloudy_g.F
-    grackle_repo/src/clib/cool1d_cloudy_old_tables_g.F
-    grackle_repo/src/clib/cool1d_multi_g.F
-    grackle_repo/src/clib/cool_multi_time_g.F
-    grackle_repo/src/clib/interpolators_g.F
-    grackle_repo/src/clib/solve_rate_cool_g.F
-)
+        grackle_repo/src/clib/initialize_chemistry_data.c
+        grackle_repo/src/clib/initialize_cloudy_data.c
+        grackle_repo/src/clib/initialize_UVbackground_data.c
+        grackle_repo/src/clib/set_default_chemistry_parameters.c
+        grackle_repo/src/clib/solve_chemistry.c
+        grackle_repo/src/clib/update_UVbackground_rates.c
+        grackle_repo/src/clib/rate_functions.c
+        grackle_repo/src/clib/initialize_rates.c
+        grackle_repo/src/clib/calc_temp1d_cloudy_g.F
+        grackle_repo/src/clib/calc_temp_cloudy_g.F
+        grackle_repo/src/clib/calc_tdust_1d_g.F
+        grackle_repo/src/clib/calc_tdust_3d_g.F
+        grackle_repo/src/clib/cool1d_cloudy_g.F
+        grackle_repo/src/clib/cool1d_cloudy_old_tables_g.F
+        grackle_repo/src/clib/cool1d_multi_g.F
+        grackle_repo/src/clib/cool_multi_time_g.F
+        grackle_repo/src/clib/interpolators_g.F
+        grackle_repo/src/clib/solve_rate_cool_g.F
+        )
 
 add_library(grackle ${grackle_SRCS})
-target_include_directories(grackle PRIVATE ${HDF5_INCLUDE_DIRS} ${MPI_C_INCLUDE_PATH})
+
+set(PRECISION_DEFINE GRACKLE_FLOAT_8)
+configure_file(${PROJECT_SOURCE_DIR}/config/grackle_float.in.h ${CMAKE_BINARY_DIR}/extern/grackle/grackle_deps/grackle_float.h)
+
 target_include_directories(grackle PUBLIC ${PROJECT_SOURCE_DIR}/grackle_repo/src/clib)
-target_include_directories(grackle PUBLIC ${CMAKE_BINARY_DIR}/extern/grackle)
+target_include_directories(grackle PUBLIC ${PROJECT_BINARY_DIR}/grackle_deps)
+target_include_directories(grackle PRIVATE ${HDF5_INCLUDE_DIRS} ${MPI_C_INCLUDE_PATH})
 target_link_libraries(grackle ${HDF5_LIBRARIES} ${MPI_C_LIBRARIES} gfortran)
-target_compile_definitions(grackle PRIVATE LINUX H5_USE_16_API CONFIG_BFLOAT_8 PIC)
+#Omit warning of deprecated functions (already from removed SPH-EXA)
+target_compile_definitions(grackle PUBLIC OMIT_LEGACY_INTERNAL_GRACKLE_FUNC)
+target_compile_definitions(grackle PRIVATE LINUX H5_USE_16_API PIC)
 set_target_properties(grackle PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Language specific compilation flags.
 target_compile_options(grackle PRIVATE
-    $<$<COMPILE_LANGUAGE:Fortran>:-fno-second-underscore -ffixed-line-length-132>
-)
+        $<$<COMPILE_LANGUAGE:Fortran>:-fno-second-underscore -ffixed-line-length-132>
+        )
 
 configure_file(grackle_deps/version.h.in ${CMAKE_BINARY_DIR}/extern/grackle/grackle_deps/version.h)

--- a/extern/grackle/config/grackle_float.in.h
+++ b/extern/grackle/config/grackle_float.in.h
@@ -1,0 +1,4 @@
+#ifndef __GRACKLE_FLOAT_H__
+#define __GRACKLE_FLOAT_H__
+#define ${PRECISION_DEFINE}
+#endif

--- a/extern/grackle/config/grackle_float.in.h
+++ b/extern/grackle/config/grackle_float.in.h
@@ -1,4 +1,0 @@
-#ifndef __GRACKLE_FLOAT_H__
-#define __GRACKLE_FLOAT_H__
-#define ${PRECISION_DEFINE}
-#endif

--- a/main/src/init/evrard_cooling_init.hpp
+++ b/main/src/init/evrard_cooling_init.hpp
@@ -35,20 +35,45 @@
 
 #include "cooling/init_chemistry.h"
 
+std::map<std::string, double> evrardCoolingConstants()
+{
+    return {{"gravConstant", 1.},
+            {"r", 1.},
+            {"mTotal", 1.},
+            {"gamma", 5. / 3.},
+            {"u0", 0.05},
+            {"minDt", 1e-4},
+            {"minDt_m1", 1e-4},
+            {"mui", 10},
+            {"ng0", 100},
+            {"ngmax", 150},
+            {"cooling::use_grackle", 1},
+            {"cooling::with_radiative_cooling", 1},
+            {"cooling::primordial_chemistry", 1},
+            {"cooling::dust_chemistry", 0},
+            {"cooling::metal_cooling", 0},
+            {"cooling::UVbackground", 0},
+            {"cooling::m_code_in_ms", 1e16},
+            {"cooling::l_code_in_kpc", 46400.}};
+}
+
 template<class Dataset>
 class EvrardGlassSphereCooling : public sphexa::EvrardGlassSphere<Dataset>
 {
+    using Base = sphexa::EvrardGlassSphere<Dataset>;
 
 public:
     EvrardGlassSphereCooling(std::string initBlock)
         : sphexa::EvrardGlassSphere<Dataset>(initBlock)
     {
+        Base::updateSettings(evrardCoolingConstants());
     }
 
     cstone::Box<typename Dataset::RealType> init(int rank, int numRanks, size_t cbrtNumPart,
                                                  Dataset& simData) const override
     {
         auto box = sphexa::EvrardGlassSphere<Dataset>::init(rank, numRanks, cbrtNumPart, simData);
+        std::fill(simData.hydro.u.begin(), simData.hydro.u.end(), Base::constants().at("u0"));
         cooling::initChemistryData(simData.chem, simData.hydro.x.size());
         return box;
     }

--- a/main/src/observables/conserved_gpu.cu
+++ b/main/src/observables/conserved_gpu.cu
@@ -89,10 +89,7 @@ conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* v
     {
         eInt = cv * thrust::inner_product(thrust::device, m + first, m + last, temp + first, Tt(0.0));
     }
-    else if (u != nullptr)
-    {
-        eInt = thrust::inner_product(thrust::device, m + first, m + last, u + first, Tt(0.0));
-    }
+    else if (u != nullptr) { eInt = thrust::inner_product(thrust::device, m + first, m + last, u + first, Tt(0.0)); }
 
     return {0.5 * eKin, eInt, linMom, angMom};
 }

--- a/main/src/observables/conserved_gpu.cu
+++ b/main/src/observables/conserved_gpu.cu
@@ -71,7 +71,7 @@ struct EMom
 template<class Tc, class Tv, class Tt, class Tm>
 std::tuple<double, double, Vec3<double>, Vec3<double>>
 conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz,
-                       const Tt* temp, const Tm* m, size_t first, size_t last)
+                       const Tt* temp, const Tt* u, const Tm* m, size_t first, size_t last)
 {
     auto it1 = thrust::make_zip_iterator(
         thrust::make_tuple(x + first, y + first, z + first, m + first, vx + first, vy + first, vz + first));
@@ -89,6 +89,10 @@ conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* v
     {
         eInt = cv * thrust::inner_product(thrust::device, m + first, m + last, temp + first, Tt(0.0));
     }
+    else if (u != nullptr)
+    {
+        eInt = thrust::inner_product(thrust::device, m + first, m + last, u + first, Tt(0.0));
+    }
 
     return {0.5 * eKin, eInt, linMom, angMom};
 }
@@ -96,7 +100,7 @@ conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* v
 #define CONSERVED_Q_GPU(Tc, Tv, Tt, Tm)                                                                                \
     template std::tuple<double, double, Vec3<double>, Vec3<double>> conservedQuantitiesGpu(                            \
         Tt, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz, const Tt* temp,           \
-        const Tm* m, size_t, size_t)
+        const Tt* u, const Tm* m, size_t, size_t)
 
 CONSERVED_Q_GPU(double, double, double, double);
 CONSERVED_Q_GPU(double, double, double, float);

--- a/main/src/observables/conserved_gpu.h
+++ b/main/src/observables/conserved_gpu.h
@@ -47,7 +47,8 @@ namespace sphexa
  * @param[in] vx         x-velocities
  * @param[in] vy         v-velocities
  * @param[in] vz         z-velocities
- * @param[in] temp       temperatures
+ * @param[in] temp       temperatures, can be nullptr
+ * @param[in] u          internal energies, can be nullptr
  * @param[in] m          masses
  * @param[in] first      first particle index to include in the sum
  * @param[in] last       last particle index to include in the sum
@@ -56,6 +57,6 @@ namespace sphexa
 template<class Tc, class Tv, class Tt, class Tm>
 extern std::tuple<double, double, cstone::Vec3<double>, cstone::Vec3<double>>
 conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz,
-                       const Tt* temp, const Tm* m, size_t first, size_t last);
+                       const Tt* temp, const Tt* u, const Tm* m, size_t first, size_t last);
 
 } // namespace sphexa

--- a/main/src/observables/conserved_quantities.hpp
+++ b/main/src/observables/conserved_quantities.hpp
@@ -63,7 +63,7 @@ auto localConservedQuantities(size_t startIndex, size_t endIndex, Dataset& d)
     double sharedCv = sph::idealGasCv(d.muiConst, d.gamma);
     bool   haveMui  = !d.mui.empty();
 
-#pragma omp declare reduction(+ : util::array<double, 3> : omp_out += omp_in) initializer(omp_priv(omp_orig))
+#pragma omp declare reduction(+ : util::array <double, 3> : omp_out += omp_in) initializer(omp_priv(omp_orig))
 
     double eKin = 0.0;
 #pragma omp parallel for reduction(+ : eKin, linmom, angmom)

--- a/main/src/observables/conserved_quantities.hpp
+++ b/main/src/observables/conserved_quantities.hpp
@@ -55,6 +55,7 @@ auto localConservedQuantities(size_t startIndex, size_t endIndex, Dataset& d)
     const auto* vz   = d.vz.data();
     const auto* m    = d.m.data();
     const auto* temp = d.temp.data();
+    const auto* u    = d.u.data();
 
     util::array<double, 3> linmom{0.0, 0.0, 0.0};
     util::array<double, 3> angmom{0.0, 0.0, 0.0};
@@ -62,7 +63,7 @@ auto localConservedQuantities(size_t startIndex, size_t endIndex, Dataset& d)
     double sharedCv = sph::idealGasCv(d.muiConst, d.gamma);
     bool   haveMui  = !d.mui.empty();
 
-#pragma omp declare reduction(+ : util::array <double, 3> : omp_out += omp_in) initializer(omp_priv(omp_orig))
+#pragma omp declare reduction(+ : util::array<double, 3> : omp_out += omp_in) initializer(omp_priv(omp_orig))
 
     double eKin = 0.0;
 #pragma omp parallel for reduction(+ : eKin, linmom, angmom)
@@ -79,8 +80,18 @@ auto localConservedQuantities(size_t startIndex, size_t endIndex, Dataset& d)
 
     double eInt = 0.0;
 
-    if (!d.temp.empty())
+    if (!d.u.empty())
     {
+#pragma omp parallel for reduction(+ : eInt)
+        for (size_t i = startIndex; i < endIndex; i++)
+        {
+            auto mi = m[i];
+            eInt += u[i] * mi;
+        }
+    }
+    else if (!d.temp.empty())
+    {
+
 #pragma omp parallel for reduction(+ : eInt)
         for (size_t i = startIndex; i < endIndex; i++)
         {
@@ -117,7 +128,7 @@ void computeConservedQuantities(size_t startIndex, size_t endIndex, Dataset& d, 
         std::tie(eKin, eInt, linmom, angmom) = conservedQuantitiesGpu(
             sph::idealGasCv(d.muiConst, d.gamma), rawPtr(d.devData.x), rawPtr(d.devData.y), rawPtr(d.devData.z),
             rawPtr(d.devData.vx), rawPtr(d.devData.vy), rawPtr(d.devData.vz), rawPtr(d.devData.temp),
-            rawPtr(d.devData.m), startIndex, endIndex);
+            rawPtr(d.devData.u), rawPtr(d.devData.m), startIndex, endIndex);
     }
     else
     {

--- a/main/src/propagator/std_hydro_grackle.hpp
+++ b/main/src/propagator/std_hydro_grackle.hpp
@@ -24,10 +24,11 @@
  */
 
 /*! @file
- * @brief A Propagator class for standard SPH
+ * @brief A Propagator class for standard SPH including Grackle chemistry and cooling
  *
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  * @author Jose A. Escartin <ja.escartin@gmail.com>
+ * @author Noah Kubli <noah.kubli@uzh.ch>
  */
 
 #pragma once
@@ -35,10 +36,12 @@
 #include <variant>
 
 #include "cstone/fields/field_get.hpp"
+#include "cstone/util/value_list.hpp"
 #include "sph/particles_data.hpp"
 #include "sph/sph.hpp"
 
 #include "cooling/cooler.hpp"
+#include "cooling/eos_cooling.hpp"
 
 #include "std_hydro.hpp"
 #include "gravity_wrapper.hpp"
@@ -55,8 +58,9 @@ class HydroGrackleProp final : public HydroProp<DomainType, DataType>
     using Base = HydroProp<DomainType, DataType>;
     using Base::timer;
 
-    using T       = typename DataType::RealType;
-    using KeyType = typename DataType::KeyType;
+    using T        = typename DataType::RealType;
+    using KeyType  = typename DataType::KeyType;
+    using ChemData = typename DataType::ChemData;
 
     cooling::Cooler<T> cooling_data;
 
@@ -64,33 +68,46 @@ class HydroGrackleProp final : public HydroProp<DomainType, DataType>
      *
      * x, y, z, h and m are automatically considered conserved and must not be specified in this list
      */
-    using ConservedFields = FieldList<"temp", "vx", "vy", "vz", "x_m1", "y_m1", "z_m1", "du_m1">;
+    using ConservedFields = FieldList<"u", "vx", "vy", "vz", "x_m1", "y_m1", "z_m1", "du_m1">;
 
     //! @brief the list of dependent particle fields, these may be used as scratch space during domain sync
     using DependentFields =
         FieldList<"rho", "p", "c", "ax", "ay", "az", "du", "c11", "c12", "c13", "c22", "c23", "c33", "nc">;
 
-    using CoolingFields =
-        FieldList<"HI_fraction", "HII_fraction", "HM_fraction", "HeI_fraction", "HeII_fraction", "HeIII_fraction",
-                  "H2I_fraction", "H2II_fraction", "DI_fraction", "DII_fraction", "HDI_fraction", "e_fraction",
-                  "metal_fraction", "volumetric_heating_rate", "specific_heating_rate", "RT_heating_rate",
-                  "RT_HI_ionization_rate", "RT_HeI_ionization_rate", "RT_HeII_ionization_rate",
-                  "RT_H2_dissociation_rate", "H2_self_shielding_length">;
+    //! @brief All fields listed in Chemistry data are used. This could be overridden with a sublist if desired
+    using CoolingFields = typename util::MakeFieldList<ChemData>::Fields;
 
 public:
     HydroGrackleProp(std::ostream& output, size_t rank)
         : Base(output, rank)
     {
-        constexpr float                 ms_sim = 1e16;
-        constexpr float                 kp_sim = 46400.;
-        std::map<std::string, std::any> grackleOptions;
-        grackleOptions["use_grackle"]            = 1;
-        grackleOptions["with_radiative_cooling"] = 1;
-        grackleOptions["dust_chemistry"]         = 0;
-        grackleOptions["metal_cooling"]          = 0;
-        grackleOptions["UVbackground"]           = 0;
-        cooling_data.init(ms_sim, kp_sim, 0, grackleOptions, std::nullopt);
     }
+
+    void load(const std::string& initCond, MPI_Comm comm) override
+    {
+        if (initCond == "evrard-cooling")
+        {
+            BuiltinWriter attributeSetter(evrardCoolingConstants());
+            cooling_data.loadOrStoreAttributes(&attributeSetter);
+        }
+        else
+        {
+            std::string path = strBeforeSign(initCond, ":");
+            if (std::filesystem::exists(path))
+            {
+                std::unique_ptr<IFileReader> reader;
+                reader = std::make_unique<H5PartReader>(comm);
+                reader->setStep(path, -1);
+                cooling_data.loadOrStoreAttributes(reader.get());
+                reader->closeStep();
+            }
+            else
+                throw std::runtime_error("");
+        }
+        cooling_data.init(0);
+    }
+
+    void save(IFileWriter* writer) override { cooling_data.loadOrStoreAttributes(writer); }
 
     std::vector<std::string> conservedFields() const override
     {
@@ -137,6 +154,42 @@ public:
         d.treeView = domain.octreeProperties();
     }
 
+    void computeForces(DomainType& domain, DataType& simData)
+    {
+        size_t first = domain.startIndex();
+        size_t last  = domain.endIndex();
+        auto&  d     = simData.hydro;
+
+        resizeNeighbors(d, domain.nParticles() * d.ngmax);
+        findNeighborsSfc(first, last, d, domain.box());
+        timer.step("FindNeighbors");
+
+        computeDensity(first, last, d, domain.box());
+        timer.step("Density");
+        eos_cooling(first, last, d, simData.chem, cooling_data);
+        timer.step("EquationOfState");
+
+        domain.exchangeHalos(get<"vx", "vy", "vz", "rho", "p", "c">(d), get<"ax">(d), get<"ay">(d));
+        timer.step("mpi::synchronizeHalos");
+
+        computeIAD(first, last, d, domain.box());
+        timer.step("IAD");
+
+        domain.exchangeHalos(get<"c11", "c12", "c13", "c22", "c23", "c33">(d), get<"ax">(d), get<"ay">(d));
+        timer.step("mpi::synchronizeHalos");
+
+        computeMomentumEnergySTD(first, last, d, domain.box());
+        timer.step("MomentumEnergyIAD");
+
+        if (d.g != 0.0)
+        {
+            Base::mHolder_.upsweep(d, domain);
+            timer.step("Upsweep");
+            Base::mHolder_.traverse(d, domain);
+            timer.step("Gravity");
+        }
+    }
+
     void step(DomainType& domain, DataType& simData) override
     {
         auto& d = simData.hydro;
@@ -149,34 +202,22 @@ public:
 
         d.resize(domain.nParticlesWithHalos());
 
-        Base::computeForces(domain, simData);
+        computeForces(domain, simData);
 
         size_t first = domain.startIndex();
         size_t last  = domain.endIndex();
 
-        computeTimestep(first, last, d);
+        auto minDtCooling = cooling::coolingTimestep(first, last, d, cooling_data, simData.chem);
+        computeTimestep(first, last, d, minDtCooling);
         timer.step("Timestep");
 
 #pragma omp parallel for schedule(static)
         for (size_t i = first; i < last; i++)
         {
-            bool haveMui = !d.mui.empty();
-            T    cv      = idealGasCv(haveMui ? d.mui[i] : d.muiConst, d.gamma);
-
-            T u_old  = cv * d.temp[i];
-            T u_cool = u_old;
-            cooling_data.cool_particle(
-                d.minDt, d.rho[i], u_cool, get<"HI_fraction">(simData.chem)[i], get<"HII_fraction">(simData.chem)[i],
-                get<"HM_fraction">(simData.chem)[i], get<"HeI_fraction">(simData.chem)[i],
-                get<"HeII_fraction">(simData.chem)[i], get<"HeIII_fraction">(simData.chem)[i],
-                get<"H2I_fraction">(simData.chem)[i], get<"H2II_fraction">(simData.chem)[i],
-                get<"DI_fraction">(simData.chem)[i], get<"DII_fraction">(simData.chem)[i],
-                get<"HDI_fraction">(simData.chem)[i], get<"e_fraction">(simData.chem)[i],
-                get<"metal_fraction">(simData.chem)[i], get<"volumetric_heating_rate">(simData.chem)[i],
-                get<"specific_heating_rate">(simData.chem)[i], get<"RT_heating_rate">(simData.chem)[i],
-                get<"RT_HI_ionization_rate">(simData.chem)[i], get<"RT_HeI_ionization_rate">(simData.chem)[i],
-                get<"RT_HeII_ionization_rate">(simData.chem)[i], get<"RT_H2_dissociation_rate">(simData.chem)[i],
-                get<"H2_self_shielding_length">(simData.chem)[i]);
+            T u_old  = d.u[i];
+            T u_cool = d.u[i];
+            cooling_data.cool_particle(d.minDt, d.rho[i], u_cool,
+                                       cstone::getPointers(get<CoolingFields>(simData.chem), i));
             const T du = (u_cool - u_old) / d.minDt;
             d.du[i] += du;
         }

--- a/physics/cooling/CMakeLists.txt
+++ b/physics/cooling/CMakeLists.txt
@@ -4,6 +4,7 @@ project(sphexa-cooling)
 set(CMAKE_CXX_STANDARD 20)
 
 set(CSTONE_DIR ${CMAKE_SOURCE_DIR}/domain/include)
+set(MAIN_APP_DIR ${CMAKE_SOURCE_DIR}/main/src)
 
 #include(CTest)
 #include(CheckLanguage)
@@ -11,4 +12,4 @@ add_subdirectory(include/cooling)
 
 if (BUILD_TESTING)
     add_subdirectory(test)
-endif()
+endif ()

--- a/physics/cooling/include/cooling/cooler.cpp
+++ b/physics/cooling/include/cooling/cooler.cpp
@@ -10,8 +10,9 @@ extern "C"
 #include "cooler.hpp"
 #include "cooler_field_data_content.h"
 
+#include <array>
+#include <vector>
 #include <map>
-#include <any>
 #include <cmath>
 #include <iostream>
 
@@ -23,6 +24,8 @@ struct Cooler<T>::Impl
 {
     friend struct Cooler<T>;
 
+    using ParticleType = typename Cooler<T>::ParticleType;
+
 private:
     //! @brief Solar mass in g
     constexpr static T ms_g = 1.989e33;
@@ -31,13 +34,13 @@ private:
     //! @brief Gravitational constant in cgs units
     constexpr static T G_newton = 6.674e-8;
     //! @brief code unit mass in solar masses
-    T ms = 1e16;
+    T m_code_in_ms = 1e16;
     //! @brief code unit length in kpc
-    T kpc = 46400.;
+    T l_code_in_kpc = 46400.;
     //! @brief Path to Grackle data file
     std::string grackle_data_file_path = CMAKE_SOURCE_DIR "/extern/grackle/grackle_repo/input/CloudyData_UVB=HM2012.h5";
 
-    void initOptions(const std::map<std::string, std::any>& grackle_options);
+    Impl();
 
     struct GlobalValues
     {
@@ -47,42 +50,87 @@ private:
     };
     GlobalValues global_values;
 
-    void init(const double ms_sim, const double kp_sim, const int comoving_coordinates,
-              const std::optional<std::map<std::string, std::any>> grackleOptions = std::nullopt,
-              const std::optional<double>                          t_sim          = std::nullopt);
+    constexpr static std::array parameterNames{
+        "m_code_in_ms", "l_code_in_kpc",
+        // Grackle parameters
+        "use_grackle", "with_radiative_cooling", "primordial_chemistry", "dust_chemistry", "metal_cooling",
+        "UVbackground",
+        //!
+        //! d.char *grackle_data_file",
+        "cmb_temperature_floor", "Gamma", "h2_on_dust", "use_dust_density_field", "dust_recombination_cooling",
+        "photoelectric_heating", "photoelectric_heating_rate", "use_isrf_field", "interstellar_radiation_field",
+        "use_volumetric_heating_rate", "use_specific_heating_rate", "three_body_rate", "cie_cooling",
+        "h2_optical_depth_approximation", "ih2co", "ipiht", "HydrogenFractionByMass", "DeuteriumToHydrogenRatio",
+        "SolarMetalFractionByMass", "local_dust_to_gas_ratio", "NumberOfTemperatureBins", "CaseBRecombination",
+        "TemperatureStart", "TemperatureEnd", "NumberOfDustTemperatureBins", "DustTemperatureStart",
+        "DustTemperatureEnd", "Compton_xray_heating", "LWbackground_sawtooth_suppression", "LWbackground_intensity",
+        "UVbackground_redshift_on", "UVbackground_redshift_off", "UVbackground_redshift_fullon",
+        "UVbackground_redshift_drop", "cloudy_electron_fraction_factor", "use_radiative_transfer",
+        "radiative_transfer_coupled_rate_solver", "radiative_transfer_intermediate_step",
+        "radiative_transfer_hydrogen_only", "self_shielding_method", "H2_self_shielding", "H2_custom_shielding",
+        "h2_charge_exchange_rate", "h2_dust_rate", "h2_h_cooling_rate", "collisional_excitation_rates",
+        "collisional_ionisation_rates", "recombination_cooling_rates", "bremsstrahlung_cooling_rates", "max_iterations",
+        "exit_after_iterations_exceeded"};
+
+    auto parametersTuple()
+    {
+        auto& d   = global_values.data;
+        auto  ret = std::tie(
+            m_code_in_ms, l_code_in_kpc, d.use_grackle, d.with_radiative_cooling, d.primordial_chemistry,
+            d.dust_chemistry, d.metal_cooling, d.UVbackground,
+            //!
+            //! d.char *grackle_data_file,
+            d.cmb_temperature_floor, d.Gamma, d.h2_on_dust, d.use_dust_density_field, d.dust_recombination_cooling,
+            d.photoelectric_heating, d.photoelectric_heating_rate, d.use_isrf_field, d.interstellar_radiation_field,
+            d.use_volumetric_heating_rate, d.use_specific_heating_rate, d.three_body_rate, d.cie_cooling,
+            d.h2_optical_depth_approximation, d.ih2co, d.ipiht, d.HydrogenFractionByMass, d.DeuteriumToHydrogenRatio,
+            d.SolarMetalFractionByMass, d.local_dust_to_gas_ratio, d.NumberOfTemperatureBins, d.CaseBRecombination,
+            d.TemperatureStart, d.TemperatureEnd, d.NumberOfDustTemperatureBins, d.DustTemperatureStart,
+            d.DustTemperatureEnd, d.Compton_xray_heating, d.LWbackground_sawtooth_suppression, d.LWbackground_intensity,
+            d.UVbackground_redshift_on, d.UVbackground_redshift_off, d.UVbackground_redshift_fullon,
+            d.UVbackground_redshift_drop, d.cloudy_electron_fraction_factor, d.use_radiative_transfer,
+            d.radiative_transfer_coupled_rate_solver, d.radiative_transfer_intermediate_step,
+            d.radiative_transfer_hydrogen_only, d.self_shielding_method, d.H2_self_shielding, d.H2_custom_shielding,
+            d.h2_charge_exchange_rate, d.h2_dust_rate, d.h2_h_cooling_rate, d.collisional_excitation_rates,
+            d.collisional_ionisation_rates, d.recombination_cooling_rates, d.bremsstrahlung_cooling_rates,
+            d.max_iterations, d.exit_after_iterations_exceeded);
+
+        static_assert(std::tuple_size_v<decltype(ret)> == parameterNames.size());
+        return ret;
+    }
+
+    std::vector<FieldVariant> getFields()
+    {
+        return std::apply([](auto&... a) { return std::vector<FieldVariant>{&a...}; }, parametersTuple());
+    }
+
+    static std::vector<const char*> getParameterNames()
+    {
+        auto a =
+            std::apply([](auto&... a) { return std::array<const char*, sizeof...(a)>{(&a[0])...}; }, parameterNames);
+        return std::vector(a.begin(), a.end());
+    }
+
+    void init(int comoving_coordinates, std::optional<T> time_unit);
 
     chemistry_data getDefaultChemistryData()
     {
-        chemistry_data data_default    = _set_default_chemistry_parameters();
+
+        chemistry_data data_default;
+        local_initialize_chemistry_parameters(&data_default);
         data_default.grackle_data_file = &grackle_data_file_path[0];
         return data_default;
     }
 
-    void cool_particle(const T& dt, T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                       T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction,
-                       T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction, T& volumetric_heating_rate,
-                       T& specific_heating_rate, T& RT_heating_rate, T& RT_HI_ionization_rate,
-                       T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate, T& RT_H2_dissociation_rate,
-                       T& H2_self_shielding_length);
+    void cool_particle(T dt, T& rho, T& u, const ParticleType& particle);
 
-    T energy_to_temperature(const T& dt, T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                            T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction,
-                            T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction,
-                            T& volumetric_heating_rate, T& specific_heating_rate, T& RT_heating_rate,
-                            T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-                            T& RT_H2_dissociation_rate, T& H2_self_shielding_length);
+    T energy_to_temperature(T dt, T rho, T u, const ParticleType& particle);
 
-    T pressure(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction, T& HeII_fraction,
-               T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction, T& DII_fraction, T& HDI_fraction,
-               T& e_fraction, T& metal_fraction, T& volumetric_heating_rate, T& specific_heating_rate,
-               T& RT_heating_rate, T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-               T& RT_H2_dissociation_rate, T& H2_self_shielding_length);
+    T pressure(T rho, T u, const ParticleType& particle);
 
-    T adiabatic_index(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction, T& HeII_fraction,
-                      T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction, T& DII_fraction,
-                      T& HDI_fraction, T& e_fraction, T& metal_fraction, T& volumetric_heating_rate,
-                      T& specific_heating_rate, T& RT_heating_rate, T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate,
-                      T& RT_HeII_ionization_rate, T& RT_H2_dissociation_rate, T& H2_self_shielding_length);
+    T adiabatic_index(T rho, T u, const ParticleType& particle);
+
+    T cooling_time(T rho, T u, const ParticleType& particle);
 };
 
 // Implementation of Cooler
@@ -96,70 +144,51 @@ template<typename T>
 Cooler<T>::~Cooler() = default;
 
 template<typename T>
-void Cooler<T>::init(const double ms_sim, const double kp_sim, const int comoving_coordinates,
-                     const std::optional<std::map<std::string, std::any>> grackleOptions,
-                     const std::optional<double>                          t_sim)
+void Cooler<T>::init(const int comoving_coordinates, const std::optional<T> time_unit)
 {
-    impl_ptr->init(ms_sim, kp_sim, comoving_coordinates, grackleOptions, t_sim);
+    impl_ptr->init(comoving_coordinates, time_unit);
 }
 
 template<typename T>
-void Cooler<T>::cool_particle(const T& dt, T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction,
-                              T& HeI_fraction, T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction,
-                              T& DI_fraction, T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction,
-                              T& volumetric_heating_rate, T& specific_heating_rate, T& RT_heating_rate,
-                              T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-                              T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+std::vector<typename Cooler<T>::FieldVariant> Cooler<T>::getParameters()
 {
-    impl_ptr->cool_particle(dt, rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction,
-                            HeIII_fraction, H2I_fraction, H2II_fraction, DI_fraction, DII_fraction, HDI_fraction,
-                            e_fraction, metal_fraction, volumetric_heating_rate, specific_heating_rate, RT_heating_rate,
-                            RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
-                            RT_H2_dissociation_rate, H2_self_shielding_length);
+    return impl_ptr->getFields();
 }
 
 template<typename T>
-T Cooler<T>::energy_to_temperature(const T& dt, T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction,
-                                   T& HeI_fraction, T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction,
-                                   T& H2II_fraction, T& DI_fraction, T& DII_fraction, T& HDI_fraction, T& e_fraction,
-                                   T& metal_fraction, T& volumetric_heating_rate, T& specific_heating_rate,
-                                   T& RT_heating_rate, T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate,
-                                   T& RT_HeII_ionization_rate, T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+std::vector<const char*> Cooler<T>::getParameterNames()
 {
-    return impl_ptr->energy_to_temperature(
-        dt, rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
-        H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction, volumetric_heating_rate,
-        specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
-        RT_H2_dissociation_rate, H2_self_shielding_length);
+    return Cooler<T>::Impl::getParameterNames();
 }
 
 template<typename T>
-T Cooler<T>::pressure(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction, T& HeII_fraction,
-                      T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction, T& DII_fraction,
-                      T& HDI_fraction, T& e_fraction, T& metal_fraction, T& volumetric_heating_rate,
-                      T& specific_heating_rate, T& RT_heating_rate, T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate,
-                      T& RT_HeII_ionization_rate, T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+void Cooler<T>::cool_particle(T dt, T& rho, T& u, const ParticleType& particle)
 {
-    return impl_ptr->pressure(rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction,
-                              HeIII_fraction, H2I_fraction, H2II_fraction, DI_fraction, DII_fraction, HDI_fraction,
-                              e_fraction, metal_fraction, volumetric_heating_rate, specific_heating_rate,
-                              RT_heating_rate, RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
-                              RT_H2_dissociation_rate, H2_self_shielding_length);
+    impl_ptr->cool_particle(dt, rho, u, particle);
 }
 
 template<typename T>
-T Cooler<T>::adiabatic_index(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                             T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction,
-                             T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction,
-                             T& volumetric_heating_rate, T& specific_heating_rate, T& RT_heating_rate,
-                             T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-                             T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+T Cooler<T>::energy_to_temperature(T dt, T rho, T u, const ParticleType& particle)
 {
-    return impl_ptr->adiabatic_index(
-        rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
-        H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction, volumetric_heating_rate,
-        specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
-        RT_H2_dissociation_rate, H2_self_shielding_length);
+    return impl_ptr->energy_to_temperature(dt, rho, u, particle);
+}
+
+template<typename T>
+T Cooler<T>::pressure(T rho, T u, const ParticleType& particle)
+{
+    return impl_ptr->pressure(rho, u, particle);
+}
+
+template<typename T>
+T Cooler<T>::adiabatic_index(T rho, T u, const ParticleType& particle)
+{
+    return impl_ptr->adiabatic_index(rho, u, particle);
+}
+
+template<typename T>
+T Cooler<T>::cooling_time(T rho, T u, const ParticleType& particle)
+{
+    return impl_ptr->cooling_time(rho, u, particle);
 }
 
 template struct Cooler<double>;
@@ -167,20 +196,23 @@ template struct Cooler<float>;
 
 // Implementation of Cooler::Impl
 template<typename T>
-void Cooler<T>::Impl::init(const double ms_sim, const double kp_sim, const int comoving_coordinates,
-                           const std::optional<std::map<std::string, std::any>> grackleOptions,
-                           const std::optional<double>                          t_sim)
+Cooler<T>::Impl::Impl()
 {
-    ms              = ms_sim;
-    kpc             = kp_sim;
+    local_initialize_chemistry_parameters(&global_values.data);
+    global_values.data.grackle_data_file = &grackle_data_file_path[0];
+}
+
+template<typename T>
+void Cooler<T>::Impl::init(const int comoving_coordinates, std::optional<T> tu)
+{
     grackle_verbose = 1;
 
     // Density
-    const double density_unit = ms * ms_g / std::pow(kpc * kp_cm, 3);
+    const double density_unit = m_code_in_ms * ms_g / std::pow(l_code_in_kpc * kp_cm, 3);
     // Time
-    const double time_unit = t_sim.value_or(std::sqrt(1. / (density_unit * G_newton)));
+    const double time_unit = tu.value_or(std::sqrt(1. / (density_unit * G_newton)));
     // Length
-    const double length_unit = kpc * kp_cm;
+    const double length_unit = l_code_in_kpc * kp_cm;
     // Velocity
     const double velocity_unit = length_unit / time_unit;
 
@@ -192,26 +224,16 @@ void Cooler<T>::Impl::init(const double ms_sim, const double kp_sim, const int c
     global_values.units.a_value              = 1.0;
     global_values.units.comoving_coordinates = comoving_coordinates;
 
+#ifndef NDEBUG
     std::cout << "debug\n";
-    std::cout << ms << "\t" << ms_g << "\t" << kpc << "\n";
+    std::cout << m_code_in_ms << "\t" << ms_g << "\t" << l_code_in_kpc << "\n";
     std::cout << "code units\n";
     std::cout << global_values.units.density_units << "\t" << global_values.units.time_units << "\t"
               << global_values.units.length_units << "\n";
 
-    global_values.data = _set_default_chemistry_parameters();
-
+#endif
     global_values.data.grackle_data_file = &grackle_data_file_path[0];
-
-    if (grackleOptions.has_value()) { initOptions(grackleOptions.value()); }
-    else
-    {
-        global_values.data     = getDefaultChemistryData();
-        grackle_data_file_path = std::string(global_values.data.grackle_data_file);
-        std::cout << grackle_data_file_path << std::endl;
-        global_values.data.grackle_data_file = &grackle_data_file_path[0];
-    }
-
-    if (0 == _initialize_chemistry_data(&global_values.data, &global_values.rates, &global_values.units))
+    if (0 == local_initialize_chemistry_data(&global_values.data, &global_values.rates, &global_values.units))
     {
         std::cout << global_values.data.with_radiative_cooling << std::endl;
         throw std::runtime_error("Grackle: Error in _initialize_chemistry_data");
@@ -219,81 +241,10 @@ void Cooler<T>::Impl::init(const double ms_sim, const double kp_sim, const int c
 }
 
 template<typename T>
-void Cooler<T>::Impl::initOptions(const std::map<std::string, std::any>& grackle_options)
-{
-    for (auto [key, value] : grackle_options)
-    {
-        try
-        {
-            if (key == "grackle_data_file_path")
-            {
-                grackle_data_file_path = std::any_cast<std::string>(value);
-                global_values.data.grackle_data_file;
-            }
-            if (key == ("use_grackle")) global_values.data.use_grackle = std::any_cast<int>(value);
-            if (key == ("with_radiative_cooling"))
-                global_values.data.with_radiative_cooling = std::any_cast<int>(value);
-            if (key == ("primordial_chemistry")) global_values.data.primordial_chemistry = std::any_cast<int>(value);
-            if (key == ("h2_on_dust")) global_values.data.h2_on_dust = std::any_cast<int>(value);
-            if (key == ("metal_cooling")) global_values.data.metal_cooling = std::any_cast<int>(value);
-            if (key == ("cmb_temperature_floor")) global_values.data.cmb_temperature_floor = std::any_cast<int>(value);
-            if (key == ("UVbackground")) global_values.data.UVbackground = std::any_cast<int>(value);
-            if (key == ("UVbackground_redshift_on"))
-                global_values.data.UVbackground_redshift_on = std::any_cast<int>(value);
-            if (key == ("UVbackground_redshift_fullon"))
-                global_values.data.UVbackground_redshift_fullon = std::any_cast<int>(value);
-            if (key == ("UVbackground_redshift_drop"))
-                global_values.data.UVbackground_redshift_drop = std::any_cast<int>(value);
-            if (key == ("UVbackground_redshift_off"))
-                global_values.data.UVbackground_redshift_off = std::any_cast<int>(value);
-            if (key == ("Gamma")) global_values.data.Gamma = std::any_cast<int>(value);
-            if (key == ("three_body_rate")) global_values.data.three_body_rate = std::any_cast<int>(value);
-            if (key == ("cie_cooling")) global_values.data.cie_cooling = std::any_cast<int>(value);
-            if (key == ("h2_optical_depth_approximation"))
-                global_values.data.h2_optical_depth_approximation = std::any_cast<int>(value);
-            if (key == ("photoelectric_heating_rate"))
-                global_values.data.photoelectric_heating_rate = std::any_cast<int>(value);
-            if (key == ("Compton_xray_heating")) global_values.data.Compton_xray_heating = std::any_cast<int>(value);
-            if (key == ("LWbackground_intensity"))
-                global_values.data.LWbackground_intensity = std::any_cast<int>(value);
-            if (key == ("LWbackground_sawtooth_suppression"))
-                global_values.data.LWbackground_sawtooth_suppression = std::any_cast<int>(value);
-            if (key == ("use_volumetric_heating_rate"))
-                global_values.data.use_volumetric_heating_rate = std::any_cast<int>(value);
-            if (key == ("use_specific_heating_rate"))
-                global_values.data.use_specific_heating_rate = std::any_cast<int>(value);
-            if (key == ("use_radiative_transfer"))
-                global_values.data.use_radiative_transfer = std::any_cast<int>(value);
-            if (key == ("radiative_transfer_coupled_rate_solver"))
-                global_values.data.radiative_transfer_coupled_rate_solver = std::any_cast<int>(value);
-            if (key == ("radiative_transfer_intermediate_step"))
-                global_values.data.radiative_transfer_intermediate_step = std::any_cast<int>(value);
-            if (key == ("radiative_transfer_hydrogen_only"))
-                global_values.data.radiative_transfer_hydrogen_only = std::any_cast<int>(value);
-            if (key == ("H2_self_shielding")) global_values.data.H2_self_shielding = std::any_cast<int>(value);
-            if (key == ("dust_chemistry")) global_values.data.dust_chemistry = std::any_cast<int>(value);
-        }
-        catch (std::bad_any_cast& e)
-        {
-            std::cout << "Wrong datatype " << key << std::endl;
-            std::cout << e.what();
-        }
-    }
-}
-template<typename T>
-void Cooler<T>::Impl::cool_particle(const T& dt, T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction,
-                                    T& HeI_fraction, T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction,
-                                    T& H2II_fraction, T& DI_fraction, T& DII_fraction, T& HDI_fraction, T& e_fraction,
-                                    T& metal_fraction, T& volumetric_heating_rate, T& specific_heating_rate,
-                                    T& RT_heating_rate, T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate,
-                                    T& RT_HeII_ionization_rate, T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+void Cooler<T>::Impl::cool_particle(T dt, T& rho, T& u, const ParticleType& particle)
 {
     cooler_field_data_content<T> grackle_fields;
-    grackle_fields.assign_field_data(
-        rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
-        H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction, volumetric_heating_rate,
-        specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
-        RT_H2_dissociation_rate, H2_self_shielding_length);
+    grackle_fields.assign_field_data(rho, u, particle);
 
     // Grackle uses 0 as a return code to indicate failure
     if (0 == local_solve_chemistry(&global_values.data, &global_values.rates, &global_values.units,
@@ -301,28 +252,14 @@ void Cooler<T>::Impl::cool_particle(const T& dt, T& rho, T& u, T& HI_fraction, T
     {
         throw std::runtime_error("Grackle: Error in local_solve_chemistry");
     }
-    grackle_fields.get_field_data(rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction,
-                                  HeIII_fraction, H2I_fraction, H2II_fraction, DI_fraction, DII_fraction, HDI_fraction,
-                                  e_fraction, metal_fraction, volumetric_heating_rate, specific_heating_rate,
-                                  RT_heating_rate, RT_HI_ionization_rate, RT_HeI_ionization_rate,
-                                  RT_HeII_ionization_rate, RT_H2_dissociation_rate, H2_self_shielding_length);
+    grackle_fields.get_field_data(rho, u, particle);
 }
 
 template<typename T>
-T Cooler<T>::Impl::energy_to_temperature(const T& dt, T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction,
-                                         T& HeI_fraction, T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction,
-                                         T& H2II_fraction, T& DI_fraction, T& DII_fraction, T& HDI_fraction,
-                                         T& e_fraction, T& metal_fraction, T& volumetric_heating_rate,
-                                         T& specific_heating_rate, T& RT_heating_rate, T& RT_HI_ionization_rate,
-                                         T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-                                         T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+T Cooler<T>::Impl::energy_to_temperature(T dt, T rho, T u, const ParticleType& particle)
 {
     cooler_field_data_content<T> grackle_fields;
-    grackle_fields.assign_field_data(
-        rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
-        H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction, volumetric_heating_rate,
-        specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
-        RT_H2_dissociation_rate, H2_self_shielding_length);
+    grackle_fields.assign_field_data(rho, u, particle);
     gr_float temp;
 
     if (0 == local_calculate_temperature(&global_values.data, &global_values.rates, &global_values.units,
@@ -334,19 +271,10 @@ T Cooler<T>::Impl::energy_to_temperature(const T& dt, T& rho, T& u, T& HI_fracti
 }
 
 template<typename T>
-T Cooler<T>::Impl::pressure(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                            T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction,
-                            T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction,
-                            T& volumetric_heating_rate, T& specific_heating_rate, T& RT_heating_rate,
-                            T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-                            T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+T Cooler<T>::Impl::pressure(T rho, T u, const ParticleType& particle)
 {
     cooler_field_data_content<T> grackle_fields;
-    grackle_fields.assign_field_data(
-        rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
-        H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction, volumetric_heating_rate,
-        specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
-        RT_H2_dissociation_rate, H2_self_shielding_length);
+    grackle_fields.assign_field_data(rho, u, particle);
     gr_float pressure(0);
     if (0 == local_calculate_pressure(&global_values.data, &global_values.rates, &global_values.units,
                                       &grackle_fields.data, &pressure))
@@ -357,22 +285,29 @@ T Cooler<T>::Impl::pressure(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM
 }
 
 template<typename T>
-T Cooler<T>::Impl::adiabatic_index(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                                   T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction,
-                                   T& DI_fraction, T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction,
-                                   T& volumetric_heating_rate, T& specific_heating_rate, T& RT_heating_rate,
-                                   T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-                                   T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+T Cooler<T>::Impl::adiabatic_index(T rho, T u, const ParticleType& particle)
 {
     cooler_field_data_content<T> grackle_fields;
-    grackle_fields.assign_field_data(
-        rho, u, HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
-        H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction, volumetric_heating_rate,
-        specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
-        RT_H2_dissociation_rate, H2_self_shielding_length);
+    grackle_fields.assign_field_data(rho, u, particle);
     gr_float gamma(0);
     local_calculate_gamma(&global_values.data, &global_values.rates, &global_values.units, &grackle_fields.data,
                           &gamma);
     return gamma;
 }
+
+template<typename T>
+T Cooler<T>::Impl::cooling_time(T rho, T u, const ParticleType& particle)
+{
+    cooler_field_data_content<T> grackle_fields;
+    grackle_fields.assign_field_data(rho, u, particle);
+    gr_float time(0.0);
+    if (0 == local_calculate_cooling_time(&global_values.data, &global_values.rates, &global_values.units,
+                                          &grackle_fields.data, &time))
+    {
+        throw std::runtime_error("Grackle: Error in local_calculate_cooling_time");
+    }
+
+    return time;
+}
+
 } // namespace cooling

--- a/physics/cooling/include/cooling/cooler.hpp
+++ b/physics/cooling/include/cooling/cooler.hpp
@@ -99,7 +99,7 @@ struct Cooler
 
     T cooling_time(T rho, T u, const ParticleType& particle);
 
-    //Parameter for cooling time criterion
+    // Parameter for cooling time criterion
     T ct_crit{0.1};
 
     template<class Archive>

--- a/physics/cooling/include/cooling/cooler.hpp
+++ b/physics/cooling/include/cooling/cooler.hpp
@@ -31,11 +31,17 @@
 
 #pragma once
 
+#include <array>
 #include <cstring>
 #include <optional>
 #include <memory>
 #include <map>
-#include <any>
+#include <variant>
+#include <vector>
+#include <iostream>
+
+#include "cstone/util/traits.hpp"
+#include "cstone/util/value_list.hpp"
 
 namespace cooling
 {
@@ -43,48 +49,89 @@ namespace cooling
 template<typename T>
 struct Cooler
 {
+    //! Grackle field names
+    inline static constexpr std::array fieldNames{"HI_fraction",
+                                                  "HII_fraction",
+                                                  "HM_fraction",
+                                                  "HeI_fraction",
+                                                  "HeII_fraction",
+                                                  "HeIII_fraction",
+                                                  "H2I_fraction",
+                                                  "H2II_fraction",
+                                                  "DI_fraction",
+                                                  "DII_fraction",
+                                                  "HDI_fraction",
+                                                  "e_fraction",
+                                                  "metal_fraction",
+                                                  "volumetric_heating_rate",
+                                                  "specific_heating_rate",
+                                                  "RT_heating_rate",
+                                                  "RT_HI_ionization_rate",
+                                                  "RT_HeI_ionization_rate",
+                                                  "RT_HeII_ionization_rate",
+                                                  "RT_H2_dissociation_rate",
+                                                  "H2_self_shielding_length"};
+
+    inline static constexpr size_t numFields = fieldNames.size();
+
+    using CoolingFields = util::MakeFieldList<Cooler<T>>::Fields;
+    using ParticleType  = util::Reduce<std::tuple, util::Repeat<util::TypeList<std::add_pointer_t<T>>, numFields>>;
+
     Cooler();
 
     ~Cooler();
 
-    //! @brief Init Cooler. Must be called before any other function is used.
-    void init(const double ms_sim, const double kp_sim, const int comoving_coordinates,
-              const std::optional<std::map<std::string, std::any>> grackleOptions = std::nullopt,
-              const std::optional<double>                          t_sim          = std::nullopt);
+    //! @brief Init Cooler. Must be called before any other function is used and after parameters are set
+    void init(int comoving_coordinates, std::optional<T> time_unit = std::nullopt);
 
     //! @brief Calls the GRACKLE library to integrate the cooling and chemistry fields
-    void cool_particle(const T& dt, T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                       T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction,
-                       T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction, T& volumetric_heating_rate,
-                       T& specific_heating_rate, T& RT_heating_rate, T& RT_HI_ionization_rate,
-                       T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate, T& RT_H2_dissociation_rate,
-                       T& H2_self_shielding_length);
+    void cool_particle(T dt, T& rho, T& u, const ParticleType& particle);
 
     //! @brief Calculate the temperature in K (physical units) from the internal energy (code units) and the chemistry
     //! composition
-    T energy_to_temperature(const T& dt, T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                            T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction,
-                            T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction,
-                            T& volumetric_heating_rate, T& specific_heating_rate, T& RT_heating_rate,
-                            T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-                            T& RT_H2_dissociation_rate, T& H2_self_shielding_length);
+    T energy_to_temperature(T dt, T rho, T u, const ParticleType& particle);
 
     //! @brief Calculate pressure using the chemistry composition
-    T pressure(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction, T& HeII_fraction,
-               T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction, T& DII_fraction, T& HDI_fraction,
-               T& e_fraction, T& metal_fraction, T& volumetric_heating_rate, T& specific_heating_rate,
-               T& RT_heating_rate, T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-               T& RT_H2_dissociation_rate, T& H2_self_shielding_length);
+    T pressure(T rho, T u, const ParticleType& particle);
 
     //! @brief Calculate adiabatic index from chemistry composition
-    T adiabatic_index(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction, T& HeII_fraction,
-                      T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction, T& DII_fraction,
-                      T& HDI_fraction, T& e_fraction, T& metal_fraction, T& volumetric_heating_rate,
-                      T& specific_heating_rate, T& RT_heating_rate, T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate,
-                      T& RT_HeII_ionization_rate, T& RT_H2_dissociation_rate, T& H2_self_shielding_length);
+    T adiabatic_index(T rho, T u, const ParticleType& particle);
+
+    T cooling_time(T rho, T u, const ParticleType& particle);
+
+    //Parameter for cooling time criterion
+    T ct_crit{0.1};
+
+    template<class Archive>
+    void loadOrStoreAttributes(Archive* ar)
+    {
+        auto parameterNames = getParameterNames();
+        auto parameters     = getParameters();
+        //! @brief load or store an attribute, skips non-existing attributes on load.
+        auto optionalIO = [ar](const std::string& attribute, auto* location, size_t attrSize)
+        {
+            try
+            {
+                ar->stepAttribute("cooling::" + attribute, location, attrSize);
+            }
+            catch (std::out_of_range&)
+            {
+                std::cout << "Attribute cooling::" << attribute
+                          << " not set in file or initializer, setting to default value " << *location << std::endl;
+            }
+        };
+        for (size_t i = 0; i < parameterNames.size(); i++)
+        {
+            std::visit([&](auto* location) { optionalIO(std::string(parameterNames[i]), location, 1); }, parameters[i]);
+        }
+        optionalIO("cooling::ct_crit", &ct_crit, 1);
+    }
 
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_ptr;
+    using FieldVariant = std::variant<float*, double*, int*>;
+    static std::vector<const char*> getParameterNames();
+    std::vector<FieldVariant>       getParameters();
 };
 } // namespace cooling

--- a/physics/cooling/include/cooling/cooler_field_data_content.h
+++ b/physics/cooling/include/cooling/cooler_field_data_content.h
@@ -112,18 +112,18 @@ struct cooler_field_data_content
 
     void get_field_data(T& rho, T& u, const ParticleType& particle)
     {
-        rho                      = gr_rho;
-        u                        = gr_u;
-        *std::get<0>(particle)  /*HI_fraction             */ = HI_density / gr_rho;
-        *std::get<1>(particle)  /*HII_fraction            */ = HII_density / gr_rho;
-        *std::get<2>(particle)  /*HM_fraction             */ = HM_density / gr_rho;
-        *std::get<3>(particle)  /*HeI_fraction            */ = HeI_density / gr_rho;
-        *std::get<4>(particle)  /*HeII_fraction           */ = HeII_density / gr_rho;
-        *std::get<5>(particle)  /*HeIII_fraction          */ = HeIII_density / gr_rho;
-        *std::get<6>(particle)  /*H2I_fraction            */ = H2I_density / gr_rho;
-        *std::get<7>(particle)  /*H2II_fraction           */ = H2II_density / gr_rho;
-        *std::get<8>(particle)  /*DI_fraction             */ = DI_density / gr_rho;
-        *std::get<9>(particle)  /*DII_fraction            */ = DII_density / gr_rho;
+        rho                                                  = gr_rho;
+        u                                                    = gr_u;
+        *std::get<0>(particle) /*HI_fraction             */  = HI_density / gr_rho;
+        *std::get<1>(particle) /*HII_fraction            */  = HII_density / gr_rho;
+        *std::get<2>(particle) /*HM_fraction             */  = HM_density / gr_rho;
+        *std::get<3>(particle) /*HeI_fraction            */  = HeI_density / gr_rho;
+        *std::get<4>(particle) /*HeII_fraction           */  = HeII_density / gr_rho;
+        *std::get<5>(particle) /*HeIII_fraction          */  = HeIII_density / gr_rho;
+        *std::get<6>(particle) /*H2I_fraction            */  = H2I_density / gr_rho;
+        *std::get<7>(particle) /*H2II_fraction           */  = H2II_density / gr_rho;
+        *std::get<8>(particle) /*DI_fraction             */  = DI_density / gr_rho;
+        *std::get<9>(particle) /*DII_fraction            */  = DII_density / gr_rho;
         *std::get<10>(particle) /*HDI_fraction            */ = HDI_density / gr_rho;
         *std::get<11>(particle) /*e_fraction              */ = e_density / gr_rho;
         *std::get<12>(particle) /*metal_fraction          */ = metal_density / gr_rho;

--- a/physics/cooling/include/cooling/cooler_field_data_content.h
+++ b/physics/cooling/include/cooling/cooler_field_data_content.h
@@ -2,18 +2,20 @@
 // Created by Noah Kubli on 29.11.22.
 //
 
-#ifndef SPHEXA_COOLER_FIELD_DATA_CONTENT_H
-#define SPHEXA_COOLER_FIELD_DATA_CONTENT_H
+#pragma once
 
 extern "C"
 {
 #include "grackle.h"
-};
+}
 
-// Implementation of cooling functions
+#include "cooler.hpp"
+
 template<typename T>
 struct cooler_field_data_content
 {
+    using ParticleType = typename cooling::Cooler<T>::ParticleType;
+
     grackle_field_data data;
     int                zero[3] = {0, 0, 0};
     int                one[3]  = {1, 1, 1};
@@ -44,12 +46,7 @@ struct cooler_field_data_content
     gr_float           RT_H2_dissociation_rate_gr;
     gr_float           H2_self_shielding_length_gr;
 
-    void assign_field_data(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                           T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction,
-                           T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction,
-                           T& volumetric_heating_rate, T& specific_heating_rate, T& RT_heating_rate,
-                           T& RT_HI_ionization_rate, T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate,
-                           T& RT_H2_dissociation_rate, T& H2_self_shielding_length)
+    void assign_field_data(T rho, T u, const ParticleType& particle)
     {
         data.grid_rank      = 3;
         data.grid_dimension = one;
@@ -62,27 +59,27 @@ struct cooler_field_data_content
         x_velocity                  = 0.;
         y_velocity                  = 0.;
         z_velocity                  = 0.;
-        HI_density                  = (gr_float)HI_fraction * (gr_float)rho;
-        HII_density                 = (gr_float)HII_fraction * (gr_float)rho;
-        HM_density                  = (gr_float)HM_fraction * (gr_float)rho;
-        HeI_density                 = (gr_float)HeI_fraction * (gr_float)rho;
-        HeII_density                = (gr_float)HeII_fraction * (gr_float)rho;
-        HeIII_density               = (gr_float)HeIII_fraction * (gr_float)rho;
-        H2I_density                 = (gr_float)H2I_fraction * (gr_float)rho;
-        H2II_density                = (gr_float)H2II_fraction * (gr_float)rho;
-        DI_density                  = (gr_float)DI_fraction * (gr_float)rho;
-        DII_density                 = (gr_float)DII_fraction * (gr_float)rho;
-        HDI_density                 = (gr_float)HDI_fraction * (gr_float)rho;
-        e_density                   = (gr_float)e_fraction * (gr_float)rho;
-        metal_density               = (gr_float)metal_fraction * (gr_float)rho;
-        volumetric_heating_rate_gr  = (gr_float)volumetric_heating_rate;
-        specific_heating_rate_gr    = (gr_float)specific_heating_rate;
-        RT_heating_rate_gr          = (gr_float)RT_heating_rate;
-        RT_HI_ionization_rate_gr    = (gr_float)RT_HI_ionization_rate;
-        RT_HeI_ionization_rate_gr   = (gr_float)RT_HeI_ionization_rate;
-        RT_HeII_ionization_rate_gr  = (gr_float)RT_HeII_ionization_rate;
-        RT_H2_dissociation_rate_gr  = (gr_float)RT_H2_dissociation_rate;
-        H2_self_shielding_length_gr = (gr_float)H2_self_shielding_length;
+        HI_density                  = (gr_float)*std::get<0>(particle) * (gr_float)rho;
+        HII_density                 = (gr_float)*std::get<1>(particle) * (gr_float)rho;
+        HM_density                  = (gr_float)*std::get<2>(particle) * (gr_float)rho;
+        HeI_density                 = (gr_float)*std::get<3>(particle) * (gr_float)rho;
+        HeII_density                = (gr_float)*std::get<4>(particle) * (gr_float)rho;
+        HeIII_density               = (gr_float)*std::get<5>(particle) * (gr_float)rho;
+        H2I_density                 = (gr_float)*std::get<6>(particle) * (gr_float)rho;
+        H2II_density                = (gr_float)*std::get<7>(particle) * (gr_float)rho;
+        DI_density                  = (gr_float)*std::get<8>(particle) * (gr_float)rho;
+        DII_density                 = (gr_float)*std::get<9>(particle) * (gr_float)rho;
+        HDI_density                 = (gr_float)*std::get<10>(particle) * (gr_float)rho;
+        e_density                   = (gr_float)*std::get<11>(particle) * (gr_float)rho;
+        metal_density               = (gr_float)*std::get<12>(particle) * (gr_float)rho;
+        volumetric_heating_rate_gr  = (gr_float)*std::get<13>(particle);
+        specific_heating_rate_gr    = (gr_float)*std::get<14>(particle);
+        RT_heating_rate_gr          = (gr_float)*std::get<15>(particle);
+        RT_HI_ionization_rate_gr    = (gr_float)*std::get<16>(particle);
+        RT_HeI_ionization_rate_gr   = (gr_float)*std::get<17>(particle);
+        RT_HeII_ionization_rate_gr  = (gr_float)*std::get<18>(particle);
+        RT_H2_dissociation_rate_gr  = (gr_float)*std::get<19>(particle);
+        H2_self_shielding_length_gr = (gr_float)*std::get<20>(particle);
 
         data.density         = &gr_rho;
         data.internal_energy = &gr_u;
@@ -113,37 +110,30 @@ struct cooler_field_data_content
         data.H2_self_shielding_length = &H2_self_shielding_length_gr;
     };
 
-    void get_field_data(T& rho, T& u, T& HI_fraction, T& HII_fraction, T& HM_fraction, T& HeI_fraction,
-                        T& HeII_fraction, T& HeIII_fraction, T& H2I_fraction, T& H2II_fraction, T& DI_fraction,
-                        T& DII_fraction, T& HDI_fraction, T& e_fraction, T& metal_fraction, T& volumetric_heating_rate,
-                        T& specific_heating_rate, T& RT_heating_rate, T& RT_HI_ionization_rate,
-                        T& RT_HeI_ionization_rate, T& RT_HeII_ionization_rate, T& RT_H2_dissociation_rate,
-                        T& H2_self_shielding_length)
+    void get_field_data(T& rho, T& u, const ParticleType& particle)
     {
         rho                      = gr_rho;
         u                        = gr_u;
-        HI_fraction              = HI_density / gr_rho;
-        HII_fraction             = HII_density / gr_rho;
-        HM_fraction              = HM_density / gr_rho;
-        HeI_fraction             = HeI_density / gr_rho;
-        HeII_fraction            = HeII_density / gr_rho;
-        HeIII_fraction           = HeIII_density / gr_rho;
-        H2I_fraction             = H2I_density / gr_rho;
-        H2II_fraction            = H2II_density / gr_rho;
-        DI_fraction              = DI_density / gr_rho;
-        DII_fraction             = DII_density / gr_rho;
-        HDI_fraction             = HDI_density / gr_rho;
-        e_fraction               = e_density / gr_rho;
-        metal_fraction           = metal_density / gr_rho;
-        volumetric_heating_rate  = volumetric_heating_rate_gr;
-        specific_heating_rate    = specific_heating_rate_gr;
-        RT_heating_rate          = RT_heating_rate_gr;
-        RT_HI_ionization_rate    = RT_HI_ionization_rate_gr;
-        RT_HeI_ionization_rate   = RT_HeI_ionization_rate_gr;
-        RT_HeII_ionization_rate  = RT_HeII_ionization_rate_gr;
-        RT_H2_dissociation_rate  = RT_H2_dissociation_rate_gr;
-        H2_self_shielding_length = H2_self_shielding_length_gr;
+        *std::get<0>(particle)  /*HI_fraction             */ = HI_density / gr_rho;
+        *std::get<1>(particle)  /*HII_fraction            */ = HII_density / gr_rho;
+        *std::get<2>(particle)  /*HM_fraction             */ = HM_density / gr_rho;
+        *std::get<3>(particle)  /*HeI_fraction            */ = HeI_density / gr_rho;
+        *std::get<4>(particle)  /*HeII_fraction           */ = HeII_density / gr_rho;
+        *std::get<5>(particle)  /*HeIII_fraction          */ = HeIII_density / gr_rho;
+        *std::get<6>(particle)  /*H2I_fraction            */ = H2I_density / gr_rho;
+        *std::get<7>(particle)  /*H2II_fraction           */ = H2II_density / gr_rho;
+        *std::get<8>(particle)  /*DI_fraction             */ = DI_density / gr_rho;
+        *std::get<9>(particle)  /*DII_fraction            */ = DII_density / gr_rho;
+        *std::get<10>(particle) /*HDI_fraction            */ = HDI_density / gr_rho;
+        *std::get<11>(particle) /*e_fraction              */ = e_density / gr_rho;
+        *std::get<12>(particle) /*metal_fraction          */ = metal_density / gr_rho;
+        *std::get<13>(particle) /*volumetric_heating_rate */ = volumetric_heating_rate_gr;
+        *std::get<14>(particle) /*specific_heating_rate   */ = specific_heating_rate_gr;
+        *std::get<15>(particle) /*RT_heating_rate         */ = RT_heating_rate_gr;
+        *std::get<16>(particle) /*RT_HI_ionization_rate   */ = RT_HI_ionization_rate_gr;
+        *std::get<17>(particle) /*RT_HeI_ionization_rate  */ = RT_HeI_ionization_rate_gr;
+        *std::get<18>(particle) /*RT_HeII_ionization_rate */ = RT_HeII_ionization_rate_gr;
+        *std::get<19>(particle) /*RT_H2_dissociation_rate */ = RT_H2_dissociation_rate_gr;
+        *std::get<20>(particle) /*H2_self_shielding_length*/ = H2_self_shielding_length_gr;
     }
 };
-
-#endif // SPHEXA_COOLER_FIELD_DATA_CONTENT_H

--- a/physics/cooling/include/cooling/eos_cooling.hpp
+++ b/physics/cooling/include/cooling/eos_cooling.hpp
@@ -1,0 +1,48 @@
+//
+// Created by Noah Kubli on 09.07.23.
+//
+
+#pragma once
+
+namespace cooling
+{
+
+//! @brief the maximum time-step based on local particles that Grackle can tolerate
+template<class Dataset, typename Cooler, typename Chem>
+auto coolingTimestep(size_t first, size_t last, Dataset& d, Cooler& cooler, Chem& chem)
+{
+    using T             = typename Dataset::RealType;
+    using CoolingFields = typename Cooler::CoolingFields;
+
+    T minTc(INFINITY);
+#pragma omp parallel for reduction(min : minTc)
+    for (size_t i = first; i < last; i++)
+    {
+        const T cooling_time = cooler.cooling_time(d.rho[i], d.u[i], cstone::getPointers(get<CoolingFields>(chem), i));
+        minTc                = std::min(std::abs(cooler.ct_crit * cooling_time), minTc);
+    }
+    return minTc;
+}
+
+template<typename HydroData, typename ChemData, typename Cooler>
+void eos_cooling(size_t startIndex, size_t endIndex, HydroData& d, ChemData& chem, Cooler& cooler)
+{
+    using CoolingFields = typename Cooler::CoolingFields;
+    using T             = typename HydroData::RealType;
+    const auto* rho     = d.rho.data();
+
+    auto* p = d.p.data();
+    auto* c = d.c.data();
+
+#pragma omp parallel for schedule(static)
+    for (size_t i = startIndex; i < endIndex; ++i)
+    {
+        T pressure    = cooler.pressure(rho[i], d.u[i], cstone::getPointers(get<CoolingFields>(chem), i));
+        T gamma       = cooler.adiabatic_index(rho[i], d.u[i], cstone::getPointers(get<CoolingFields>(chem), i));
+        T sound_speed = std::sqrt(gamma * pressure / rho[i]);
+        p[i]          = pressure;
+        c[i]          = sound_speed;
+    }
+}
+
+} // namespace cooling

--- a/physics/cooling/test/CMakeLists.txt
+++ b/physics/cooling/test/CMakeLists.txt
@@ -6,8 +6,7 @@ target_compile_options(${testname} PRIVATE -Wall -Wextra)
 target_compile_definitions(${testname} PUBLIC SPH_EXA_HAVE_H5PART)
 
 
-
-target_include_directories(${testname} PRIVATE ${CSTONE_DIR} ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(${testname} PRIVATE ${CSTONE_DIR} ${PROJECT_SOURCE_DIR}/include ${MAIN_APP_DIR})
 
 target_link_libraries(${testname} PRIVATE grackle)
 target_link_libraries(${testname} PRIVATE cooler)

--- a/physics/cooling/test/cooling.cpp
+++ b/physics/cooling/test/cooling.cpp
@@ -1,11 +1,13 @@
 
-#define CONFIG_BFLOAT_8
-
-#include "cooling/cooler.hpp"
 #include <iostream>
 #include <vector>
 #include <cmath>
 #include "gtest/gtest.h"
+
+#include "cooling/cooler.hpp"
+
+#include "cstone/fields/field_get.hpp"
+#include "io/ifile_io.hpp"
 
 TEST(cooling_grackle, test1a)
 {
@@ -25,16 +27,22 @@ TEST(cooling_grackle, test1a)
 
     const Real mass_unit = std::pow(length_units, 3.0) * density_units / MSOLG;
 
-    cooling::Cooler<Real>           cd;
-    std::map<std::string, std::any> grackleOptions;
-    grackleOptions["use_grackle"]            = 1;
-    grackleOptions["with_radiative_cooling"] = 1;
-    grackleOptions["primordial_chemistry"]   = 3;
-    grackleOptions["dust_chemistry"]         = 1;
-    grackleOptions["UVbackground"]           = 1;
-    grackleOptions["metal_cooling"]          = 1;
+    cooling::Cooler<Real> cd;
 
-    cd.init(mass_unit, 1.0 / KPCCM, 0, grackleOptions, time_units);
+    std::map<std::string, double> grackleOptions;
+    grackleOptions["cooling::m_code_in_ms"]           = mass_unit;
+    grackleOptions["cooling::l_code_in_kpc"]          = 1. / KPCCM;
+    grackleOptions["cooling::use_grackle"]            = 1;
+    grackleOptions["cooling::with_radiative_cooling"] = 1;
+    grackleOptions["cooling::primordial_chemistry"]   = 3;
+    grackleOptions["cooling::dust_chemistry"]         = 1;
+    grackleOptions["cooling::UVbackground"]           = 1;
+    grackleOptions["cooling::metal_cooling"]          = 1;
+
+    sphexa::BuiltinWriter attributeSetter(grackleOptions);
+    cd.loadOrStoreAttributes(&attributeSetter);
+
+    cd.init(0, time_units);
 
     constexpr Real tiny_number = 1.e-20;
     constexpr Real dt          = 3.15e7 * 1e6; // grackle_units.time_units;
@@ -76,53 +84,40 @@ TEST(cooling_grackle, test1a)
     std::cout << HeI_fraction[0] << std::endl;
     std::cout << metal_fraction[0] << std::endl;
 
-    cd.cool_particle(dt / time_units, rho[0], u[0], HI_fraction[0], HII_fraction[0], HM_fraction[0], HeI_fraction[0],
-                     HeII_fraction[0], HeIII_fraction[0], H2I_fraction[0], H2II_fraction[0], DI_fraction[0],
-                     DII_fraction[0], HDI_fraction[0], e_fraction[0], metal_fraction[0], volumetric_heating_rate[0],
-                     specific_heating_rate[0], RT_heating_rate[0], RT_HI_ionization_rate[0], RT_HeI_ionization_rate[0],
-                     RT_HeII_ionization_rate[0], RT_H2_dissociation_rate[0], H2_self_shielding_length[0]);
+    auto grData =
+        std::tie(HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
+                 H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction,
+                 volumetric_heating_rate, specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate,
+                 RT_HeI_ionization_rate, RT_HeII_ionization_rate, RT_H2_dissociation_rate, H2_self_shielding_length);
+
+    cd.cool_particle(dt / time_units, rho[0], u[0], cstone::getPointers(grData, 0));
 
     std::cout << HI_fraction[0] << std::endl;
 
     EXPECT_NEAR(HI_fraction[0], 0.630705, 1e-6);
     EXPECT_NEAR(u[0], 2.95159e+35, 1e30);
-
-    /*constexpr Real R = 8.317e7;
-    constexpr Real mui = 1.21;
-    constexpr Real conv = Real(1.5) * R / mui;
-
-    gr_float grackle_conv = 1./get_temperature_units(&cd.global_values.units);
-    double grackle_R = grackle_conv * mui * 1.5;
-    std::cout << grackle_R << std::endl;
-    double gamma;
-    calculate_gamma(&cd.global_values.units, &cd.global_values.data, &gamma);
-
-    std::cout << gamma << std::endl; */
-
-    /* get_temperature_units();
-     calculate_gamma();
-     calculate_pressure();
-     calculate_temperature();*/
-    // cleanGrackle();
 }
 // This test just produces a table of cooling values for different choices of rho and u
 TEST(cooling_grackle2, test2)
 {
     // Path where to write the table
-    const std::string writePath{"~/cooling_test1/sphexa.txt"};
+    const std::string writePath{"sphexa_cooling_test.txt"};
 
     using Real = double;
-    cooling::Cooler<Real> cd;
-    // auto options = cd.getDefaultChemistryData();
-    std::map<std::string, std::any> grackleOptions;
-    grackleOptions["use_grackle"]            = 1;
-    grackleOptions["with_radiative_cooling"] = 1;
-    grackleOptions["primordial_chemistry"]   = 1;
-    grackleOptions["dust_chemistry"]         = 0;
-    grackleOptions["UVbackground"]           = 0;
-    grackleOptions["metal_cooling"]          = 0;
+    cooling::Cooler<Real>         cd;
+    std::map<std::string, double> grackleOptions;
+    grackleOptions["cooling::m_code_in_ms"]           = 1e16;
+    grackleOptions["cooling::l_code_in_kpc"]          = 46400;
+    grackleOptions["cooling::use_grackle"]            = 1;
+    grackleOptions["cooling::with_radiative_cooling"] = 1;
+    grackleOptions["cooling::primordial_chemistry"]   = 1;
+    grackleOptions["cooling::dust_chemistry"]         = 0;
+    grackleOptions["cooling::UVbackground"]           = 0;
+    grackleOptions["cooling::metal_cooling"]          = 0;
 
-    cd.init(1e16, 46400., 0, grackleOptions, std::nullopt);
+    sphexa::BuiltinWriter attributeSetter(grackleOptions);
+    cd.loadOrStoreAttributes(&attributeSetter);
+    cd.init(0);
 
     constexpr Real tiny_number = 1.e-20;
     constexpr Real dt          = 0.01; // grackle_units.time_units;
@@ -173,12 +168,13 @@ TEST(cooling_grackle2, test2)
         auto RT_H2_dissociation_rate  = std::vector<Real>{0.};
         auto H2_self_shielding_length = std::vector<Real>{0.};
 
-        cd.cool_particle(dt, rho[0], u[0], HI_fraction[0], HII_fraction[0], HM_fraction[0], HeI_fraction[0],
-                         HeII_fraction[0], HeIII_fraction[0], H2I_fraction[0], H2II_fraction[0], DI_fraction[0],
-                         DII_fraction[0], HDI_fraction[0], e_fraction[0], metal_fraction[0], volumetric_heating_rate[0],
-                         specific_heating_rate[0], RT_heating_rate[0], RT_HI_ionization_rate[0],
-                         RT_HeI_ionization_rate[0], RT_HeII_ionization_rate[0], RT_H2_dissociation_rate[0],
-                         H2_self_shielding_length[0]);
+      auto grData =
+          std::tie(HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
+                   H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction,
+                   volumetric_heating_rate, specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate,
+                   RT_HeI_ionization_rate, RT_HeII_ionization_rate, RT_H2_dissociation_rate, H2_self_shielding_length);
+
+        cd.cool_particle(dt, rho[0], u[0], cstone::getPointers(grData, 0));
 
         return u[0];
     };

--- a/physics/cooling/test/cooling.cpp
+++ b/physics/cooling/test/cooling.cpp
@@ -168,11 +168,11 @@ TEST(cooling_grackle2, test2)
         auto RT_H2_dissociation_rate  = std::vector<Real>{0.};
         auto H2_self_shielding_length = std::vector<Real>{0.};
 
-      auto grData =
-          std::tie(HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction, H2I_fraction,
-                   H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction, metal_fraction,
-                   volumetric_heating_rate, specific_heating_rate, RT_heating_rate, RT_HI_ionization_rate,
-                   RT_HeI_ionization_rate, RT_HeII_ionization_rate, RT_H2_dissociation_rate, H2_self_shielding_length);
+        auto grData = std::tie(HI_fraction, HII_fraction, HM_fraction, HeI_fraction, HeII_fraction, HeIII_fraction,
+                               H2I_fraction, H2II_fraction, DI_fraction, DII_fraction, HDI_fraction, e_fraction,
+                               metal_fraction, volumetric_heating_rate, specific_heating_rate, RT_heating_rate,
+                               RT_HI_ionization_rate, RT_HeI_ionization_rate, RT_HeII_ionization_rate,
+                               RT_H2_dissociation_rate, H2_self_shielding_length);
 
         cd.cool_particle(dt, rho[0], u[0], cstone::getPointers(grData, 0));
 

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -78,19 +78,13 @@ HOST_DEVICE_FUN auto positionUpdate(double dt, double dt_m1, cstone::Vec3<T> X, 
 }
 
 template<class T, class Dataset>
-void computePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
+void updatePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
 {
-    double dt    = d.minDt;
-    double dt_m1 = d.minDt_m1;
-
     bool fbcX = (box.boundaryX() == cstone::BoundaryType::fixed);
     bool fbcY = (box.boundaryY() == cstone::BoundaryType::fixed);
     bool fbcZ = (box.boundaryZ() == cstone::BoundaryType::fixed);
 
     bool anyFBC = fbcX || fbcY || fbcZ;
-
-    bool haveMui = !d.mui.empty();
-    T    constCv = idealGasCv(d.muiConst, d.gamma);
 
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
@@ -109,21 +103,37 @@ void computePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const 
         cstone::Vec3<T> X{d.x[i], d.y[i], d.z[i]};
         cstone::Vec3<T> X_m1{d.x_m1[i], d.y_m1[i], d.z_m1[i]};
         cstone::Vec3<T> V;
-        util::tie(X, V, X_m1) = positionUpdate(dt, dt_m1, X, A, X_m1, box);
+        util::tie(X, V, X_m1) = positionUpdate(d.minDt, d.minDt_m1, X, A, X_m1, box);
 
         util::tie(d.x[i], d.y[i], d.z[i])          = util::tie(X[0], X[1], X[2]);
         util::tie(d.x_m1[i], d.y_m1[i], d.z_m1[i]) = util::tie(X_m1[0], X_m1[1], X_m1[2]);
         util::tie(d.vx[i], d.vy[i], d.vz[i])       = util::tie(V[0], V[1], V[2]);
     }
+}
 
-    if (d.temp.empty()) { return; }
+template<class Dataset>
+void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d)
+{
+    bool haveMui = !d.mui.empty();
+    auto constCv = idealGasCv(d.muiConst, d.gamma);
 
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        T cv       = haveMui ? idealGasCv(d.mui[i], d.gamma) : constCv;
-        T u_old    = cv * d.temp[i];
-        d.temp[i]  = energyUpdate(u_old, dt, dt_m1, d.du[i], d.du_m1[i]) / cv;
+        auto cv    = haveMui ? idealGasCv(d.mui[i], d.gamma) : constCv;
+        auto u_old = cv * d.temp[i];
+        d.temp[i]  = energyUpdate(u_old, d.minDt, d.minDt_m1, d.du[i], d.du_m1[i]) / cv;
+        d.du_m1[i] = d.du[i];
+    }
+}
+
+template<class Dataset>
+void updateIntEnergyHost(size_t startIndex, size_t endIndex, Dataset& d)
+{
+#pragma omp parallel for schedule(static)
+    for (size_t i = startIndex; i < endIndex; i++)
+    {
+        d.u[i]     = energyUpdate(d.u[i], d.minDt, d.minDt_m1, d.du[i], d.du_m1[i]);
         d.du_m1[i] = d.du[i];
     }
 }
@@ -140,10 +150,16 @@ void computePositions(size_t startIndex, size_t endIndex, Dataset& d, const csto
                             rawPtr(d.devData.z), rawPtr(d.devData.vx), rawPtr(d.devData.vy), rawPtr(d.devData.vz),
                             rawPtr(d.devData.x_m1), rawPtr(d.devData.y_m1), rawPtr(d.devData.z_m1),
                             rawPtr(d.devData.ax), rawPtr(d.devData.ay), rawPtr(d.devData.az), rawPtr(d.devData.temp),
-                            rawPtr(d.devData.du), rawPtr(d.devData.du_m1), rawPtr(d.devData.h), d_mui, d.gamma, constCv,
-                            box);
+                            rawPtr(d.devData.u), rawPtr(d.devData.du), rawPtr(d.devData.du_m1), rawPtr(d.devData.h),
+                            d_mui, d.gamma, constCv, box);
     }
-    else { computePositionsHost(startIndex, endIndex, d, box); }
+    else
+    {
+        updatePositionsHost(startIndex, endIndex, d, box);
+
+        if (!d.temp.empty()) { updateTempHost(startIndex, endIndex, d); }
+        else if (!d.u.empty()) { updateIntEnergyHost(startIndex, endIndex, d); }
+    }
 }
 
 } // namespace sph

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -38,7 +38,7 @@ namespace sph
 template<class Tc, class Tv, class Ta, class Tm1, class Tt, class Thydro>
 __global__ void computePositionsKernel(size_t first, size_t last, double dt, double dt_m1, Tc* x, Tc* y, Tc* z, Tv* vx,
                                        Tv* vy, Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az,
-                                       Tt* temp, Tm1* du, Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma,
+                                       Tt* temp, Tt* u, Tm1* du, Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma,
                                        Thydro constCv, const cstone::Box<Tc> box)
 {
     cstone::LocalIndex i = first + blockDim.x * blockIdx.x + threadIdx.x;
@@ -75,25 +75,30 @@ __global__ void computePositionsKernel(size_t first, size_t last, double dt, dou
         temp[i]      = energyUpdate(u_old, dt, dt_m1, du[i], du_m1[i]) / cv;
         du_m1[i]     = du[i];
     }
+    else if (u != nullptr)
+    {
+        u[i]     = energyUpdate(u[i], dt, dt_m1, du[i], du_m1[i]);
+        du_m1[i] = du[i];
+    }
 }
 
 template<class Tc, class Tv, class Ta, class Tm1, class Tt, class Thydro>
 void computePositionsGpu(size_t first, size_t last, double dt, double dt_m1, Tc* x, Tc* y, Tc* z, Tv* vx, Tv* vy,
-                         Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az, Tt* temp, Tm1* du, Tm1* du_m1,
-                         Thydro* h, Thydro* mui, Thydro gamma, Thydro constCv, const cstone::Box<Tc>& box)
+                         Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az, Tt* temp, Tt* u, Tm1* du,
+                         Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma, Thydro constCv, const cstone::Box<Tc>& box)
 {
     cstone::LocalIndex numParticles = last - first;
     unsigned           numThreads   = 256;
     unsigned           numBlocks    = (numParticles + numThreads - 1) / numThreads;
 
     computePositionsKernel<<<numBlocks, numThreads>>>(first, last, dt, dt_m1, x, y, z, vx, vy, vz, x_m1, y_m1, z_m1, ax,
-                                                      ay, az, temp, du, du_m1, h, mui, gamma, constCv, box);
+                                                      ay, az, temp, u, du, du_m1, h, mui, gamma, constCv, box);
 }
 
 #define POS_GPU(Tc, Tv, Ta, Tm1, Tt, Thydro)                                                                           \
     template void computePositionsGpu(size_t first, size_t last, double dt, double dt_m1, Tc* x, Tc* y, Tc* z, Tv* vx, \
                                       Tv* vy, Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az,         \
-                                      Tt* temp, Tm1* du, Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma,             \
+                                      Tt* temp, Tt* u, Tm1* du, Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma,      \
                                       Thydro constCv, const cstone::Box<Tc>& box)
 
 POS_GPU(double, double, double, double, double, double);

--- a/sph/include/sph/sph_gpu.hpp
+++ b/sph/include/sph/sph_gpu.hpp
@@ -47,8 +47,8 @@ extern void computeEOS(size_t, size_t, Tu, Tu, const Tu*, const Tm*, const Thydr
 
 template<class Tc, class Tv, class Ta, class Tm1, class Tu, class Thydro>
 extern void computePositionsGpu(size_t first, size_t last, double dt, double dt_m1, Tc* x, Tc* y, Tc* z, Tv* vx, Tv* vy,
-                                Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az, Tu* u, Tm1* du,
-                                Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma, Thydro constCv,
+                                Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az, Tu* temp, Tu* u,
+                                Tm1* du, Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma, Thydro constCv,
                                 const cstone::Box<Tc>& box);
 
 template<class Th>


### PR DESCRIPTION
Update for the radiative cooling.
Changes made:
- Propagator now also calculates a cooling timestep
- Propagator calculates pressure via grackle (important if H2 is present)
- Function loadOrStoreAttributes() implemented in cooler.hpp allowing to read and write Cooling parameters to file. This happens in load and save functions of the propagator.
- Adapted Evrard init and cooling tests for the new layout.
- Using internal energy u instead of temperature if cooling is activated (otherwise tedious conversions are required).