### PR TITLE
Reapply domain exchange to additional fields after domain.sync

### DIFF
--- a/domain/include/cstone/domain/buffer_description.hpp
+++ b/domain/include/cstone/domain/buffer_description.hpp
@@ -1,0 +1,247 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 CSCS, ETH Zurich
+ *               2021 University of Basel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief Buffer description and management for domain decomposition particle exchanges
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#pragma once
+
+#include "cstone/domain/index_ranges.hpp"
+#include "cstone/primitives/gather.hpp"
+#include "cstone/tree/definitions.h"
+#include "cstone/util/traits.hpp"
+
+namespace cstone
+{
+
+/*! @brief Layout description for particle buffers
+ *
+ * Common usage: storing the sub-range of locally owned/assigned particles within particle buffers
+ *
+ * 0       start              end      size
+ * |-------|------------------|--------|
+ *   halos   locally assigned   halos
+ */
+struct BufferDescription
+{
+    //! @brief subrange start
+    LocalIndex start;
+    //! @brief subrange end
+    LocalIndex end;
+    //! @brief total size of the buffer
+    LocalIndex size;
+};
+
+template<class... Arrays>
+auto computeByteOffsets(size_t count, int alignment, Arrays... arrays)
+{
+    static_assert((... && std::is_pointer_v<Arrays>)&&"all arrays must be pointers");
+
+    util::array<size_t, sizeof...(Arrays) + 1> byteOffsets{sizeof(std::decay_t<decltype(*arrays)>)...};
+    byteOffsets *= count;
+
+    //! each sub-buffer will be aligned on a @a alignment-byte aligned boundary
+    for (size_t i = 0; i < byteOffsets.size(); ++i)
+    {
+        byteOffsets[i] = round_up(byteOffsets[i], alignment);
+    }
+
+    std::exclusive_scan(byteOffsets.begin(), byteOffsets.end(), byteOffsets.begin(), size_t(0));
+
+    return byteOffsets;
+}
+
+template<int alignment, class... Arrays>
+size_t
+computeTotalSendBytes(const SendList& sendList, int thisRank, size_t numBytesHeader, Arrays... arrays)
+{
+    size_t totalSendBytes = 0;
+    for (int destinationRank = 0; destinationRank < int(sendList.size()); ++destinationRank)
+    {
+        size_t sendCount = sendList[destinationRank].totalCount();
+        if (destinationRank == thisRank || sendCount == 0) { continue; }
+
+        size_t particleBytes = computeByteOffsets(sendCount, alignment, arrays...).back();
+        //! we add @a alignment bytes to the start of each message to provide space for the message length
+        totalSendBytes += numBytesHeader + particleBytes;
+    }
+
+    return totalSendBytes;
+}
+
+namespace aux_traits
+{
+template<class T>
+using MakeL2ArrayPtrs = util::array<T*, 2>;
+}
+
+/*! @brief Compute multiple pointers such that the argument @p arrays can be mapped into a single buffer
+ *
+ * @tparam alignment        byte alignment of the individual arrays in the packed buffer
+ * @tparam Arrays           arbitrary type of size 16 bytes or smaller
+ * @param packedBufferBase  base address of the packed buffer
+ * @param arraySize         number of elements of each @p array
+ * @param arrays            independent array pointers
+ * @return                  a tuple with (src, packed) pointers for each array
+ *
+ * @p arrays:    ------      ------         ------
+ *   (pointers)  a           b              c
+ *
+ * packedBuffer    |------|------|------|
+ *  (pointer)       A      B      C
+ *                  |
+ *                  packedBufferBase
+ *
+ * return  tuple( (a, A), (b, B), (c, C) )
+ *
+ * Pointer types are util::array<float, sizeof(*(a, b or c) / sizeof(float)>..., i.e. the same size as the original
+ * element types. This is done to express all types up to 16 bytes with just four util::array types in order
+ * to reduce the number of gather/scatter GPU kernel template instantiations.
+ */
+template<int alignment, class... Arrays>
+auto packBufferPtrs(char* packedBufferBase, size_t arraySize, Arrays... arrays)
+{
+    static_assert((... && std::is_pointer_v<Arrays>)&&"all arrays must be pointers");
+    constexpr int numArrays = sizeof...(Arrays);
+    constexpr util::array<size_t, numArrays> elementSizes{sizeof(std::decay_t<decltype(*arrays)>)...};
+    constexpr auto indices = makeIntegralTuple(std::make_index_sequence<numArrays>{});
+
+    const std::array<char*, numArrays> data{reinterpret_cast<char*>(arrays)...};
+
+    auto arrayByteOffsets = computeByteOffsets(arraySize, alignment, arrays...);
+
+    using Types     = util::TypeList<util::array<float, sizeof(std::decay_t<decltype(*arrays)>) / sizeof(float)>...>;
+    using PtrTypes  = util::Map<aux_traits::MakeL2ArrayPtrs, Types>;
+    using TupleType = util::Reduce<std::tuple, PtrTypes>;
+
+    TupleType ret;
+
+    auto packOneBuffer = [packedBufferBase, &data, &elementSizes, &arrayByteOffsets, &ret](auto index)
+    {
+        using ElementType = util::array<float, elementSizes[index] / sizeof(float)>;
+        auto* srcPtr      = reinterpret_cast<ElementType*>(data[index]);
+        auto* packedPtr   = reinterpret_cast<ElementType*>(packedBufferBase + arrayByteOffsets[index]);
+
+        std::get<index>(ret) = util::array<ElementType*, 2>{srcPtr, packedPtr};
+    };
+
+    for_each_tuple(packOneBuffer, indices);
+
+    return ret;
+}
+
+//! @brief Gather @p numElements of each array accessed through @p ordering into @p buffer. CPU and GPU.
+template<int alignment, class F, class... Arrays>
+std::size_t packArrays(F&& gather, const LocalIndex* ordering, LocalIndex numElements, char* buffer, Arrays... arrays)
+{
+    auto gatherArray = [&gather, numElements, ordering](auto arrayPair)
+    { gather(ordering, numElements, arrayPair[0], arrayPair[1]); };
+
+    auto packTuple = packBufferPtrs<alignment>(buffer, numElements, arrays...);
+    for_each_tuple(gatherArray, packTuple);
+
+    std::size_t numBytesPacked = computeByteOffsets(numElements, alignment, arrays...).back();
+    return numBytesPacked;
+}
+
+namespace domain_exchange
+{
+
+//! @brief return the required buffer size for calling exchangeParticles
+[[maybe_unused]] static LocalIndex
+exchangeBufferSize(BufferDescription bufDesc, LocalIndex numPresent, LocalIndex numAssigned)
+{
+    LocalIndex numIncoming = numAssigned - numPresent;
+
+    bool fitHead = bufDesc.start >= numIncoming;
+    bool fitTail = bufDesc.size - bufDesc.end >= numIncoming;
+
+    return (fitHead || fitTail) ? bufDesc.size : bufDesc.end + numIncoming;
+}
+
+//! @brief return the index where particles from remote ranks will be received
+[[maybe_unused]] static LocalIndex
+receiveStart(BufferDescription bufDesc, LocalIndex numPresent, LocalIndex numAssigned)
+{
+    LocalIndex numIncoming = numAssigned - numPresent;
+
+    bool fitHead = bufDesc.start >= numIncoming;
+    assert(fitHead || /*fitTail*/ bufDesc.size - bufDesc.end >= numIncoming);
+
+    if (fitHead) { return bufDesc.start - numIncoming; }
+    else { return bufDesc.end; }
+}
+
+//! @brief The index range that contains the locally assigned particles. Can contain left-over particles too.
+[[maybe_unused]] static util::array<LocalIndex, 2>
+assignedEnvelope(BufferDescription bufDesc, LocalIndex numPresent, LocalIndex numAssigned)
+{
+    LocalIndex numIncoming = numAssigned - numPresent;
+
+    bool fitHead = bufDesc.start >= numIncoming;
+    assert(fitHead || /*fitTail*/ bufDesc.size - bufDesc.end >= numIncoming);
+
+    if (fitHead) { return {bufDesc.start - numIncoming, bufDesc.end}; }
+    else { return {bufDesc.start, bufDesc.end + numIncoming}; }
+}
+
+template<class Vector>
+void extractLocallyOwnedImpl(BufferDescription bufDesc,
+                             LocalIndex numPresent,
+                             LocalIndex numAssigned,
+                             const LocalIndex* ordering,
+                             Vector& buffer)
+{
+    Vector temp(numAssigned);
+
+    // extract what we already had before the exchange
+    gatherCpu(ordering, numPresent, buffer.data() + bufDesc.start, temp.data());
+
+    // extract what we received during the exchange
+    LocalIndex rStart = receiveStart(bufDesc, numPresent, numAssigned);
+    std::copy_n(buffer.data() + rStart, numAssigned - numPresent, temp.data() + numPresent);
+    swap(temp, buffer);
+}
+
+/*! @brief Only used in testing to isolate locally owned particles after calling exchangeParticles.
+ *         In production code, this step is deferred until after halo detection to rearrange particles to their final
+ *         location in a single step.
+ */
+template<class... Vector>
+void extractLocallyOwned(BufferDescription bufDesc,
+                         LocalIndex numPresent,
+                         LocalIndex numAssigned,
+                         const LocalIndex* ordering,
+                         Vector&... buffers)
+{
+    std::initializer_list<int>{(extractLocallyOwnedImpl(bufDesc, numPresent, numAssigned, ordering, buffers), 0)...};
+}
+
+} // namespace domain_exchange
+
+} // namespace cstone

--- a/domain/include/cstone/domain/domaindecomp.hpp
+++ b/domain/include/cstone/domain/domaindecomp.hpp
@@ -34,14 +34,12 @@
 #pragma once
 
 #include <algorithm>
-#include <stdio.h>
-#include <string.h>
+#include <numeric>
 #include <vector>
 
-#include "cstone/primitives/gather.hpp"
 #include "cstone/tree/csarray.hpp"
-#include "index_ranges.hpp"
 #include "cstone/util/gsl-lite.hpp"
+#include "index_ranges.hpp"
 
 namespace cstone
 {
@@ -57,8 +55,6 @@ namespace cstone
 using Rank = StrongType<int, struct RankTag>;
 
 /*! @brief stores which parts of the SFC belong to which rank, on a per-rank basis
- *
- * @tparam I  32- or 64-bit unsigned integer
  *
  * The storage layout allows fast look-up of the SFC code ranges that a given rank
  * was assigned.
@@ -332,45 +328,6 @@ SendList createSendList(const SpaceCurveAssignment& assignment,
     }
 
     return ret;
-}
-
-template<size_t N>
-util::array<size_t, N + 1>
-computeByteOffsets(size_t count, const util::array<size_t, N>& elementSizes, size_t alignment)
-{
-    util::array<size_t, N + 1> byteOffsets;
-    std::copy(elementSizes.begin(), elementSizes.end(), byteOffsets.begin());
-    byteOffsets *= count;
-
-    //! each sub-buffer will be aligned on a @a alignment-byte aligned boundary
-    for (size_t i = 0; i < byteOffsets.size(); ++i)
-    {
-        byteOffsets[i] = round_up(byteOffsets[i], alignment);
-    }
-
-    std::exclusive_scan(byteOffsets.begin(), byteOffsets.end(), byteOffsets.begin(), size_t(0));
-
-    return byteOffsets;
-}
-
-template<size_t N>
-size_t computeTotalSendBytes(const SendList& sendList,
-                             const util::array<size_t, N>& elementSizes,
-                             int thisRank,
-                             size_t alignment)
-{
-    size_t totalSendBytes = 0;
-    for (int destinationRank = 0; destinationRank < int(sendList.size()); ++destinationRank)
-    {
-        size_t sendCount = sendList[destinationRank].totalCount();
-        if (destinationRank == thisRank || sendCount == 0) { continue; }
-
-        size_t particleBytes = computeByteOffsets(sendCount, elementSizes, alignment).back();
-        //! we add @a alignment bytes to the start of each message to provide space for the message length
-        totalSendBytes += alignment + particleBytes;
-    }
-
-    return totalSendBytes;
 }
 
 /*! @brief return @p numRanks equal length SFC segments for initial domain decomposition

--- a/domain/include/cstone/domain/domaindecomp_gpu.cuh
+++ b/domain/include/cstone/domain/domaindecomp_gpu.cuh
@@ -53,20 +53,15 @@ namespace cstone
  *
  * Converts the global assignment particle keys ranges into particle indices with binary search
  */
-template<class KeyType, class DeviceVector>
+template<class KeyType>
 SendList createSendListGpu(const SpaceCurveAssignment& assignment,
                            gsl::span<const KeyType> treeLeaves,
                            gsl::span<const KeyType> particleKeys,
-                           DeviceVector& sendScratch,
-                           DeviceVector& receiveScratch)
+                           KeyType* d_searchKeys,
+                           LocalIndex* d_indices)
 {
     size_t numRanks = assignment.numRanks();
     using IndexType = SendManifest::IndexType;
-
-    size_t ssz = reallocateBytes(sendScratch, numRanks * sizeof(KeyType));
-    size_t rsz = reallocateBytes(receiveScratch, numRanks * sizeof(LocalIndex));
-    gsl::span<KeyType> d_searchKeys{reinterpret_cast<KeyType*>(rawPtr(sendScratch)), numRanks};
-    gsl::span<LocalIndex> d_indices{reinterpret_cast<LocalIndex*>(rawPtr(receiveScratch)), numRanks};
 
     SendList ret(numRanks);
 
@@ -76,20 +71,16 @@ SendList createSendListGpu(const SpaceCurveAssignment& assignment,
         searchKeys[rank] = treeLeaves[assignment.firstNodeIdx(rank)];
     }
 
-    memcpyH2D(searchKeys.data(), searchKeys.size(), d_searchKeys.data());
-    lowerBoundGpu(particleKeys.begin(), particleKeys.end(), d_searchKeys.begin(), d_searchKeys.end(),
-                  d_indices.begin());
+    memcpyH2D(searchKeys.data(), searchKeys.size(), d_searchKeys);
+    lowerBoundGpu(particleKeys.begin(), particleKeys.end(), d_searchKeys, d_searchKeys + numRanks, d_indices);
 
     std::vector<IndexType> indices(numRanks + 1, particleKeys.size());
-    memcpyD2H(d_indices.data(), numRanks, indices.data());
+    memcpyD2H(d_indices, numRanks, indices.data());
 
     for (int rank = 0; rank < numRanks; ++rank)
     {
         ret[rank].addRange(indices[rank], indices[rank + 1]);
     }
-
-    reallocateDevice(sendScratch, ssz, 1.0);
-    reallocateDevice(receiveScratch, rsz, 1.0);
 
     return ret;
 }

--- a/domain/include/cstone/domain/index_ranges.hpp
+++ b/domain/include/cstone/domain/index_ranges.hpp
@@ -152,16 +152,6 @@ public:
         return count;
     }
 
-    std::size_t sendCount(int myRank) const
-    {
-        size_t count = 0;
-        for (std::size_t i = 0; i < data_.size(); ++i)
-        {
-            if (int(i) != myRank) { count += (*this)[i].totalCount(); }
-        }
-        return count;
-    }
-
     auto begin() { return data_.begin(); }
     auto end() { return data_.end(); }
 
@@ -183,5 +173,27 @@ inline size_t maxNumRanges(const SendList& sendList)
     }
     return ret;
 }
+
+class SendRanges : public std::vector<LocalIndex>
+{
+    using Base = std::vector<LocalIndex>;
+
+    size_t size() const { return Base::size(); };
+
+public:
+    SendRanges() = default;
+    explicit SendRanges(int s)
+        : Base(s)
+    {
+    }
+
+    int numRanks() const { return int(Base::size()) - 1; }
+
+    LocalIndex count(int rank) const
+    {
+        if ((*this)[rank + 1] >= (*this)[rank]) { return (*this)[rank + 1] - (*this)[rank]; }
+        else { return 0; }
+    }
+};
 
 } // namespace cstone

--- a/domain/include/cstone/domain/layout.hpp
+++ b/domain/include/cstone/domain/layout.hpp
@@ -56,24 +56,6 @@
 namespace cstone
 {
 
-/*! @brief Layout description for particle buffers
- *
- * Common usage: storing the sub-range of locally owned/assigned particles within particle buffers
- *
- * 0       start              end      size
- * |-------|------------------|--------|
- *   halos   locally assigned   halos
- */
-struct BufferDescription
-{
-    //! @brief subrange start
-    LocalIndex start;
-    //! @brief subrange end
-    LocalIndex end;
-    //! @brief total size of the buffer
-    LocalIndex size;
-};
-
 /*! @brief calculates the complementary range of the input ranges
  *
  * Input:  │      ------    -----   --     ----     --  │

--- a/domain/include/cstone/halos/exchange_halos.hpp
+++ b/domain/include/cstone/halos/exchange_halos.hpp
@@ -87,8 +87,8 @@ void haloexchange(int epoch, const SendList& incomingHalos, const SendList& outg
     {
         MPI_Status status;
         mpiRecvSync(receiveBuffer.data(), receiveBuffer.size(), MPI_ANY_SOURCE, haloExchangeTag, &status);
-        int receiveRank       = status.MPI_SOURCE;
-        size_t receiveCount   = incomingHalos[receiveRank].totalCount();
+        int receiveRank     = status.MPI_SOURCE;
+        size_t receiveCount = incomingHalos[receiveRank].totalCount();
 
         auto scatterRanges = [inHalos = incomingHalos[receiveRank]](auto arrayPair)
         {

--- a/domain/include/cstone/halos/exchange_halos.hpp
+++ b/domain/include/cstone/halos/exchange_halos.hpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include "cstone/primitives/mpi_wrappers.hpp"
-#include "cstone/domain/index_ranges.hpp"
+#include "cstone/domain/buffer_description.hpp"
 
 namespace cstone
 {
@@ -43,80 +43,65 @@ namespace cstone
 template<class... Arrays>
 void haloexchange(int epoch, const SendList& incomingHalos, const SendList& outgoingHalos, Arrays... arrays)
 {
-    using IndexType         = SendManifest::IndexType;
-    constexpr int numArrays = sizeof...(Arrays);
-    constexpr util::array<size_t, numArrays> elementSizes{sizeof(std::decay_t<decltype(*arrays)>)...};
-
-    std::array<char*, numArrays> data{reinterpret_cast<char*>(arrays)...};
+    using IndexType     = SendManifest::IndexType;
+    int haloExchangeTag = static_cast<int>(P2pTags::haloExchange) + epoch;
 
     std::vector<std::vector<char>> sendBuffers;
     std::vector<MPI_Request> sendRequests;
-
-    int haloExchangeTag = static_cast<int>(P2pTags::haloExchange) + epoch;
 
     for (std::size_t destinationRank = 0; destinationRank < outgoingHalos.size(); ++destinationRank)
     {
         size_t sendCount = outgoingHalos[destinationRank].totalCount();
         if (sendCount == 0) continue;
 
-        util::array<size_t, numArrays> arrayByteOffsets = sendCount * elementSizes;
-        size_t totalBytes = std::accumulate(arrayByteOffsets.begin(), arrayByteOffsets.end(), size_t(0));
-        std::exclusive_scan(arrayByteOffsets.begin(), arrayByteOffsets.end(), arrayByteOffsets.begin(), size_t(0));
+        std::vector<char> buffer(computeByteOffsets(sendCount, 1, arrays...).back());
 
-        std::vector<char> buffer(totalBytes);
-        for (int arrayIndex = 0; arrayIndex < numArrays; ++arrayIndex)
+        auto packSendBuffer = [outHalos = outgoingHalos[destinationRank]](auto arrayPair)
         {
-            size_t outputOffset = arrayByteOffsets[arrayIndex];
-            for (std::size_t rangeIdx = 0; rangeIdx < outgoingHalos[destinationRank].nRanges(); ++rangeIdx)
+            for (std::size_t rangeIdx = 0; rangeIdx < outHalos.nRanges(); ++rangeIdx)
             {
-                size_t lowerIndex = outgoingHalos[destinationRank].rangeStart(rangeIdx) * elementSizes[arrayIndex];
-                size_t upperIndex = outgoingHalos[destinationRank].rangeEnd(rangeIdx) * elementSizes[arrayIndex];
-
-                std::copy(data[arrayIndex] + lowerIndex, data[arrayIndex] + upperIndex, buffer.data() + outputOffset);
-                outputOffset += upperIndex - lowerIndex;
+                std::copy_n(arrayPair[0] + outHalos.rangeStart(rangeIdx), outHalos.count(rangeIdx), arrayPair[1]);
+                arrayPair[1] += outHalos.count(rangeIdx);
             }
-        }
+        };
 
-        mpiSendAsync(buffer.data(), totalBytes, destinationRank, haloExchangeTag, sendRequests);
+        auto packTuple = packBufferPtrs<1>(buffer.data(), sendCount, arrays...);
+        for_each_tuple(packSendBuffer, packTuple);
+
+        mpiSendAsync(buffer.data(), buffer.size(), destinationRank, haloExchangeTag, sendRequests);
         sendBuffers.push_back(std::move(buffer));
     }
 
     int numMessages            = 0;
     std::size_t maxReceiveSize = 0;
-    for (std::size_t sourceRank = 0; sourceRank < incomingHalos.size(); ++sourceRank)
-        if (incomingHalos[sourceRank].totalCount() > 0)
-        {
-            numMessages++;
-            maxReceiveSize = std::max(maxReceiveSize, incomingHalos[sourceRank].totalCount());
-        }
+    for (const auto& incomingHalo : incomingHalos)
+    {
+        numMessages += int(incomingHalo.totalCount() > 0);
+        maxReceiveSize = std::max(maxReceiveSize, incomingHalo.totalCount());
+    }
+    size_t maxReceiveBytes = computeByteOffsets(maxReceiveSize, 1, arrays...).back();
 
-    size_t bytesPerParticle = std::accumulate(elementSizes.begin(), elementSizes.end(), size_t(0));
-    std::vector<char> receiveBuffer(maxReceiveSize * bytesPerParticle);
+    std::vector<char> receiveBuffer(maxReceiveBytes);
 
     while (numMessages > 0)
     {
         MPI_Status status;
         mpiRecvSync(receiveBuffer.data(), receiveBuffer.size(), MPI_ANY_SOURCE, haloExchangeTag, &status);
-        int receiveRank     = status.MPI_SOURCE;
-        size_t receiveCount = incomingHalos[receiveRank].totalCount();
+        int receiveRank       = status.MPI_SOURCE;
+        size_t receiveCount   = incomingHalos[receiveRank].totalCount();
 
-        util::array<size_t, numArrays> arrayByteOffsets = receiveCount * elementSizes;
-        std::exclusive_scan(arrayByteOffsets.begin(), arrayByteOffsets.end(), arrayByteOffsets.begin(), size_t(0));
-
-        for (int arrayIndex = 0; arrayIndex < numArrays; ++arrayIndex)
+        auto scatterRanges = [inHalos = incomingHalos[receiveRank]](auto arrayPair)
         {
-            size_t inputOffset = arrayByteOffsets[arrayIndex];
-            for (std::size_t rangeIdx = 0; rangeIdx < incomingHalos[receiveRank].nRanges(); ++rangeIdx)
+            for (size_t rangeIdx = 0; rangeIdx < inHalos.nRanges(); ++rangeIdx)
             {
-                IndexType offset  = incomingHalos[receiveRank].rangeStart(rangeIdx) * elementSizes[arrayIndex];
-                size_t countBytes = incomingHalos[receiveRank].count(rangeIdx) * elementSizes[arrayIndex];
-
-                std::copy(receiveBuffer.data() + inputOffset, receiveBuffer.data() + inputOffset + countBytes,
-                          data[arrayIndex] + offset);
-
-                inputOffset += countBytes;
+                std::copy_n(arrayPair[1], inHalos.count(rangeIdx), arrayPair[0] + inHalos.rangeStart(rangeIdx));
+                arrayPair[1] += inHalos.count(rangeIdx);
             }
-        }
+        };
+
+        auto packTuple = packBufferPtrs<1>(receiveBuffer.data(), receiveCount, arrays...);
+        for_each_tuple(scatterRanges, packTuple);
+
         numMessages--;
     }
 

--- a/domain/include/cstone/halos/exchange_halos_gpu.cuh
+++ b/domain/include/cstone/halos/exchange_halos_gpu.cuh
@@ -38,7 +38,7 @@
 #include "cstone/cuda/errorcheck.cuh"
 #include "cstone/primitives/mpi_wrappers.hpp"
 #include "cstone/primitives/mpi_cuda.cuh"
-#include "cstone/domain/index_ranges.hpp"
+#include "cstone/domain/buffer_description.hpp"
 #include "cstone/util/reallocate.hpp"
 #include "cstone/util/util.hpp"
 
@@ -55,28 +55,22 @@ void haloExchangeGpu(int epoch,
                      DevVec2& receiveScratchBuffer,
                      Arrays... arrays)
 {
+    constexpr int alignment = 1;
     using IndexType         = SendManifest::IndexType;
-    constexpr int numArrays = sizeof...(Arrays);
-    constexpr util::array<size_t, numArrays> elementSizes{sizeof(std::decay_t<decltype(*arrays)>)...};
-    const int bytesPerElement = std::accumulate(elementSizes.begin(), elementSizes.end(), 0);
-    constexpr auto indices    = makeIntegralTuple(std::make_index_sequence<numArrays>{});
 
-    std::array<char*, numArrays> data{reinterpret_cast<char*>(arrays)...};
-
-    const size_t oldSendSize = reallocateBytes(sendScratchBuffer, outgoingHalos.totalCount() * bytesPerElement);
-    char* sendBuffer         = reinterpret_cast<char*>(rawPtr(sendScratchBuffer));
-
+    int haloExchangeTag = static_cast<int>(P2pTags::haloExchange) + epoch;
     std::vector<MPI_Request> sendRequests;
     std::vector<std::vector<char, util::DefaultInitAdaptor<char>>> sendBuffers;
 
-    int haloExchangeTag = static_cast<int>(P2pTags::haloExchange) + epoch;
+    const size_t oldSendSize =
+        reallocateBytes(sendScratchBuffer, computeTotalSendBytes<alignment>(outgoingHalos, -1, 0, arrays...));
 
     size_t numRanges = std::max(maxNumRanges(outgoingHalos), maxNumRanges(incomingHalos));
     IndexType* d_range;
     checkGpuErrors(cudaMalloc((void**)&d_range, 2 * numRanges * sizeof(IndexType)));
     IndexType* d_rangeScan = d_range + numRanges;
 
-    char* sendPtr = sendBuffer;
+    char* sendPtr = reinterpret_cast<char*>(rawPtr(sendScratchBuffer));
     for (std::size_t destinationRank = 0; destinationRank < outgoingHalos.size(); ++destinationRank)
     {
         const auto& outHalos = outgoingHalos[destinationRank];
@@ -88,52 +82,36 @@ void haloExchangeGpu(int epoch,
         checkGpuErrors(
             cudaMemcpy(d_rangeScan, outHalos.scan(), outHalos.nRanges() * sizeof(IndexType), cudaMemcpyHostToDevice));
 
-        util::array<size_t, numArrays> arrayByteOffsets = sendCount * elementSizes;
-        std::exclusive_scan(arrayByteOffsets.begin(), arrayByteOffsets.end(), arrayByteOffsets.begin(), size_t(0));
-        size_t sendBytes = sendCount * bytesPerElement;
+        auto gatherArray = [d_range, d_rangeScan, numRanges = outHalos.nRanges(), sendCount](auto arrayPtr)
+        { gatherRanges(d_rangeScan, d_range, numRanges, arrayPtr[0], arrayPtr[1], sendCount); };
 
-        auto gatherArray = [sendPtr, sendCount, &data, &arrayByteOffsets, &elementSizes, d_range, d_rangeScan,
-                            numRanges = outHalos.nRanges()](auto arrayIndex)
-        {
-            size_t outputOffset = arrayByteOffsets[arrayIndex];
-            char* bufferPtr     = sendPtr + outputOffset;
-
-            using ElementType = util::array<float, elementSizes[arrayIndex] / sizeof(float)>;
-            gatherRanges(d_rangeScan, d_range, numRanges, reinterpret_cast<ElementType*>(data[arrayIndex]),
-                         reinterpret_cast<ElementType*>(bufferPtr), sendCount);
-        };
-
-        for_each_tuple(gatherArray, indices);
+        for_each_tuple(gatherArray, packBufferPtrs<alignment>(sendPtr, sendCount, arrays...));
         checkGpuErrors(cudaDeviceSynchronize());
 
-        mpiSendGpuDirect(sendPtr, sendBytes, destinationRank, haloExchangeTag, sendRequests, sendBuffers);
-        sendPtr += sendBytes;
+        size_t numBytesSend = computeByteOffsets(sendCount, alignment, arrays...).back();
+        mpiSendGpuDirect(sendPtr, numBytesSend, int(destinationRank), haloExchangeTag, sendRequests, sendBuffers);
+        sendPtr += numBytesSend;
     }
 
-    int numMessages            = 0;
-    std::size_t maxReceiveSize = 0;
-    for (std::size_t sourceRank = 0; sourceRank < incomingHalos.size(); ++sourceRank)
+    int numMessages       = 0;
+    size_t maxReceiveSize = 0;
+    for (const auto& incomingHalo : incomingHalos)
     {
-        if (incomingHalos[sourceRank].totalCount() > 0)
-        {
-            numMessages++;
-            maxReceiveSize = std::max(maxReceiveSize, incomingHalos[sourceRank].totalCount());
-        }
+        numMessages += int(incomingHalo.totalCount() > 0);
+        maxReceiveSize = std::max(maxReceiveSize, incomingHalo.totalCount());
     }
+    size_t maxReceiveBytes = computeByteOffsets(maxReceiveSize, alignment, arrays...).back();
 
-    const size_t oldRecvSize = reallocateBytes(receiveScratchBuffer, maxReceiveSize * bytesPerElement);
+    const size_t oldRecvSize = reallocateBytes(receiveScratchBuffer, maxReceiveBytes);
     char* receiveBuffer      = reinterpret_cast<char*>(rawPtr(receiveScratchBuffer));
 
     while (numMessages > 0)
     {
         MPI_Status status;
-        mpiRecvGpuDirect(receiveBuffer, maxReceiveSize * bytesPerElement, MPI_ANY_SOURCE, haloExchangeTag, &status);
+        mpiRecvGpuDirect(receiveBuffer, maxReceiveBytes, MPI_ANY_SOURCE, haloExchangeTag, &status);
         int receiveRank     = status.MPI_SOURCE;
         const auto& inHalos = incomingHalos[receiveRank];
         size_t receiveCount = inHalos.totalCount();
-
-        util::array<size_t, numArrays> arrayByteOffsets = receiveCount * elementSizes;
-        std::exclusive_scan(arrayByteOffsets.begin(), arrayByteOffsets.end(), arrayByteOffsets.begin(), size_t(0));
 
         // compute indices to extract and upload to GPU
         checkGpuErrors(
@@ -141,18 +119,10 @@ void haloExchangeGpu(int epoch,
         checkGpuErrors(
             cudaMemcpy(d_rangeScan, inHalos.scan(), inHalos.nRanges() * sizeof(IndexType), cudaMemcpyHostToDevice));
 
-        auto scatterArray = [receiveBuffer, receiveCount, &data, &arrayByteOffsets, &elementSizes, d_range, d_rangeScan,
-                             numRanges = inHalos.nRanges()](auto arrayIndex)
-        {
-            size_t outputOffset = arrayByteOffsets[arrayIndex];
-            char* bufferPtr     = receiveBuffer + outputOffset;
+        auto scatterArray = [d_range, d_rangeScan, numRanges = inHalos.nRanges(), receiveCount](auto arrayPtr)
+        { scatterRanges(d_rangeScan, d_range, numRanges, arrayPtr[0], arrayPtr[1], receiveCount); };
 
-            using ElementType = util::array<float, elementSizes[arrayIndex] / sizeof(float)>;
-            scatterRanges(d_rangeScan, d_range, numRanges, reinterpret_cast<ElementType*>(data[arrayIndex]),
-                          reinterpret_cast<ElementType*>(bufferPtr), receiveCount);
-        };
-
-        for_each_tuple(scatterArray, indices);
+        for_each_tuple(scatterArray, packBufferPtrs<alignment>(receiveBuffer, receiveCount, arrays...));
         checkGpuErrors(cudaDeviceSynchronize());
 
         numMessages--;
@@ -165,8 +135,8 @@ void haloExchangeGpu(int epoch,
     }
 
     checkGpuErrors(cudaFree(d_range));
-    reallocateDevice(sendScratchBuffer, oldSendSize, 1.01);
-    reallocateDevice(receiveScratchBuffer, oldRecvSize, 1.01);
+    reallocateDevice(sendScratchBuffer, oldSendSize, 1.0);
+    reallocateDevice(receiveScratchBuffer, oldRecvSize, 1.0);
 
     // MUST call MPI_Barrier or any other collective MPI operation that enforces synchronization
     // across all ranks before calling this function again.

--- a/domain/include/cstone/primitives/gather.hpp
+++ b/domain/include/cstone/primitives/gather.hpp
@@ -113,6 +113,11 @@ void gather(gsl::span<const IndexType> ordering, const ValueType* source, ValueT
     }
 }
 
+//! @brief Lambda to avoid templated functors that would become template-template parameters when passed to functions.
+inline auto gatherCpu = [](const auto* ordering, auto numElements, const auto* src, const auto dest) {
+    gather<LocalIndex>({ordering, numElements}, src, dest);
+};
+
 //! @brief scatter reorder
 template<class IndexType, class ValueType>
 void scatter(gsl::span<const IndexType> ordering, const ValueType* source, ValueType* destination)

--- a/domain/include/cstone/primitives/gather.hpp
+++ b/domain/include/cstone/primitives/gather.hpp
@@ -140,55 +140,26 @@ public:
 
     SfcSorter(const SfcSorter&) = delete;
 
-    const IndexType* getReorderMap() const { return ordering(); }
+    const IndexType* getMap() const { return ordering(); }
 
     template<class KeyType>
     void setMapFromCodes(KeyType* first, KeyType* last)
     {
-        offset_     = 0;
-        mapSize_    = std::size_t(last - first);
-        numExtract_ = mapSize_;
-
+        mapSize_ = std::size_t(last - first);
         reallocateBytes(buffer_, mapSize_ * sizeof(IndexType));
         std::iota(ordering(), ordering() + mapSize_, 0);
         sort_by_key(first, last, ordering());
     }
 
-    /*! @brief reorder the array @p values according to the reorder map provided previously
-     *
-     * @p values must have at least as many elements as the reorder map provided in the last call
-     * to setMapFromCodes, otherwise the behavior is undefined.
-     */
-    template<class T>
-    void operator()(const T* source, T* destination, IndexType offset, IndexType numExtract) const
-    {
-        gather<IndexType>({ordering() + offset, numExtract}, source, destination);
-    }
-
-    template<class T>
-    void operator()(const T* source, T* destination) const
-    {
-        this->operator()(source, destination, offset_, numExtract_);
-    }
-
-    void restrictRange(std::size_t offset, std::size_t numExtract)
-    {
-        assert(offset + numExtract <= mapSize_);
-
-        offset_     = offset;
-        numExtract_ = numExtract;
-    }
+    auto gatherFunc() const { return gatherCpu; }
 
 private:
     IndexType* ordering() { return reinterpret_cast<IndexType*>(buffer_.data()); }
     const IndexType* ordering() const { return reinterpret_cast<const IndexType*>(buffer_.data()); }
 
-    std::size_t offset_{0};
-    std::size_t numExtract_{0};
-    std::size_t mapSize_{0};
-
     //! @brief reference to (non-owning) buffer for ordering
     BufferType& buffer_;
+    std::size_t mapSize_{0};
 };
 
 } // namespace cstone

--- a/domain/include/cstone/primitives/primitives_gpu.h
+++ b/domain/include/cstone/primitives/primitives_gpu.h
@@ -45,6 +45,11 @@ extern void scaleGpu(T* first, T* last, T value);
 template<class T, class IndexType>
 extern void gatherGpu(const IndexType* ordering, size_t numElements, const T* src, T* buffer);
 
+//! @brief Lambda to avoid templated functors that would become template-template parameters when passed to functions.
+inline auto gatherGpuL = [](const auto* ordering, auto numElements, const auto* src, const auto dest) {
+    gatherGpu(ordering, numElements, src, dest);
+};
+
 template<class T>
 struct MinMaxGpu
 {

--- a/domain/include/cstone/primitives/primitives_gpu.h
+++ b/domain/include/cstone/primitives/primitives_gpu.h
@@ -46,9 +46,8 @@ template<class T, class IndexType>
 extern void gatherGpu(const IndexType* ordering, size_t numElements, const T* src, T* buffer);
 
 //! @brief Lambda to avoid templated functors that would become template-template parameters when passed to functions.
-inline auto gatherGpuL = [](const auto* ordering, auto numElements, const auto* src, const auto dest) {
-    gatherGpu(ordering, numElements, src, dest);
-};
+inline auto gatherGpuL = [](const auto* ordering, auto numElements, const auto* src, const auto dest)
+{ gatherGpu(ordering, numElements, src, dest); };
 
 template<class T>
 struct MinMaxGpu

--- a/domain/include/cstone/primitives/scan.hpp
+++ b/domain/include/cstone/primitives/scan.hpp
@@ -75,7 +75,7 @@ void exclusiveScan(const T1* in, T2* out, size_t numElements)
         {
             size_t stepOffset = step * elementsPerStep + tid * blockSize;
 
-            stl::exclusive_scan(in + stepOffset, in + stepOffset + blockSize, out + stepOffset, 0);
+            std::exclusive_scan(in + stepOffset, in + stepOffset + blockSize, out + stepOffset, 0);
 
             superBlock[step % 2][tid] = out[stepOffset + blockSize - 1] + in[stepOffset + blockSize - 1];
 
@@ -93,7 +93,7 @@ void exclusiveScan(const T1* in, T2* out, size_t numElements)
 
     // remainder
     T2 stepSum = superBlock[(nSteps + 1) % 2][numThreads];
-    stl::exclusive_scan(in + nSteps * elementsPerStep, in + numElements, out + nSteps * elementsPerStep, stepSum);
+    std::exclusive_scan(in + nSteps * elementsPerStep, in + numElements, out + nSteps * elementsPerStep, stepSum);
 }
 
 template<class T>

--- a/domain/include/cstone/primitives/stl.hpp
+++ b/domain/include/cstone/primitives/stl.hpp
@@ -125,15 +125,4 @@ HOST_DEVICE_FUN ForwardIt upper_bound(ForwardIt first, ForwardIt last, const T& 
     return first;
 }
 
-//! @brief this can be removed once most compilers support it as part of STL
-template<class InputIterator, class OutputIterator, class T>
-void exclusive_scan(InputIterator in1, InputIterator in2, OutputIterator out, T init)
-{
-    while (in1 != in2)
-    {
-        *out++ = init;
-        init += *in1++;
-    }
-}
-
 } // namespace stl

--- a/domain/include/cstone/util/reallocate.cu
+++ b/domain/include/cstone/util/reallocate.cu
@@ -61,6 +61,7 @@ template void reallocateDevice(thrust::device_vector<unsigned long>&, size_t, do
 template void reallocateDevice(thrust::device_vector<unsigned long long>&, size_t, double);
 template void reallocateDevice(thrust::device_vector<char>&, size_t, double);
 
+template void reallocateDevice(thrust::device_vector<util::array<int, 2>>&, size_t, double);
 template void reallocateDevice(thrust::device_vector<util::array<float, 3>>&, size_t, double);
 template void reallocateDevice(thrust::device_vector<util::array<double, 3>>&, size_t, double);
 template void reallocateDevice(thrust::device_vector<util::array<float, 4>>&, size_t, double);

--- a/domain/test/integration_mpi/assignment_gpu.cpp
+++ b/domain/test/integration_mpi/assignment_gpu.cpp
@@ -99,7 +99,7 @@ void randomGaussianAssignment(int rank, int numRanks)
     std::vector<unsigned> sfcScratchCpu;
     SfcSorter<LocalIndex, std::vector<unsigned>> cpuGather(sfcScratchCpu);
 
-    LocalIndex numAssignedCpu = assignment.assign(bufDesc, cpuGather, keys.data(), x.data(), y.data(), z.data());
+    LocalIndex exchangeSizeCpu = assignment.assign(bufDesc, cpuGather, keys.data(), x.data(), y.data(), z.data());
 
     thrust::device_vector<KeyType> d_keys;
     reallocateDevice(d_keys, numParticles, 1.0);
@@ -112,20 +112,17 @@ void randomGaussianAssignment(int rank, int numRanks)
     thrust::device_vector<unsigned> sfcScratch;
     GpuSfcSorter<LocalIndex, thrust::device_vector<unsigned>> deviceSort(sfcScratch);
 
-    LocalIndex numAssignedGpu =
-        assignmentGpu.assign(bufDesc, deviceSort, rawPtr(d_keys), rawPtr(d_x), rawPtr(d_y), rawPtr(d_z));
+    bufDesc.size = assignmentGpu.assign(bufDesc, deviceSort, rawPtr(d_keys), rawPtr(d_x), rawPtr(d_y), rawPtr(d_z));
 
-    ASSERT_EQ(numAssignedCpu, numAssignedGpu);
+    ASSERT_EQ(exchangeSizeCpu, bufDesc.size);
     EXPECT_EQ(assignment.treeLeaves().size(), assignmentGpu.treeLeaves().size());
 
-    size_t exchangeSize = std::max(x.size(), size_t(numAssignedCpu));
+    reallocate(exchangeSizeCpu, keys, x, y, z);
 
-    reallocate(exchangeSize, keys, x, y, z);
-
-    reallocateDevice(d_keys, exchangeSize, 1.01);
-    reallocateDevice(d_x, exchangeSize, 1.01);
-    reallocateDevice(d_y, exchangeSize, 1.01);
-    reallocateDevice(d_z, exchangeSize, 1.01);
+    reallocateDevice(d_keys, bufDesc.size, 1.01);
+    reallocateDevice(d_x, bufDesc.size, 1.01);
+    reallocateDevice(d_y, bufDesc.size, 1.01);
+    reallocateDevice(d_z, bufDesc.size, 1.01);
 
     std::vector<double> dummy;
     auto [exchangeStartCpu, cpuKeyView] =

--- a/domain/test/integration_mpi/treedomain.cpp
+++ b/domain/test/integration_mpi/treedomain.cpp
@@ -86,7 +86,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
     }
 
     std::vector<LocalIndex> ordering(numParticles);
-    // particles are in Morton order
+    // particles are in SFC order
     std::iota(begin(ordering), end(ordering), 0);
 
     auto assignment = singleRangeSfcSplit(counts, numRanks);
@@ -98,41 +98,45 @@ void globalRandomGaussian(int thisRank, int numRanks)
     std::vector<T> y(coords.y().begin(), coords.y().end());
     std::vector<T> z(coords.z().begin(), coords.z().end());
 
-    LocalIndex numParticlesAssigned = assignment.totalCount(thisRank);
+    LocalIndex numAssigned = assignment.totalCount(thisRank);
+    LocalIndex numPresent  = sendList[thisRank].totalCount();
 
-    reallocate(std::max(numParticlesAssigned, numParticles), x, y, z);
-    auto [particleStart, particleEnd] =
-        exchangeParticles(sendList, Rank(thisRank), 0, numParticles, x.size(), numParticlesAssigned, ordering.data(),
-                          x.data(), y.data(), z.data());
+    BufferDescription bufDesc{0, numParticles, numParticles};
+    bufDesc.size = domain_exchange::exchangeBufferSize(bufDesc, numPresent, numAssigned);
+    reallocate(bufDesc.size, x, y, z);
+    exchangeParticles(sendList, Rank(thisRank), bufDesc, numAssigned, ordering.data(), x.data(), y.data(), z.data());
+
+    domain_exchange::extractLocallyOwned(bufDesc, numPresent, numAssigned,
+                                         ordering.data() + sendList[thisRank].rangeStart(0), x, y, z);
 
     /// post-exchange test:
     /// if the global tree build and assignment is repeated, no particles are exchanged anymore
 
-    EXPECT_EQ(particleEnd - particleStart, numParticlesAssigned);
+    std::vector<KeyType> newCodes(x.size());
+    computeSfcKeys(x.data(), y.data(), z.data(), sfcKindPointer(newCodes.data()), x.size(), box);
 
-    std::vector<KeyType> newCodes(numParticlesAssigned);
-    computeSfcKeys(x.data() + particleStart, y.data() + particleStart, z.data() + particleStart,
-                   sfcKindPointer(newCodes.data()), particleEnd - particleStart, box);
-
-    // received particles are not stored in morton order after the exchange
+    // received particles are not stored in SFC order after the exchange
     std::sort(begin(newCodes), end(newCodes));
 
+    //! what particles we actually have should equal what was assigned
+    EXPECT_EQ(numAssigned, x.size());
+
     std::vector<KeyType> newTree = makeRootNodeTree<KeyType>();
-    std::vector<unsigned> newCounts{unsigned(newCodes.size())};
-    while (!updateOctreeGlobal(newCodes.data(), newCodes.data() + newCodes.size(), bucketSize, newTree, newCounts))
+    std::vector<unsigned> newCounts{unsigned(x.size())};
+    while (!updateOctreeGlobal(newCodes.data(), newCodes.data() + x.size(), bucketSize, newTree, newCounts))
         ;
 
     // global tree and counts stay the same
     EXPECT_EQ(tree, newTree);
     EXPECT_EQ(counts, newCounts);
 
-    auto newSendList = createSendList<KeyType>(assignment, newTree, newCodes);
+    auto newSendList = createSendList<KeyType>(assignment, newTree, {newCodes.data(), numAssigned});
 
     for (int rank = 0; rank < numRanks; ++rank)
     {
         // the new send list now indicates that all elements on the current rank
         // stay where they are
-        if (rank == thisRank) EXPECT_EQ(newSendList[rank].totalCount(), numParticlesAssigned);
+        if (rank == thisRank) EXPECT_EQ(newSendList[rank].totalCount(), numAssigned);
         // no particles are sent to other ranks
         else
             EXPECT_EQ(newSendList[rank].totalCount(), 0);

--- a/domain/test/performance/scan.cpp
+++ b/domain/test/performance/scan.cpp
@@ -41,7 +41,7 @@
 template<class T>
 void exclusiveScanSerial(const T* in, T* out, std::size_t num_elements)
 {
-    stl::exclusive_scan(in, in + num_elements, out, 0);
+    std::exclusive_scan(in, in + num_elements, out, 0);
 }
 
 template<class T>

--- a/domain/test/unit/CMakeLists.txt
+++ b/domain/test/unit/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(UNIT_TESTS
+        domain/buffer_description.cpp
         domain/domaindecomp.cpp
         domain/index_ranges.cpp
         domain/layout.cpp

--- a/domain/test/unit/domain/buffer_description.cpp
+++ b/domain/test/unit/domain/buffer_description.cpp
@@ -41,8 +41,8 @@ TEST(BufferDescription, computeByteOffsets1)
     size_t sendCount           = 1001;
 
     double* p1 = nullptr;
-    float* p2 = nullptr;
-    long* p3 = nullptr;
+    float* p2  = nullptr;
+    long* p3   = nullptr;
     util::array<size_t, 3> elementSizes{sizeof(*p1), sizeof(*p2), sizeof(*p3)};
 
     auto offsets = computeByteOffsets(sendCount, alignment, p1, p2, p3);

--- a/domain/test/unit/domain/buffer_description.cpp
+++ b/domain/test/unit/domain/buffer_description.cpp
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 CSCS, ETH Zurich
+ *               2021 University of Basel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief Space filling curve octree assignment to ranks tests
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#include "gtest/gtest.h"
+
+#include "cstone/domain/buffer_description.hpp"
+
+using namespace cstone;
+
+TEST(BufferDescription, computeByteOffsets1)
+{
+    constexpr size_t alignment = 128;
+    size_t sendCount           = 1001;
+
+    double* p1 = nullptr;
+    float* p2 = nullptr;
+    long* p3 = nullptr;
+    util::array<size_t, 3> elementSizes{sizeof(*p1), sizeof(*p2), sizeof(*p3)};
+
+    auto offsets = computeByteOffsets(sendCount, alignment, p1, p2, p3);
+
+    EXPECT_EQ(offsets[0], 0);
+    EXPECT_EQ(offsets[1], round_up(elementSizes[0] * sendCount, alignment));
+    EXPECT_EQ(offsets[2], offsets[1] + round_up(elementSizes[1] * sendCount, alignment));
+    EXPECT_EQ(offsets[3], offsets[2] + round_up(elementSizes[2] * sendCount, alignment));
+
+    EXPECT_EQ(offsets[3], 8064 + 4096 + 8064);
+}
+
+TEST(BufferDescription, computeByteOffsetsPadLast)
+{
+    constexpr size_t alignment = 8;
+    size_t sendCount           = 1;
+
+    double* p1 = nullptr;
+    long* p2   = nullptr;
+    float* p3  = nullptr;
+
+    auto offsets = computeByteOffsets(sendCount, alignment, p1, p2, p3);
+    EXPECT_EQ(offsets[0], 0);
+    EXPECT_EQ(offsets[1], 8);
+    EXPECT_EQ(offsets[2], 16);
+    EXPECT_EQ(offsets[3], 24);
+}
+
+TEST(BufferDescription, packBufferPtrs)
+{
+    char* packedBufferBase = 0; // NOLINT
+
+    size_t bufferSizes = 10;
+    auto* p1           = reinterpret_cast<double*>(1024);
+    auto* p2           = reinterpret_cast<float*>(2048);
+    auto* p3           = reinterpret_cast<util::array<int, 4>*>(4096);
+    auto* p4           = reinterpret_cast<int*>(8192);
+
+    auto packed = packBufferPtrs<1>(packedBufferBase, bufferSizes, p1, p2, p3, p4);
+
+    EXPECT_EQ(reinterpret_cast<long>(std::get<0>(packed)[0]), 1024);
+    EXPECT_EQ(reinterpret_cast<long>(std::get<0>(packed)[1]), 0);
+    static_assert(std::is_same_v<std::decay_t<decltype(*std::get<0>(packed)[0])>, util::array<float, 2>>);
+
+    EXPECT_EQ(reinterpret_cast<long>(std::get<1>(packed)[0]), 2048);
+    EXPECT_EQ(reinterpret_cast<long>(std::get<1>(packed)[1]), 80);
+    static_assert(std::is_same_v<std::decay_t<decltype(*std::get<1>(packed)[0])>, util::array<float, 1>>);
+
+    EXPECT_EQ(reinterpret_cast<long>(std::get<2>(packed)[0]), 4096);
+    EXPECT_EQ(reinterpret_cast<long>(std::get<2>(packed)[1]), 120);
+    static_assert(std::is_same_v<std::decay_t<decltype(*std::get<2>(packed)[0])>, util::array<float, 4>>);
+
+    EXPECT_EQ(reinterpret_cast<long>(std::get<3>(packed)[0]), 8192);
+    EXPECT_EQ(reinterpret_cast<long>(std::get<3>(packed)[1]), 280);
+    static_assert(std::is_same_v<std::decay_t<decltype(*std::get<3>(packed)[0])>, util::array<float, 1>>);
+}

--- a/domain/test/unit/domain/domaindecomp.cpp
+++ b/domain/test/unit/domain/domaindecomp.cpp
@@ -128,15 +128,15 @@ static void sendListMinimal()
     assignment.addRange(Rank(1), 2, 4, 0);
 
     // note: codes input needs to be sorted
-    auto sendList = createSendList<KeyType>(assignment, tree, codes);
+    auto sendList = createSendRanges<KeyType>(assignment, tree, codes);
 
-    EXPECT_EQ(sendList[0].totalCount(), 6);
-    EXPECT_EQ(sendList[1].totalCount(), 3);
+    EXPECT_EQ(sendList.count(0), 6);
+    EXPECT_EQ(sendList.count(1), 3);
 
-    EXPECT_EQ(sendList[0].rangeStart(0), 0);
-    EXPECT_EQ(sendList[0].rangeEnd(0), 6);
-    EXPECT_EQ(sendList[1].rangeStart(0), 6);
-    EXPECT_EQ(sendList[1].rangeEnd(0), 9);
+    EXPECT_EQ(sendList[0], 0);
+    EXPECT_EQ(sendList[0] + sendList.count(0), 6);
+    EXPECT_EQ(sendList[1], 6);
+    EXPECT_EQ(sendList[1] + sendList.count(1), 9);
 }
 
 TEST(DomainDecomposition, createSendList)

--- a/domain/test/unit/domain/domaindecomp.cpp
+++ b/domain/test/unit/domain/domaindecomp.cpp
@@ -33,6 +33,7 @@
 
 #include "gtest/gtest.h"
 
+#include "cstone/domain/buffer_description.hpp"
 #include "cstone/domain/domaindecomp.hpp"
 
 using namespace cstone;
@@ -142,22 +143,6 @@ TEST(DomainDecomposition, createSendList)
 {
     sendListMinimal<unsigned>();
     sendListMinimal<uint64_t>();
-}
-
-TEST(DomainDecomposition, computeByteOffsets)
-{
-    util::array<size_t, 3> elementSizes{8, 4, 8};
-    size_t sendCount = 1001;
-    size_t alignment = 128;
-
-    auto offsets = computeByteOffsets(sendCount, elementSizes, alignment);
-
-    EXPECT_EQ(offsets[0], 0);
-    EXPECT_EQ(offsets[1], round_up(elementSizes[0] * sendCount, alignment));
-    EXPECT_EQ(offsets[2], offsets[1] + round_up(elementSizes[1] * sendCount, alignment));
-    EXPECT_EQ(offsets[3], offsets[2] + round_up(elementSizes[2] * sendCount, alignment));
-
-    EXPECT_EQ(offsets[3], 8064 + 4096 + 8064);
 }
 
 template<class KeyType>

--- a/domain/test/unit/focus/source_center.cpp
+++ b/domain/test/unit/focus/source_center.cpp
@@ -92,7 +92,7 @@ static void computeSourceCenter()
     std::vector<util::array<T, 4>> centers(octree.numNodes);
 
     std::vector<LocalIndex> layout(octree.numLeafNodes + 1);
-    stl::exclusive_scan(csCounts.begin(), csCounts.end() + 1, layout.begin(), LocalIndex(0));
+    std::exclusive_scan(csCounts.begin(), csCounts.end() + 1, layout.begin(), LocalIndex(0));
 
     auto toInternal = leafToInternal(octree);
     computeLeafMassCenter<T, T, T>(coords.x(), coords.y(), coords.z(), masses, toInternal, layout.data(),

--- a/domain/test/unit/primitives/gather.cpp
+++ b/domain/test/unit/primitives/gather.cpp
@@ -57,8 +57,8 @@ void CpuGatherTest()
     std::vector<KeyType> codes{0, 50, 10, 60, 20, 70, 30, 80, 40, 90};
 
     std::vector<unsigned> scratch;
-    SfcSorter<IndexType, std::vector<unsigned>> cpuGather(scratch);
-    cpuGather.setMapFromCodes(codes.data(), codes.data() + codes.size());
+    SfcSorter<IndexType, std::vector<unsigned>> sorter(scratch);
+    sorter.setMapFromCodes(codes.data(), codes.data() + codes.size());
 
     {
         std::vector<KeyType> refCodes{0, 10, 20, 30, 40, 50, 60, 70, 80, 90};
@@ -67,7 +67,7 @@ void CpuGatherTest()
 
     std::vector<ValueType> values{-2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
     std::vector<ValueType> probe = values;
-    cpuGather(values.data() + 2, probe.data() + 2, 0, codes.size());
+    gatherCpu(sorter.getMap(), codes.size(), values.data() + 2, probe.data() + 2);
     std::vector<ValueType> reference{-2, -1, 0, 2, 4, 6, 8, 1, 3, 5, 7, 9, 10, 11};
 
     EXPECT_EQ(probe, reference);

--- a/domain/test/unit/traversal/macs.cpp
+++ b/domain/test/unit/traversal/macs.cpp
@@ -156,7 +156,7 @@ static void markMacVector()
     updateInternalTree<KeyType>(leaves, octree.data());
 
     std::vector<LocalIndex> layout(octree.numLeafNodes + 1);
-    stl::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), LocalIndex(0));
+    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), LocalIndex(0));
 
     auto toInternal = leafToInternal(octree);
 

--- a/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
+++ b/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
@@ -56,15 +56,13 @@ static void sendListMinimalGpu()
     gsl::span<const KeyType> d_keyView{rawPtr(d_keys), d_keys.size()};
 
     // note: codes input needs to be sorted
-    auto sendList = createSendListGpu<KeyType>(assignment, tree, d_keyView, rawPtr(d_searchKeys), rawPtr(d_indices));
+    auto sendList = createSendRangesGpu<KeyType>(assignment, tree, d_keyView, rawPtr(d_searchKeys), rawPtr(d_indices));
 
-    EXPECT_EQ(sendList[0].totalCount(), 6);
-    EXPECT_EQ(sendList[1].totalCount(), 3);
+    EXPECT_EQ(sendList.count(0), 6);
+    EXPECT_EQ(sendList.count(1), 3);
 
-    EXPECT_EQ(sendList[0].rangeStart(0), 0);
-    EXPECT_EQ(sendList[0].rangeEnd(0), 6);
-    EXPECT_EQ(sendList[1].rangeStart(0), 6);
-    EXPECT_EQ(sendList[1].rangeEnd(0), 9);
+    EXPECT_EQ(sendList[0], 0);
+    EXPECT_EQ(sendList[1], 6);
 }
 
 TEST(DomainDecomposition, createSendListGpu)

--- a/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
+++ b/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
@@ -50,13 +50,13 @@ static void sendListMinimalGpu()
     assignment.addRange(Rank(1), 2, 4, 0);
 
     thrust::device_vector<KeyType> d_keys = codes;
-    thrust::device_vector<double> scratch1;
-    thrust::device_vector<double> scratch2;
+    thrust::device_vector<KeyType> d_searchKeys(numRanks);
+    thrust::device_vector<LocalIndex> d_indices(numRanks);
 
     gsl::span<const KeyType> d_keyView{rawPtr(d_keys), d_keys.size()};
 
     // note: codes input needs to be sorted
-    auto sendList = createSendListGpu<KeyType>(assignment, tree, d_keyView, scratch1, scratch2);
+    auto sendList = createSendListGpu<KeyType>(assignment, tree, d_keyView, rawPtr(d_searchKeys), rawPtr(d_indices));
 
     EXPECT_EQ(sendList[0].totalCount(), 6);
     EXPECT_EQ(sendList[1].totalCount(), 3);

--- a/main/src/init/early_sync.hpp
+++ b/main/src/init/early_sync.hpp
@@ -64,18 +64,20 @@ void syncCoords(size_t rank, size_t numRanks, size_t numParticlesGlobal, Vector&
     cstone::GlobalAssignment<KeyType, T> distributor(rank, numRanks, bucketSize, globalBox);
 
     std::vector<unsigned>                                        orderScratch;
-    cstone::SfcSorter<cstone::LocalIndex, std::vector<unsigned>> reorderFunctor(orderScratch);
+    cstone::SfcSorter<cstone::LocalIndex, std::vector<unsigned>> sorter(orderScratch);
 
     std::vector<T>       scratch1, scratch2;
     std::vector<KeyType> particleKeys(x.size());
     cstone::LocalIndex   newNParticlesAssigned =
-        distributor.assign(bufDesc, reorderFunctor, particleKeys.data(), x.data(), y.data(), z.data());
+        distributor.assign(bufDesc, sorter, particleKeys.data(), x.data(), y.data(), z.data());
     size_t exchangeSize = std::max(x.size(), size_t(newNParticlesAssigned));
     reallocate(exchangeSize, particleKeys, x, y, z);
-    auto [exchangeStart, keyView] = distributor.distribute(bufDesc, reorderFunctor, scratch1, scratch2,
-                                                           particleKeys.data(), x.data(), y.data(), z.data());
+    auto [exchangeStart, keyView] =
+        distributor.distribute(bufDesc, sorter, scratch1, scratch2, particleKeys.data(), x.data(), y.data(), z.data());
+
     scratch1.resize(x.size());
-    cstone::reorderArrays(reorderFunctor, exchangeStart, 0, std::tie(x, y, z), std::tie(scratch1));
+    cstone::gatherArrays(sorter.gatherFunc(), sorter.getMap() + distributor.numSendDown(), distributor.numAssigned(),
+                         exchangeStart, 0, std::tie(x, y, z), std::tie(scratch1));
     x.resize(keyView.size());
     y.resize(keyView.size());
     z.resize(keyView.size());

--- a/ryoanji/test/nbody/traversal_cpu.cpp
+++ b/ryoanji/test/nbody/traversal_cpu.cpp
@@ -74,7 +74,7 @@ TEST(Gravity, TreeWalk)
 
     // layout[i] is equal to the index in (x,y,z,m) of the first particle in leaf cell with index i
     std::vector<LocalIndex> layout(octree.numLeafNodes + 1);
-    stl::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), LocalIndex(0));
+    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), LocalIndex(0));
 
     auto toInternal = leafToInternal(octree);
 


### PR DESCRIPTION
primary use case: synchronize GRACKLE fields on the CPU with a GPU-enabled domain for hydro and gravity