### PR TITLE
use cub double buffer radix sort

### DIFF
--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -80,9 +80,15 @@ public:
      *
      * This function does not modify / communicate any particle data.
      */
-    template<class Reorderer>
-    LocalIndex assign(
-        BufferDescription bufDesc, Reorderer& reorderFunctor, KeyType* particleKeys, const T* x, const T* y, const T* z)
+    template<class Reorderer, class Vector>
+    LocalIndex assign(BufferDescription bufDesc,
+                      Reorderer& reorderFunctor,
+                      Vector& /*sratch0*/,
+                      Vector& /*scratch1*/,
+                      KeyType* particleKeys,
+                      const T* x,
+                      const T* y,
+                      const T* z)
     {
         // number of locally assigned particles to consider for global tree building
         LocalIndex numParticles = bufDesc.end - bufDesc.start;

--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -198,6 +198,7 @@ public:
     //! @brief return the space filling curve rank assignment of the last call to @a assign()
     const SpaceCurveAssignment& assignment() const { return assignment_; }
 
+    //! @brief number of local particles to be sent to lower ranks
     LocalIndex numSendDown() const { return exchanges_[myRank_]; }
     LocalIndex numPresent() const { return exchanges_.count(myRank_); }
     LocalIndex numAssigned() const { return assignment_.totalCount(myRank_); }

--- a/domain/include/cstone/domain/assignment_gpu.cuh
+++ b/domain/include/cstone/domain/assignment_gpu.cuh
@@ -211,6 +211,7 @@ public:
     //! @brief return the space filling curve rank assignment of the last call to @a assign()
     const SpaceCurveAssignment& assignment() const { return assignment_; }
 
+    //! @brief number of local particles to be sent to lower ranks
     LocalIndex numSendDown() const { return exchanges_[myRank_]; }
     LocalIndex numPresent() const { return exchanges_.count(myRank_); }
     LocalIndex numAssigned() const { return assignment_.totalCount(myRank_); }

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -467,7 +467,8 @@ private:
         std::apply([size = x.size()](auto&... arrays) { checkSizesEqual(size, arrays...); }, distributedArrays);
 
         // Global tree build and assignment
-        auto exchangeSize = global_.assign(bufDesc_, sorter, rawPtr(keys), rawPtr(x), rawPtr(y), rawPtr(z));
+        auto exchangeSize = global_.assign(bufDesc_, sorter, std::get<0>(scratchBuffers), std::get<1>(scratchBuffers),
+                                           rawPtr(keys), rawPtr(x), rawPtr(y), rawPtr(z));
         lowMemReallocate(exchangeSize, 1.01, distributedArrays, scratchBuffers);
 
         return std::apply(

--- a/domain/include/cstone/domain/domaindecomp.hpp
+++ b/domain/include/cstone/domain/domaindecomp.hpp
@@ -44,16 +44,6 @@
 namespace cstone
 {
 
-/*! @brief a custom type for type safety in function calls
- *
- * The resulting type behaves like an int, except that explicit
- * conversion is required in function calls. Used e.g. in
- * SpaceCurveAssignment::addRange to force the caller to write
- * addRange(Rank(r), a,b,c) instead of addRange(r,a,b,c).
- * This makes it impossible to unintentionally mix up the arguments.
- */
-using Rank = StrongType<int, struct RankTag>;
-
 /*! @brief stores which parts of the SFC belong to which rank, on a per-rank basis
  *
  * The storage layout allows fast look-up of the SFC code ranges that a given rank
@@ -81,7 +71,7 @@ public:
     }
 
     //! @brief add an index/code range to rank @p rank
-    void addRange(Rank rank, TreeNodeIndex lower, TreeNodeIndex upper, std::size_t cnt)
+    void addRange(int rank, TreeNodeIndex lower, TreeNodeIndex upper, std::size_t cnt)
     {
         // make sure that there's no holes or overlap between or with the range of the previous rank
         assert(rankAssignment_[rank] == lower || rankAssignment_[rank] == untouched);
@@ -177,7 +167,7 @@ inline SpaceCurveAssignment singleRangeSfcSplit(const std::vector<unsigned>& glo
         }
 
         // other distribution strategies might have more than one range per rank
-        ret.addRange(Rank(split), leavesDone, j, splitCount);
+        ret.addRange(split, leavesDone, j, splitCount);
         leavesDone = j;
     }
 
@@ -242,7 +232,7 @@ void limitBoundaryShifts(gsl::span<const KeyType> oldBoundaries,
         {
             std::size_t segmentCount = std::accumulate(counts.begin() + newIndexBoundaries[rank],
                                                        counts.begin() + newIndexBoundaries[rank + 1], std::size_t(0));
-            newAssignment.addRange(Rank(rank), newIndexBoundaries[rank], newIndexBoundaries[rank + 1], segmentCount);
+            newAssignment.addRange(rank, newIndexBoundaries[rank], newIndexBoundaries[rank + 1], segmentCount);
         }
     }
 }

--- a/domain/include/cstone/domain/domaindecomp_mpi.hpp
+++ b/domain/include/cstone/domain/domaindecomp_mpi.hpp
@@ -148,7 +148,7 @@ void exchangeParticles(const SendRanges& sends,
         char* particleData = receiveBuffer.data() + headerBytes;
         auto packTuple     = packBufferPtrs<alignment>(particleData, receiveCount, (arrays + receiveLocation)...);
         auto scatterRanges = [receiveCount](auto arrayPair) { std::copy_n(arrayPair[1], receiveCount, arrayPair[0]); };
-        for_each_tuple(scatterRanges, packTuple);
+        util::for_each_tuple(scatterRanges, packTuple);
 
         receiveStart += receiveCount;
     }

--- a/domain/include/cstone/domain/domaindecomp_mpi_gpu.cuh
+++ b/domain/include/cstone/domain/domaindecomp_mpi_gpu.cuh
@@ -155,7 +155,7 @@ void exchangeParticlesGpu(const SendRanges& sends,
                                       receiveCount * sizeof(std::decay_t<decltype(*arrayPair[0])>),
                                       cudaMemcpyDeviceToDevice));
         };
-        for_each_tuple(scatterRanges, packTuple);
+        util::for_each_tuple(scatterRanges, packTuple);
         checkGpuErrors(cudaDeviceSynchronize());
 
         receiveStart += receiveCount;

--- a/domain/include/cstone/domain/index_ranges.hpp
+++ b/domain/include/cstone/domain/index_ranges.hpp
@@ -37,7 +37,6 @@
 #include <vector>
 
 #include "cstone/tree/definitions.h"
-#include "cstone/util/util.hpp"
 
 namespace cstone
 {

--- a/domain/include/cstone/domain/layout.hpp
+++ b/domain/include/cstone/domain/layout.hpp
@@ -51,7 +51,8 @@
 #include <vector>
 
 #include "cstone/domain/domaindecomp.hpp"
-#include "cstone/util/traits.hpp"
+#include "cstone/util/tuple_util.hpp"
+#include "cstone/util/type_list.hpp"
 
 namespace cstone
 {
@@ -213,7 +214,7 @@ void gatherArrays(Gather&& gatherFunc,
         swap(swapSpace, array);
     };
 
-    for_each_tuple(reorderArray, arrays);
+    util::for_each_tuple(reorderArray, arrays);
 }
 
 } // namespace cstone

--- a/domain/include/cstone/fields/data_util.hpp
+++ b/domain/include/cstone/fields/data_util.hpp
@@ -34,7 +34,7 @@
 #include <vector>
 #include <variant>
 
-#include "cstone/util/traits.hpp"
+#include "cstone/util/type_list.hpp"
 
 namespace cstone
 {

--- a/domain/include/cstone/findneighbors.hpp
+++ b/domain/include/cstone/findneighbors.hpp
@@ -92,29 +92,29 @@ HOST_DEVICE_FUN constexpr T distanceSq(T x1, T y1, T z1, T x2, T y2, T z2, const
  * @param[out] neighbors       output to store the neighbors
  * @return                     neighbor count of particle @p i, does not include self-reference; min return val is 0.
  */
-template<class T, class KeyType>
+template<class Tc, class Th, class KeyType>
 HOST_DEVICE_FUN unsigned findNeighbors(LocalIndex i,
-                                       const T* x,
-                                       const T* y,
-                                       const T* z,
-                                       const T* h,
-                                       const OctreeNsView<T, KeyType>& tree,
-                                       const Box<T>& box,
+                                       const Tc* x,
+                                       const Tc* y,
+                                       const Tc* z,
+                                       const Th* h,
+                                       const OctreeNsView<Tc, KeyType>& tree,
+                                       const Box<Tc>& box,
                                        unsigned ngmax,
                                        LocalIndex* neighbors)
 {
-    T xi = x[i];
-    T yi = y[i];
-    T zi = z[i];
-    T hi = h[i];
+    auto xi = x[i];
+    auto yi = y[i];
+    auto zi = z[i];
+    auto hi = h[i];
 
-    T radiusSq = 4.0 * hi * hi;
-    Vec3<T> particle{xi, yi, zi};
+    auto radiusSq = Th(4.0) * hi * hi;
+    Vec3<Tc> particle{xi, yi, zi};
     unsigned numNeighbors = 0;
 
     auto pbc    = BoundaryType::periodic;
     bool anyPbc = box.boundaryX() == pbc || box.boundaryY() == pbc || box.boundaryZ() == pbc;
-    bool usePbc = anyPbc && !insideBox(particle, {T(2) * hi, T(2) * hi, T(2) * hi}, box);
+    bool usePbc = anyPbc && !insideBox(particle, {Tc(2) * hi, Tc(2) * hi, Tc(2) * hi}, box);
 
     auto overlapsPbc = [particle, radiusSq, centers = tree.centers, sizes = tree.sizes, &box](TreeNodeIndex idx)
     {

--- a/domain/include/cstone/focus/rebalance_gpu.cu
+++ b/domain/include/cstone/focus/rebalance_gpu.cu
@@ -33,7 +33,7 @@
 #include "cstone/cuda/errorcheck.cuh"
 #include "cstone/focus/rebalance.hpp"
 #include "cstone/focus/rebalance_gpu.h"
-#include "cstone/util/util.hpp"
+#include "cstone/primitives/math.hpp"
 
 namespace cstone
 {

--- a/domain/include/cstone/focus/source_center_gpu.cu
+++ b/domain/include/cstone/focus/source_center_gpu.cu
@@ -28,7 +28,7 @@
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
-#include "cstone/util/util.hpp"
+#include "cstone/primitives/math.hpp"
 #include "source_center.hpp"
 #include "source_center_gpu.h"
 

--- a/domain/include/cstone/halos/exchange_halos_gpu.cuh
+++ b/domain/include/cstone/halos/exchange_halos_gpu.cuh
@@ -40,7 +40,7 @@
 #include "cstone/primitives/mpi_cuda.cuh"
 #include "cstone/domain/buffer_description.hpp"
 #include "cstone/util/reallocate.hpp"
-#include "cstone/util/util.hpp"
+#include "cstone/util/tuple_util.hpp"
 
 #include "gather_halos_gpu.h"
 

--- a/domain/include/cstone/halos/exchange_halos_gpu.cuh
+++ b/domain/include/cstone/halos/exchange_halos_gpu.cuh
@@ -55,7 +55,7 @@ void haloExchangeGpu(int epoch,
                      DevVec2& receiveScratchBuffer,
                      Arrays... arrays)
 {
-    constexpr int alignment = 1;
+    constexpr int alignment = 8;
     using IndexType         = SendManifest::IndexType;
 
     int haloExchangeTag = static_cast<int>(P2pTags::haloExchange) + epoch;

--- a/domain/include/cstone/halos/gather_halos_gpu.cu
+++ b/domain/include/cstone/halos/gather_halos_gpu.cu
@@ -30,11 +30,9 @@
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
-#include <cstdint>
-
+#include "cstone/primitives/math.hpp"
 #include "cstone/primitives/stl.hpp"
 #include "cstone/util/array.hpp"
-#include "cstone/util/util.hpp"
 #include "gather_halos_gpu.h"
 
 namespace cstone

--- a/domain/include/cstone/primitives/gather.cuh
+++ b/domain/include/cstone/primitives/gather.cuh
@@ -77,6 +77,31 @@ public:
         sortByKeyGpu(first, last, ordering());
     }
 
+    template<class KeyType>
+    void setMapFromCodes(KeyType* first, KeyType* last, KeyType* keyBuf, IndexType* valueBuf)
+    {
+        mapSize_ = std::size_t(last - first);
+        reallocateBytes(buffer_, mapSize_ * sizeof(IndexType));
+        sequenceGpu(ordering(), mapSize_, LocalIndex(0));
+        sortByKeyGpu(first, last, ordering(), keyBuf, valueBuf);
+    }
+
+    template<class KeyType, class KeyBuf, class ValueBuf>
+    void setMapFromCodes(KeyType* first, KeyType* last, KeyBuf& keyBuf, ValueBuf& valueBuf)
+    {
+        mapSize_ = std::size_t(last - first);
+        reallocateBytes(buffer_, mapSize_ * sizeof(IndexType));
+        sequenceGpu(ordering(), mapSize_, LocalIndex(0));
+
+        auto s1 = reallocateBytes(keyBuf, mapSize_ * sizeof(KeyType));
+        auto s2 = reallocateBytes(valueBuf, mapSize_ * sizeof(IndexType));
+
+        setMapFromCodes(first, last, (KeyType*)rawPtr(keyBuf), (IndexType*)rawPtr(valueBuf));
+
+        reallocateDevice(keyBuf, s1, 1.01);
+        reallocateDevice(valueBuf, s2, 1.01);
+    }
+
     auto gatherFunc() const { return gatherGpuL; }
 
 private:

--- a/domain/include/cstone/primitives/math.hpp
+++ b/domain/include/cstone/primitives/math.hpp
@@ -1,0 +1,25 @@
+/*! @file
+ * @brief  Basic math
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "cstone/cuda/annotation.hpp"
+
+namespace cstone
+{
+
+//! @brief ceil(dividend/divisor) for unsigned integers
+HOST_DEVICE_FUN constexpr size_t iceil(size_t dividend, unsigned divisor)
+{
+    return (dividend + divisor - 1lu) / divisor;
+}
+
+//! @brief round up @p n to multiple of @p m
+HOST_DEVICE_FUN constexpr size_t round_up(size_t n, unsigned m) { return ((n + m - 1) / m) * m; }
+
+} // namespace cstone

--- a/domain/include/cstone/primitives/primitives_gpu.cu
+++ b/domain/include/cstone/primitives/primitives_gpu.cu
@@ -40,7 +40,8 @@
 #include <thrust/sort.h>
 
 #include "cstone/cuda/errorcheck.cuh"
-#include "cstone/util/util.hpp"
+#include "cstone/primitives/math.hpp"
+#include "cstone/util/array.hpp"
 #include "primitives_gpu.h"
 
 namespace cstone

--- a/domain/include/cstone/primitives/primitives_gpu.cu
+++ b/domain/include/cstone/primitives/primitives_gpu.cu
@@ -29,6 +29,8 @@
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
+#include <cub/cub.cuh>
+
 #include <thrust/binary_search.h>
 #include <thrust/count.h>
 #include <thrust/execution_policy.h>
@@ -232,6 +234,46 @@ void sequenceGpu(IndexType* input, size_t numElements, IndexType init)
 template void sequenceGpu(int*, size_t, int);
 template void sequenceGpu(unsigned*, size_t, unsigned);
 template void sequenceGpu(uint64_t*, uint64_t, uint64_t);
+
+template<class KeyType, class ValueType>
+void sortByKeyGpu(KeyType* first, KeyType* last, ValueType* values, KeyType* keyBuf, ValueType* valueBuf)
+{
+    size_t numElements = last - first;
+
+    cub::DoubleBuffer<KeyType> d_keys(first, keyBuf);
+    cub::DoubleBuffer<ValueType> d_values(values, valueBuf);
+
+    // Determine temporary device storage requirements
+    void* d_tempStorage     = nullptr;
+    size_t tempStorageBytes = 0;
+    cub::DeviceRadixSort::SortPairs(d_tempStorage, tempStorageBytes, d_keys, d_values, numElements);
+
+    // Allocate temporary storage
+    checkGpuErrors(cudaMalloc(&d_tempStorage, tempStorageBytes));
+
+    // Run sorting operation
+    checkGpuErrors(cub::DeviceRadixSort::SortPairs(d_tempStorage, tempStorageBytes, d_keys, d_values, numElements));
+
+    auto* curKeys = d_keys.Current();
+    if (curKeys != first)
+    {
+        checkGpuErrors(cudaMemcpy(first, curKeys, numElements * sizeof(KeyType), cudaMemcpyDeviceToDevice));
+    }
+
+    auto* curValues = d_values.Current();
+    if (curValues != values)
+    {
+        checkGpuErrors(cudaMemcpy(values, curValues, numElements * sizeof(ValueType), cudaMemcpyDeviceToDevice));
+    }
+
+    checkGpuErrors(cudaFree(d_tempStorage));
+}
+
+template void sortByKeyGpu(unsigned*, unsigned*, unsigned*, unsigned*, unsigned*);
+template void sortByKeyGpu(unsigned*, unsigned*, int*, unsigned*, int*);
+template void sortByKeyGpu(uint64_t*, uint64_t*, unsigned*, uint64_t*, unsigned*);
+template void sortByKeyGpu(uint64_t*, uint64_t*, int*, uint64_t*, int*);
+template void sortByKeyGpu(uint64_t*, uint64_t*, uint64_t*, uint64_t*, uint64_t*);
 
 template<class KeyType, class ValueType>
 void sortByKeyGpu(KeyType* first, KeyType* last, ValueType* values)

--- a/domain/include/cstone/primitives/primitives_gpu.h
+++ b/domain/include/cstone/primitives/primitives_gpu.h
@@ -84,6 +84,9 @@ template<class IndexType>
 extern void sequenceGpu(IndexType* input, size_t numElements, IndexType init);
 
 template<class KeyType, class ValueType>
+extern void sortByKeyGpu(KeyType* first, KeyType* last, ValueType* values, KeyType* keyBuf, ValueType* valueBuf);
+
+template<class KeyType, class ValueType>
 extern void sortByKeyGpu(KeyType* first, KeyType* last, ValueType* values);
 
 template<class IndexType, class SumType>

--- a/domain/include/cstone/primitives/scan.hpp
+++ b/domain/include/cstone/primitives/scan.hpp
@@ -35,7 +35,9 @@
 #include <iostream>
 #include <numeric>
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include "cstone/primitives/stl.hpp"
 
@@ -55,11 +57,13 @@ void exclusiveScan(const T1* in, T2* out, size_t numElements)
     constexpr int blockSize = (8192 + 16384) / sizeof(T1);
 
     int numThreads = 1;
+#ifdef _OPENMP
 #pragma omp parallel
     {
 #pragma omp single
         numThreads = omp_get_num_threads();
     }
+#endif
 
     T2 superBlock[2][numThreads + 1];
     std::fill(superBlock[0], superBlock[0] + numThreads + 1, 0);
@@ -70,7 +74,10 @@ void exclusiveScan(const T1* in, T2* out, size_t numElements)
 
 #pragma omp parallel num_threads(numThreads)
     {
-        int tid = omp_get_thread_num();
+        int tid = 0;
+#ifdef _OPENMP
+        tid = omp_get_thread_num();
+#endif
         for (size_t step = 0; step < nSteps; ++step)
         {
             size_t stepOffset = step * elementsPerStep + tid * blockSize;

--- a/domain/include/cstone/sfc/box.hpp
+++ b/domain/include/cstone/sfc/box.hpp
@@ -231,8 +231,8 @@ HOST_DEVICE_FUN inline Vec3<T> putInBox(Vec3<T> X, const Box<T>& box)
 }
 
 //! @brief Legacy PBC
-template<class T>
-HOST_DEVICE_FUN inline void applyPBC(const cstone::Box<T>& box, T r, T& xx, T& yy, T& zz)
+template<class Tc, class T>
+HOST_DEVICE_FUN inline void applyPBC(const cstone::Box<Tc>& box, T r, T& xx, T& yy, T& zz)
 {
     bool pbcX = (box.boundaryX() == BoundaryType::periodic);
     bool pbcY = (box.boundaryY() == BoundaryType::periodic);
@@ -257,11 +257,11 @@ HOST_DEVICE_FUN inline void applyPBC(const cstone::Box<T>& box, T r, T& xx, T& y
 template<class Tc, class T>
 HOST_DEVICE_FUN inline T distancePBC(const cstone::Box<Tc>& box, T hi, Tc x1, Tc y1, Tc z1, Tc x2, Tc y2, Tc z2)
 {
-    Tc xx = x1 - x2;
-    Tc yy = y1 - y2;
-    Tc zz = z1 - z2;
+    T xx = x1 - x2;
+    T yy = y1 - y2;
+    T zz = z1 - z2;
 
-    applyPBC<Tc>(box, 2.0 * hi, xx, yy, zz);
+    applyPBC(box, T(2) * hi, xx, yy, zz);
 
     return std::sqrt(xx * xx + yy * yy + zz * zz);
 }

--- a/domain/include/cstone/sfc/common.hpp
+++ b/domain/include/cstone/sfc/common.hpp
@@ -40,7 +40,6 @@
 #include "cstone/primitives/stl.hpp"
 #include "cstone/tree/definitions.h"
 #include "cstone/util/tuple.hpp"
-#include "cstone/util/util.hpp"
 
 namespace cstone
 {

--- a/domain/include/cstone/sfc/sfc.hpp
+++ b/domain/include/cstone/sfc/sfc.hpp
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include "cstone/util/strong_type.hpp"
+
 #include "morton.hpp"
 #include "hilbert.hpp"
 

--- a/domain/include/cstone/sfc/sfc_gpu.cu
+++ b/domain/include/cstone/sfc/sfc_gpu.cu
@@ -29,8 +29,8 @@
  */
 
 #include "cstone/cuda/errorcheck.cuh"
+#include "cstone/primitives/math.hpp"
 #include "cstone/sfc/sfc_gpu.h"
-#include "cstone/util/util.hpp"
 
 namespace cstone
 {

--- a/domain/include/cstone/traversal/collisions_gpu.cu
+++ b/domain/include/cstone/traversal/collisions_gpu.cu
@@ -29,6 +29,7 @@
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
+#include "cstone/primitives/math.hpp"
 #include "cstone/traversal/collisions_gpu.h"
 
 namespace cstone

--- a/domain/include/cstone/traversal/groups.cuh
+++ b/domain/include/cstone/traversal/groups.cuh
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "cstone/cuda/gpu_config.cuh"
+#include "cstone/primitives/math.hpp"
 #include "cstone/primitives/primitives_gpu.h"
 #include "cstone/primitives/warpscan.cuh"
 #include "cstone/sfc/sfc.hpp"

--- a/domain/include/cstone/traversal/groups.cuh
+++ b/domain/include/cstone/traversal/groups.cuh
@@ -185,17 +185,17 @@ __global__ void makeSplitsKernel(const util::array<GpuConfig::ThreadMask, N>* sp
  * @param[out] splitMasks      split mask for each of the ceil((last-first)/groupSize) fixed-size groups
  * @param[out] numSplitsPerGroup 1 + number-of-1-bits in @p splitMasks for each fixed-size group
  */
-template<unsigned groupSize, class T, class KeyType>
+template<unsigned groupSize, class Tc, class T, class KeyType>
 __global__ void groupSplitsKernel(LocalIndex first,
                                   LocalIndex last,
-                                  const T* x,
-                                  const T* y,
-                                  const T* z,
+                                  const Tc* x,
+                                  const Tc* y,
+                                  const Tc* z,
                                   const T* h,
                                   const KeyType* leaves,
                                   TreeNodeIndex numLeaves,
                                   const LocalIndex* layout,
-                                  const Box<T> box,
+                                  const Box<Tc> box,
                                   float tolFactor,
                                   util::array<GpuConfig::ThreadMask, groupSize / GpuConfig::warpSize>* splitMasks,
                                   LocalIndex* numSplitsPerGroup,
@@ -231,14 +231,14 @@ __global__ void groupSplitsKernel(LocalIndex first,
         nodeVolume = min(vol, nodeVolume);
     }
     nodeVolume = warpMin(nodeVolume);
-    T distCrit = std::cbrt(nodeVolume) * tolFactor;
+    Tc distCrit = std::cbrt(nodeVolume) * tolFactor;
 
     // load target coordinates
-    util::array<Vec4<T>, nwt> pos_i;
+    util::array<Vec4<Tc>, nwt> pos_i;
     for (int k = 0; k < nwt; k++)
     {
         pos_i[k] = {x[bodyIdx[k]] * box.ilx(), y[bodyIdx[k]] * box.ily(), z[bodyIdx[k]] * box.ilz(),
-                    h ? T(2) * h[bodyIdx[k]] : T(0)};
+                    h ? Tc(2) * h[bodyIdx[k]] : Tc(0)};
     }
 
     auto splitMask = findSplits(pos_i, distCrit * distCrit);
@@ -256,18 +256,18 @@ __global__ void groupSplitsKernel(LocalIndex first,
 }
 
 //! @brief convenience wrapper for groupSplitsKernel
-template<unsigned groupSize, class T, class KeyType>
+template<unsigned groupSize, class Tc, class T, class KeyType>
 void computeGroupSplits(
     LocalIndex first,
     LocalIndex last,
-    const T* x,
-    const T* y,
-    const T* z,
+    const Tc* x,
+    const Tc* y,
+    const Tc* z,
     const T* h,
     const KeyType* leaves,
     TreeNodeIndex numLeaves,
     const LocalIndex* layout,
-    const Box<T> box,
+    const Box<Tc> box,
     float tolFactor,
     thrust::device_vector<util::array<GpuConfig::ThreadMask, groupSize / GpuConfig::warpSize>>& splitMasks,
     thrust::device_vector<LocalIndex>& numSplitsPerGroup,
@@ -283,7 +283,7 @@ void computeGroupSplits(
     numSplitsPerGroup.reserve(numFixedGroups * 1.1);
     numSplitsPerGroup.resize(numFixedGroups);
 
-    groupSplitsKernel<groupSize, T><<<iceil(gridSize, numThreads), numThreads>>>(
+    groupSplitsKernel<groupSize><<<iceil(gridSize, numThreads), numThreads>>>(
         first, last, x, y, z, h, leaves, numLeaves, layout, box, tolFactor, rawPtr(splitMasks),
         rawPtr(numSplitsPerGroup), numFixedGroups);
 

--- a/domain/include/cstone/tree/btree.cuh
+++ b/domain/include/cstone/tree/btree.cuh
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "cstone/primitives/math.hpp"
 #include "btree.hpp"
 
 namespace cstone

--- a/domain/include/cstone/tree/csarray_gpu.cu
+++ b/domain/include/cstone/tree/csarray_gpu.cu
@@ -37,7 +37,7 @@
 #include <thrust/scan.h>
 
 #include "cstone/cuda/errorcheck.cuh"
-#include "cstone/util/util.hpp"
+#include "cstone/primitives/math.hpp"
 #include "csarray.hpp"
 
 #include "csarray_gpu.h"

--- a/domain/include/cstone/tree/octree_gpu.cu
+++ b/domain/include/cstone/tree/octree_gpu.cu
@@ -34,6 +34,7 @@
 #include <thrust/sort.h>
 #include <thrust/fill.h>
 
+#include "cstone/primitives/math.hpp"
 #include "cstone/sfc/common.hpp"
 #include "cstone/tree/octree_gpu.h"
 

--- a/domain/include/cstone/util/reallocate.hpp
+++ b/domain/include/cstone/util/reallocate.hpp
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "cstone/cuda/cuda_stubs.h"
+#include "cstone/util/tuple_util.hpp"
 
 template<class Vector>
 extern void reallocateDevice(Vector&, size_t, double);
@@ -109,12 +110,12 @@ void lowMemReallocate(size_t size,
                       std::tuple<Vectors2&...> scratch)
 {
     // if the new size exceeds capacity, we first deallocate all scratch buffers to make space for the reallocations
-    for_each_tuple(
+    util::for_each_tuple(
         [size](auto& v)
         {
             if (size > v.capacity()) { std::decay_t<decltype(v)>{}.swap(v); }
         },
         scratch);
-    for_each_tuple([size, growthFactor](auto& v) { reallocate(v, size, growthFactor); }, conserved);
-    for_each_tuple([size, growthFactor](auto& v) { reallocate(v, size, growthFactor); }, scratch);
+    util::for_each_tuple([size, growthFactor](auto& v) { reallocate(v, size, growthFactor); }, conserved);
+    util::for_each_tuple([size, growthFactor](auto& v) { reallocate(v, size, growthFactor); }, scratch);
 }

--- a/domain/include/cstone/util/strong_type.hpp
+++ b/domain/include/cstone/util/strong_type.hpp
@@ -31,12 +31,7 @@
 
 #pragma once
 
-#include <algorithm>
-#include <tuple>
-#include <utility>
-
 #include "cstone/cuda/annotation.hpp"
-#include "array.hpp"
 
 /*! @brief A template to create structs as a type-safe version to using declarations
  *
@@ -125,50 +120,3 @@ constexpr HOST_DEVICE_FUN StrongType<T, Phantom> operator-(const StrongType<T, P
 {
     return StrongType<T, Phantom>(lhs.value() - rhs.value());
 }
-
-//! @brief Utility to call function with each element in tuple_
-template<class F, class... Ts>
-void for_each_tuple(F&& func, std::tuple<Ts...>& tuple_)
-{
-    std::apply([f = func](auto&... args) { [[maybe_unused]] auto list = std::initializer_list<int>{(f(args), 0)...}; },
-               tuple_);
-}
-
-//! @brief Utility to call function with each element in tuple_ with const guarantee
-template<class F, class... Ts>
-void for_each_tuple(F&& func, const std::tuple<Ts...>& tuple_)
-{
-    std::apply([f = func](auto&... args) { [[maybe_unused]] auto list = std::initializer_list<int>{(f(args), 0)...}; },
-               tuple_);
-}
-
-//! @brief convert an index_sequence into a tuple of integral constants (e.g. for use with for_each_tuple)
-template<size_t... Is>
-constexpr auto makeIntegralTuple(std::index_sequence<Is...>)
-{
-    return std::make_tuple(std::integral_constant<size_t, Is>{}...);
-}
-
-template<class Tuple, size_t... Is>
-constexpr auto discardLastImpl(const Tuple& tuple, std::index_sequence<Is...>)
-{
-    return std::tie(std::get<Is>(tuple)...);
-}
-
-template<class Tuple>
-constexpr auto discardLastElement(const Tuple& tuple)
-{
-    constexpr int tupleSize = std::tuple_size_v<Tuple>;
-    static_assert(tupleSize > 1);
-
-    using Seq = std::make_index_sequence<tupleSize - 1>;
-    return discardLastImpl(tuple, Seq{});
-}
-
-//! @brief ceil(dividend/divisor) for unsigned integers
-HOST_DEVICE_FUN constexpr size_t iceil(size_t dividend, unsigned divisor)
-{
-    return (dividend + divisor - 1lu) / divisor;
-}
-
-HOST_DEVICE_FUN constexpr size_t round_up(size_t n, unsigned multiple) { return iceil(n, multiple) * multiple; }

--- a/domain/include/cstone/util/tuple_util.hpp
+++ b/domain/include/cstone/util/tuple_util.hpp
@@ -1,0 +1,92 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 CSCS, ETH Zurich
+ *               2021 University of Basel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief  General purpose utilities
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace util
+{
+
+//! @brief Utility to call function with each element in tuple_
+template<class F, class Tuple>
+void for_each_tuple(F&& func, Tuple&& tuple_)
+{
+    std::apply([f = func](auto&&... args) { [[maybe_unused]] auto list = std::initializer_list<int>{(f(args), 0)...}; },
+               std::forward<Tuple>(tuple_));
+}
+
+//! @brief convert an index_sequence into a tuple of integral constants (e.g. for use with for_each_tuple)
+template<size_t... Is>
+constexpr auto makeIntegralTuple(std::index_sequence<Is...>)
+{
+    return std::make_tuple(std::integral_constant<size_t, Is>{}...);
+}
+
+template<class Tuple, size_t... Is>
+constexpr auto discardLastImpl(const Tuple& tuple, std::index_sequence<Is...>)
+{
+    return std::tie(std::get<Is>(tuple)...);
+}
+
+template<class Tuple>
+constexpr auto discardLastElement(const Tuple& tuple)
+{
+    constexpr int tupleSize = std::tuple_size_v<Tuple>;
+    static_assert(tupleSize > 1);
+
+    using Seq = std::make_index_sequence<tupleSize - 1>;
+    return discardLastImpl(tuple, Seq{});
+}
+
+template<class Tuple, std::size_t... Ints>
+std::tuple<std::tuple_element_t<Ints, std::decay_t<Tuple>>...> selectTuple(Tuple&& tuple, std::index_sequence<Ints...>)
+{
+    return {std::get<Ints>(std::forward<Tuple>(tuple))...};
+}
+
+template<std::size_t... Is>
+constexpr auto indexSequenceReverse(std::index_sequence<Is...> const&)
+    -> decltype(std::index_sequence<sizeof...(Is) - 1U - Is...>{});
+
+template<std::size_t N>
+using makeIndexSequenceReverse = decltype(indexSequenceReverse(std::make_index_sequence<N>{}));
+
+template<class Tuple>
+decltype(auto) reverse(Tuple&& tuple)
+{
+    return selectTuple(std::forward<Tuple>(tuple), makeIndexSequenceReverse<std::tuple_size_v<std::decay_t<Tuple>>>{});
+}
+
+} // namespace util

--- a/domain/include/cstone/util/type_list.hpp
+++ b/domain/include/cstone/util/type_list.hpp
@@ -36,7 +36,6 @@
 #include <type_traits>
 
 #include "cstone/primitives/stl.hpp"
-#include "util.hpp"
 
 namespace util
 {
@@ -346,5 +345,12 @@ struct SwapArg<Base<T, I>, Arg>
 {
     using type = Base<Arg, I>;
 };
+
+//! @brief return the index sequence of the subList entries in the baseList
+template<class... Ts1, class... Ts2>
+auto subsetIndices(TypeList<Ts1...> /*subList*/, TypeList<Ts2...> /*baseList*/)
+{
+    return std::index_sequence<FindIndex<Ts1, TypeList<Ts2...>>{}...>{};
+}
 
 } // namespace util

--- a/domain/test/integration_mpi/assignment_gpu.cpp
+++ b/domain/test/integration_mpi/assignment_gpu.cpp
@@ -99,7 +99,9 @@ void randomGaussianAssignment(int rank, int numRanks)
     std::vector<unsigned> sfcScratchCpu;
     SfcSorter<LocalIndex, std::vector<unsigned>> cpuGather(sfcScratchCpu);
 
-    LocalIndex exchangeSizeCpu = assignment.assign(bufDesc, cpuGather, keys.data(), x.data(), y.data(), z.data());
+    std::vector<T> s0, s1;
+    LocalIndex exchangeSizeCpu =
+        assignment.assign(bufDesc, cpuGather, s0, s1, keys.data(), x.data(), y.data(), z.data());
 
     thrust::device_vector<KeyType> d_keys;
     reallocateDevice(d_keys, numParticles, 1.0);
@@ -112,7 +114,9 @@ void randomGaussianAssignment(int rank, int numRanks)
     thrust::device_vector<unsigned> sfcScratch;
     GpuSfcSorter<LocalIndex, thrust::device_vector<unsigned>> deviceSort(sfcScratch);
 
-    bufDesc.size = assignmentGpu.assign(bufDesc, deviceSort, rawPtr(d_keys), rawPtr(d_x), rawPtr(d_y), rawPtr(d_z));
+    thrust::device_vector<T> d_s0, d_s1;
+    bufDesc.size =
+        assignmentGpu.assign(bufDesc, deviceSort, d_s0, d_s1, rawPtr(d_keys), rawPtr(d_x), rawPtr(d_y), rawPtr(d_z));
 
     ASSERT_EQ(exchangeSizeCpu, bufDesc.size);
     EXPECT_EQ(assignment.treeLeaves().size(), assignmentGpu.treeLeaves().size());

--- a/domain/test/integration_mpi/exchange_domain_gpu.cpp
+++ b/domain/test/integration_mpi/exchange_domain_gpu.cpp
@@ -78,7 +78,7 @@ void exchangeAllToAll(int thisRank, int numRanks)
 
     int segmentSize = gridSize / numRanks;
 
-    SendRanges sends(numRanks);
+    SendRanges sends(numRanks + 1);
     sends.back() = gridSize;
     for (int rank = 0; rank < numRanks; ++rank)
     {
@@ -110,7 +110,7 @@ void exchangeAllToAll(int thisRank, int numRanks)
     reallocateDevice(d_y, bufDesc.size, 1.0);
 
     std::vector<std::tuple<int, LocalIndex>> log;
-    exchangeParticlesGpu(sends, Rank(thisRank), bufDesc, numParticlesThisRank, sendScratch, receiveScratch,
+    exchangeParticlesGpu(sends, thisRank, bufDesc, numParticlesThisRank, sendScratch, receiveScratch,
                          rawPtr(d_ordering), log, rawPtr(d_x), rawPtr(d_y));
 
     reallocate(bufDesc.size, x, y);
@@ -193,7 +193,7 @@ void exchangeCyclicNeighbors(int thisRank, int numRanks)
     reallocateDevice(d_testArray, bufDesc.size, 1.0);
 
     std::vector<std::tuple<int, LocalIndex>> log;
-    exchangeParticlesGpu(sends, Rank(thisRank), bufDesc, gridSize, sendScratch, receiveScratch, rawPtr(d_ordering), log,
+    exchangeParticlesGpu(sends, thisRank, bufDesc, gridSize, sendScratch, receiveScratch, rawPtr(d_ordering), log,
                          rawPtr(d_x), rawPtr(d_y), rawPtr(d_testArray));
 
     reallocate(bufDesc.size, x, y, testArray);

--- a/domain/test/integration_mpi/treedomain.cpp
+++ b/domain/test/integration_mpi/treedomain.cpp
@@ -105,7 +105,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
     bufDesc.size = domain_exchange::exchangeBufferSize(bufDesc, numPresent, numAssigned);
     reallocate(bufDesc.size, x, y, z);
     std::vector<std::tuple<int, LocalIndex>> log;
-    exchangeParticles(sends, Rank(thisRank), bufDesc, numAssigned, ordering.data(), log, x.data(), y.data(), z.data());
+    exchangeParticles(sends, thisRank, bufDesc, numAssigned, ordering.data(), log, x.data(), y.data(), z.data());
 
     domain_exchange::extractLocallyOwned(bufDesc, numPresent, numAssigned, ordering.data() + sends[thisRank], x, y, z);
 

--- a/domain/test/performance/hilbert.cu
+++ b/domain/test/performance/hilbert.cu
@@ -38,8 +38,8 @@
 #include <thrust/sort.h>
 
 #include "cstone/cuda/cuda_utils.cuh"
+#include "cstone/primitives/math.hpp"
 #include "cstone/sfc/sfc_gpu.h"
-#include "cstone/util/util.hpp"
 
 #include "timing.cuh"
 

--- a/domain/test/unit/CMakeLists.txt
+++ b/domain/test/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ set(UNIT_TESTS
         neighbors/findneighbors.cpp
         primitives/clz.cpp
         primitives/gather.cpp
+        primitives/math.cpp
         sfc/box.cpp
         sfc/common.cpp
         sfc/hilbert.cpp
@@ -28,7 +29,8 @@ set(UNIT_TESTS
         tree/octree.cpp
         tree/cs_util.cpp
         util/array.cpp
-        util/util.cpp
+        util/tuple_util.cpp
+        util/type_list.cpp
         util/value_list.cpp
         test_main.cpp)
 

--- a/domain/test/unit/domain/buffer_description.cpp
+++ b/domain/test/unit/domain/buffer_description.cpp
@@ -24,7 +24,7 @@
  */
 
 /*! @file
- * @brief Space filling curve octree assignment to ranks tests
+ * @brief Buffer description tests
  *
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */

--- a/domain/test/unit/domain/domaindecomp.cpp
+++ b/domain/test/unit/domain/domaindecomp.cpp
@@ -47,8 +47,8 @@ TEST(DomainDecomposition, singleRangeSfcSplit)
         auto splits = singleRangeSfcSplit(counts, nSplits);
 
         SpaceCurveAssignment ref(nSplits);
-        ref.addRange(Rank(0), 0, 3, 15);
-        ref.addRange(Rank(1), 3, 6, 16);
+        ref.addRange(0, 0, 3, 15);
+        ref.addRange(1, 3, 6, 16);
         EXPECT_EQ(ref, splits);
     }
     {
@@ -58,8 +58,8 @@ TEST(DomainDecomposition, singleRangeSfcSplit)
         auto splits = singleRangeSfcSplit(counts, nSplits);
 
         SpaceCurveAssignment ref(nSplits);
-        ref.addRange(Rank(0), 0, 3, 15);
-        ref.addRange(Rank(1), 3, 6, 16);
+        ref.addRange(0, 0, 3, 15);
+        ref.addRange(1, 3, 6, 16);
         EXPECT_EQ(ref, splits);
     }
     {
@@ -69,8 +69,8 @@ TEST(DomainDecomposition, singleRangeSfcSplit)
         auto splits = singleRangeSfcSplit(counts, nSplits);
 
         SpaceCurveAssignment ref(nSplits);
-        ref.addRange(Rank(0), 0, 3, 16);
-        ref.addRange(Rank(1), 3, 6, 15);
+        ref.addRange(0, 0, 3, 16);
+        ref.addRange(1, 3, 6, 15);
         EXPECT_EQ(ref, splits);
     }
     {
@@ -81,13 +81,13 @@ TEST(DomainDecomposition, singleRangeSfcSplit)
         auto splits = singleRangeSfcSplit(counts, nSplits);
 
         SpaceCurveAssignment ref(nSplits);
-        ref.addRange(Rank(0), 0, 1, 4);
-        ref.addRange(Rank(1), 1, 3, 7);
-        ref.addRange(Rank(2), 3, 4, 3);
-        ref.addRange(Rank(3), 4, 6, 7);
-        ref.addRange(Rank(4), 6, 7, 4);
-        ref.addRange(Rank(5), 7, 9, 7);
-        ref.addRange(Rank(6), 9, 10, 3);
+        ref.addRange(0, 0, 1, 4);
+        ref.addRange(1, 1, 3, 7);
+        ref.addRange(2, 3, 4, 3);
+        ref.addRange(3, 4, 6, 7);
+        ref.addRange(4, 6, 7, 4);
+        ref.addRange(5, 7, 9, 7);
+        ref.addRange(6, 9, 10, 3);
         EXPECT_EQ(ref, splits);
     }
 }
@@ -97,10 +97,10 @@ TEST(DomainDecomposition, AssignmentFindRank)
 {
     int nRanks = 4;
     SpaceCurveAssignment assignment(nRanks);
-    assignment.addRange(Rank(0), 0, 1, 0);
-    assignment.addRange(Rank(1), 1, 3, 0);
-    assignment.addRange(Rank(2), 3, 4, 0);
-    assignment.addRange(Rank(3), 4, 5, 0);
+    assignment.addRange(0, 0, 1, 0);
+    assignment.addRange(1, 1, 3, 0);
+    assignment.addRange(2, 3, 4, 0);
+    assignment.addRange(3, 4, 5, 0);
 
     EXPECT_EQ(0, assignment.findRank(0));
     EXPECT_EQ(1, assignment.findRank(1));
@@ -124,8 +124,8 @@ static void sendListMinimal()
 
     int nRanks = 2;
     SpaceCurveAssignment assignment(nRanks);
-    assignment.addRange(Rank(0), 0, 2, 0);
-    assignment.addRange(Rank(1), 2, 4, 0);
+    assignment.addRange(0, 0, 2, 0);
+    assignment.addRange(1, 2, 4, 0);
 
     // note: codes input needs to be sorted
     auto sendList = createSendRanges<KeyType>(assignment, tree, codes);

--- a/domain/test/unit/primitives/math.cpp
+++ b/domain/test/unit/primitives/math.cpp
@@ -1,0 +1,23 @@
+
+/*! @file
+ * @brief math tests
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#include "gtest/gtest.h"
+#include "cstone/primitives/math.hpp"
+
+using namespace cstone;
+
+TEST(Math, round_up)
+{
+    EXPECT_EQ(round_up(127, 128), 128);
+    EXPECT_EQ(round_up(128, 128), 128);
+    EXPECT_EQ(round_up(129, 128), 256);
+    EXPECT_EQ(round_up(257, 128), 384);
+
+    EXPECT_EQ(round_up(127lu, 128lu), 128lu);
+    EXPECT_EQ(round_up(128lu, 128lu), 128lu);
+    EXPECT_EQ(round_up(129lu, 128lu), 256lu);
+}

--- a/domain/test/unit/traversal/peers.cpp
+++ b/domain/test/unit/traversal/peers.cpp
@@ -83,7 +83,7 @@ static void findMacPeers64grid(int rank, float theta, BoundaryType pbc, int /*re
     SpaceCurveAssignment assignment(octree.numLeafNodes());
     for (int i = 0; i < octree.numLeafNodes(); ++i)
     {
-        assignment.addRange(Rank(i), i, i + 1, 1);
+        assignment.addRange(i, i, i + 1, 1);
     }
 
     std::vector<int> peers     = findPeersMac(rank, assignment, octree, box, invThetaVecMac(theta));

--- a/domain/test/unit/util/tuple_util.cpp
+++ b/domain/test/unit/util/tuple_util.cpp
@@ -35,13 +35,53 @@
 
 #include "cstone/util/aligned_alloc.hpp"
 #include "cstone/util/noinit_alloc.hpp"
-#include "cstone/util/traits.hpp"
+#include "cstone/util/tuple_util.hpp"
 
 using namespace util;
 
 template<class T>
 using AllocatorType = DefaultInitAdaptor<T, AlignedAllocator<T, 64>>;
-// using AllocatorType = DefaultInitAdaptor<T, std::allocator<T>>;
+
+TEST(Utils, ForEachTuple)
+{
+    std::vector<int> a{90};
+    std::vector<double> b{3.14};
+
+    auto tup = std::tie(a, b);
+
+    for_each_tuple([](auto& v) { v.push_back(2); }, tup);
+
+    EXPECT_EQ(a.size(), 2);
+    EXPECT_EQ(b.size(), 2);
+}
+
+TEST(Utils, TupleReverse)
+{
+    std::vector<int> a{90};
+    std::vector<double> b{3.14};
+    auto tup = std::tie(a, b);
+
+    auto revTup = reverse(tup);
+
+    EXPECT_EQ(std::get<1>(revTup)[0], a[0]);
+
+    a.push_back(91);
+
+    EXPECT_EQ(std::get<1>(revTup)[1], a[1]);
+}
+
+TEST(Utils, ForEachTupleRvalue)
+{
+    std::vector<int> a{90};
+    std::vector<double> b{3.14};
+
+    auto tup = std::tie(a, b);
+
+    for_each_tuple([](auto& v) { v.push_back(2); }, reverse(tup));
+
+    EXPECT_EQ(a.size(), 2);
+    EXPECT_EQ(b.size(), 2);
+}
 
 /*! @brief noinit allocation test
  *
@@ -76,18 +116,6 @@ TEST(Utils, AlignedNoInitAlloc)
 
     // std::copy(v.begin(), v.end(), std::ostream_iterator<double>(std::cout, " "));
     // std::cout << " address: " << v.data() << std::endl;
-}
-
-TEST(Utils, round_up)
-{
-    EXPECT_EQ(round_up(127, 128), 128);
-    EXPECT_EQ(round_up(128, 128), 128);
-    EXPECT_EQ(round_up(129, 128), 256);
-    EXPECT_EQ(round_up(257, 128), 384);
-
-    EXPECT_EQ(round_up(127lu, 128lu), 128lu);
-    EXPECT_EQ(round_up(128lu, 128lu), 128lu);
-    EXPECT_EQ(round_up(129lu, 128lu), 256lu);
 }
 
 TEST(Utils, discardLastElement)

--- a/domain/test/unit/util/type_list.cpp
+++ b/domain/test/unit/util/type_list.cpp
@@ -1,0 +1,197 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 CSCS, ETH Zurich
+ *               2022 University of Basel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief Utility tests
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#include "gtest/gtest.h"
+#include "cstone/util/type_list.hpp"
+
+using namespace util;
+
+TEST(TypeList, FuseTwo)
+{
+    using TL1 = TypeList<float, int>;
+    using TL2 = TypeList<double, unsigned>;
+
+    using TL_fused = FuseTwo<TL1, TL2>;
+    using TL_ref   = TypeList<float, int, double, unsigned>;
+
+    constexpr bool match = std::is_same_v<TL_fused, TL_ref>;
+    EXPECT_TRUE(match);
+}
+
+TEST(TypeList, Fuse)
+{
+    using TL1 = TypeList<float, int>;
+    using TL2 = TypeList<double, unsigned>;
+    using TL3 = TypeList<char, short>;
+
+    using TL_fused = Fuse<TL1, TL2, TL3>;
+    using TL_ref   = TypeList<float, int, double, unsigned, char, short>;
+
+    constexpr bool match = std::is_same_v<TL_fused, TL_ref>;
+    EXPECT_TRUE(match);
+}
+
+TEST(TypeList, Repeat)
+{
+    using TL1 = TypeList<float, int>;
+
+    using TL_repeated = Repeat<TL1, 3>;
+    using TL_ref      = TypeList<float, int, float, int, float, int>;
+
+    constexpr bool match = std::is_same_v<TL_repeated, TL_ref>;
+    EXPECT_TRUE(match);
+}
+
+TEST(TypeList, FindIndexTuple1)
+{
+    using TupleType = std::tuple<float>;
+
+    constexpr int floatIndex = FindIndex<float, TupleType>{};
+
+    constexpr int outOfRange = FindIndex<unsigned, TupleType>{};
+
+    EXPECT_EQ(0, floatIndex);
+    EXPECT_EQ(1, outOfRange);
+}
+
+TEST(TypeList, FindIndexTuple2)
+{
+    using TupleType = std::tuple<float, int>;
+
+    constexpr int floatIndex = FindIndex<float, TupleType>{};
+    constexpr int intIndex   = FindIndex<int, TupleType>{};
+
+    constexpr int outOfRange = FindIndex<unsigned, TupleType>{};
+
+    EXPECT_EQ(0, floatIndex);
+    EXPECT_EQ(1, intIndex);
+    EXPECT_EQ(2, outOfRange);
+}
+
+TEST(TypeList, FindIndexTypeList1)
+{
+    using ListType = TypeList<float>;
+
+    constexpr int floatIndex = FindIndex<float, ListType>{};
+
+    constexpr int outOfRange = FindIndex<unsigned, ListType>{};
+
+    EXPECT_EQ(0, floatIndex);
+    EXPECT_EQ(1, outOfRange);
+}
+
+TEST(TypeList, FindIndexTypeList2)
+{
+    using ListType = TypeList<float, int>;
+
+    constexpr int floatIndex = FindIndex<float, ListType>{};
+    constexpr int intIndex   = FindIndex<int, ListType>{};
+
+    constexpr int outOfRange = FindIndex<unsigned, ListType>{};
+
+    EXPECT_EQ(0, floatIndex);
+    EXPECT_EQ(1, intIndex);
+    EXPECT_EQ(2, outOfRange);
+}
+
+TEST(TypeList, Contains)
+{
+    using ListType = TypeList<float, int>;
+
+    constexpr bool hasFloat = Contains<float, ListType>{};
+    constexpr bool hasInt   = Contains<int, ListType>{};
+    constexpr bool hasUint  = Contains<unsigned, ListType>{};
+
+    EXPECT_TRUE(hasFloat);
+    EXPECT_TRUE(hasInt);
+    EXPECT_FALSE(hasUint);
+}
+
+TEST(TypeList, FindIndexTupleRepeated)
+{
+    using TupleType = std::tuple<float, float, int>;
+
+    constexpr int floatIndex = FindIndex<float, TupleType>{};
+
+    constexpr int intIndex = FindIndex<int, TupleType>{};
+
+    constexpr int outOfRange = FindIndex<unsigned, TupleType>{};
+
+    EXPECT_EQ(0, floatIndex);
+    EXPECT_EQ(2, intIndex);
+    EXPECT_EQ(3, outOfRange);
+}
+
+TEST(TypeList, FindIndexTypeListRepeated)
+{
+    using TupleType = TypeList<float, float, int>;
+
+    constexpr int floatIndex = FindIndex<float, TupleType>{};
+
+    constexpr int intIndex = FindIndex<int, TupleType>{};
+
+    constexpr int outOfRange = FindIndex<unsigned, TupleType>{};
+
+    EXPECT_EQ(0, floatIndex);
+    EXPECT_EQ(2, intIndex);
+    EXPECT_EQ(3, outOfRange);
+}
+
+TEST(TypeList, TypeListElementAccess)
+{
+    using TupleType = TypeList<float, double, int, unsigned>;
+
+    static_assert(TypeListSize<TupleType>{} == 4);
+    static_assert(std::is_same_v<TypeListElement_t<0, TupleType>, float>);
+    static_assert(std::is_same_v<TypeListElement_t<1, TupleType>, double>);
+    static_assert(std::is_same_v<TypeListElement_t<2, TupleType>, int>);
+    static_assert(std::is_same_v<TypeListElement_t<3, TupleType>, unsigned>);
+}
+
+TEST(TypeList, SubsetIndices)
+{
+    using SubList  = TypeList<short, unsigned>;
+    using BaseList = TypeList<float, double, short, int, unsigned>;
+
+    [[maybe_unused]] auto indices = subsetIndices(SubList{}, BaseList{});
+    static_assert(std::is_same_v<decltype(indices), std::index_sequence<2, 4>>);
+}
+
+TEST(TypeList, SubsetIndicesOutOfRange)
+{
+    using SubList  = TypeList<short, unsigned>;
+    using BaseList = TypeList<float, double, short, int, unsigned>;
+
+    [[maybe_unused]] auto outOfRange = subsetIndices(BaseList{}, SubList{});
+
+    constexpr std::size_t length = TypeListSize<SubList>{};
+    static_assert(std::is_same_v<decltype(outOfRange), std::index_sequence<length, length, 0, length, 1>>);
+}

--- a/domain/test/unit/util/value_list.cpp
+++ b/domain/test/unit/util/value_list.cpp
@@ -35,6 +35,10 @@
 
 using namespace util;
 
+/*
+
+ // see comment in source code
+
 TEST(ConstexprString, OperatorEq)
 {
     constexpr StructuralString a("id");
@@ -65,6 +69,7 @@ TEST(ValueList, find)
     static_assert(require_gcc_12::FindIndex<4, TestList>{} == 1);
     static_assert(require_gcc_12::FindIndex<8, TestList>{} == 5);
 }
+*/
 
 TEST(ValueList, nameGet)
 {

--- a/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
+++ b/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
@@ -46,8 +46,8 @@ static void sendListMinimalGpu()
 
     int numRanks = 2;
     SpaceCurveAssignment assignment(numRanks);
-    assignment.addRange(Rank(0), 0, 2, 0);
-    assignment.addRange(Rank(1), 2, 4, 0);
+    assignment.addRange(0, 0, 2, 0);
+    assignment.addRange(1, 2, 4, 0);
 
     thrust::device_vector<KeyType> d_keys = codes;
     thrust::device_vector<KeyType> d_searchKeys(numRanks);

--- a/domain/test/unit_cuda/traversal/groups.cu
+++ b/domain/test/unit_cuda/traversal/groups.cu
@@ -41,7 +41,6 @@
 #include "cstone/cuda/cuda_utils.cuh"
 #include "cstone/traversal/groups.cuh"
 #include "cstone/tree/cs_util.hpp"
-#include "cstone/util/util.hpp"
 
 using namespace cstone;
 

--- a/main/src/init/early_sync.hpp
+++ b/main/src/init/early_sync.hpp
@@ -69,7 +69,7 @@ void syncCoords(size_t rank, size_t numRanks, size_t numParticlesGlobal, Vector&
     std::vector<T>       scratch1, scratch2;
     std::vector<KeyType> particleKeys(x.size());
     cstone::LocalIndex   newNParticlesAssigned =
-        distributor.assign(bufDesc, sorter, particleKeys.data(), x.data(), y.data(), z.data());
+        distributor.assign(bufDesc, sorter, scratch1, scratch2, particleKeys.data(), x.data(), y.data(), z.data());
     size_t exchangeSize = std::max(x.size(), size_t(newNParticlesAssigned));
     reallocate(exchangeSize, particleKeys, x, y, z);
     auto [exchangeStart, keyView] =

--- a/main/src/io/ifile_io.hpp
+++ b/main/src/io/ifile_io.hpp
@@ -35,7 +35,7 @@
 #include <variant>
 
 #include "cstone/sfc/box.hpp"
-#include "cstone/util/traits.hpp"
+#include "cstone/util/type_list.hpp"
 
 namespace sphexa
 {

--- a/main/src/observables/conserved_gpu.cu
+++ b/main/src/observables/conserved_gpu.cu
@@ -70,7 +70,7 @@ struct EMom
 
 template<class Tc, class Tv, class Tt, class Tm>
 std::tuple<double, double, Vec3<double>, Vec3<double>>
-conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz,
+conservedQuantitiesGpu(double cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz,
                        const Tt* temp, const Tt* u, const Tm* m, size_t first, size_t last)
 {
     auto it1 = thrust::make_zip_iterator(
@@ -96,7 +96,7 @@ conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* v
 
 #define CONSERVED_Q_GPU(Tc, Tv, Tt, Tm)                                                                                \
     template std::tuple<double, double, Vec3<double>, Vec3<double>> conservedQuantitiesGpu(                            \
-        Tt, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz, const Tt* temp,           \
+        double cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz, const Tt* temp,    \
         const Tt* u, const Tm* m, size_t, size_t)
 
 CONSERVED_Q_GPU(double, double, double, double);

--- a/main/src/observables/conserved_gpu.h
+++ b/main/src/observables/conserved_gpu.h
@@ -56,7 +56,7 @@ namespace sphexa
  */
 template<class Tc, class Tv, class Tt, class Tm>
 extern std::tuple<double, double, cstone::Vec3<double>, cstone::Vec3<double>>
-conservedQuantitiesGpu(Tt cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz,
+conservedQuantitiesGpu(double cv, const Tc* x, const Tc* y, const Tc* z, const Tv* vx, const Tv* vy, const Tv* vz,
                        const Tt* temp, const Tt* u, const Tm* m, size_t first, size_t last);
 
 } // namespace sphexa

--- a/main/src/observables/gpu_reductions.h
+++ b/main/src/observables/gpu_reductions.h
@@ -50,14 +50,14 @@ namespace sphexa
  * @param endIndex      last particle to be included
  * @return              a tuple containing the local si, di, ci
  */
-template<class Tc, class Tv, class Tm>
-extern std::tuple<double, double, double> gpuGrowthRate(const Tc* x, const Tc* y, const Tv* vy, const Tm* xm,
-                                                        const Tm* kx, const cstone::Box<Tc>& box, size_t startIndex,
+template<class Tc, class Tv, class T>
+extern std::tuple<double, double, double> gpuGrowthRate(const Tc* x, const Tc* y, const Tv* vy, const T* xm,
+                                                        const T* kx, const cstone::Box<Tc>& box, size_t startIndex,
                                                         size_t endIndex);
 
 /*! @brief compute square of local Mach number sum
  *
- * @tparam     Tc     float or double
+ * @tparam     T      float or double
  * @tparam     Tv     float or double
  * @param[in]  vx     velocities x-component
  * @param[in]  vy     velocities y-component
@@ -67,14 +67,14 @@ extern std::tuple<double, double, double> gpuGrowthRate(const Tc* x, const Tc* y
  * @param[in]  last   last local particle
  * @return
  */
-template<class Tc, class Tv>
-extern double machSquareSumGpu(const Tv* vx, const Tv* vy, const Tv* vz, const Tc* c, size_t first, size_t last);
+template<class Tv, class T>
+extern double machSquareSumGpu(const Tv* vx, const Tv* vy, const Tv* vz, const T* c, size_t first, size_t last);
 
 /*!@brief sum up the particles that still belong to the cloud
  *
- * @tparam Tc
- * @tparam Tt       float or double
- * @tparam Tm
+ * @tparam T        Hydro field type, float or double
+ * @tparam Tt       Temperature / internal energy field type, float or double
+ * @tparam Tm       mass field type, float or dobule
  * @param temp      particle temperatures
  * @param kx        VE normalization
  * @param xmass     VE definition
@@ -85,7 +85,7 @@ extern double machSquareSumGpu(const Tv* vx, const Tv* vy, const Tv* vz, const T
  * @param last      index of last local particle
  * @return
  */
-template<class Tc, class Tt, class Tm>
-extern size_t survivorsGpu(const Tt* temp, const Tt* kx, const Tc* xmass, const Tm* m, double rhoBubble,
-                           double tempWind, size_t first, size_t last);
+template<class T, class Tt, class Tm>
+extern size_t survivorsGpu(const Tt* temp, const T* kx, const T* xmass, const Tm* m, double rhoBubble, double tempWind,
+                           size_t first, size_t last);
 } // namespace sphexa

--- a/main/src/propagator/nbody.hpp
+++ b/main/src/propagator/nbody.hpp
@@ -53,8 +53,9 @@ class NbodyProp final : public Propagator<DomainType, DataType>
     using Base = Propagator<DomainType, DataType>;
     using Base::timer;
 
-    using T             = typename DataType::RealType;
     using KeyType       = typename DataType::KeyType;
+    using T             = typename DataType::RealType;
+    using HydroType     = typename DataType::HydroData::HydroType;
     using Tmass         = typename DataType::HydroData::Tmass;
     using MultipoleType = ryoanji::CartesianQuadrupole<Tmass>;
 
@@ -71,7 +72,7 @@ class NbodyProp final : public Propagator<DomainType, DataType>
     using ConservedFields = FieldList<"vx", "vy", "vz", "x_m1", "y_m1", "z_m1">;
 
     //! @brief the list of dependent particle fields, these may be used as scratch space during domain sync
-    using DependentFields = FieldList<"ax", "ay", "du_m1", "az">;
+    using DependentFields = FieldList<"ax", "ay", "du", "du_m1", "az">;
 
 public:
     NbodyProp(std::ostream& output, size_t rank)
@@ -124,9 +125,9 @@ public:
         fill(get<"m">(d), 0, first, d.m[first]);
         fill(get<"m">(d), last, domain.nParticlesWithHalos(), d.m[first]);
 
-        fill(get<"ax">(d), first, last, T(0));
-        fill(get<"ay">(d), first, last, T(0));
-        fill(get<"az">(d), first, last, T(0));
+        fill(get<"ax">(d), first, last, HydroType(0));
+        fill(get<"ay">(d), first, last, HydroType(0));
+        fill(get<"az">(d), first, last, HydroType(0));
 
         mHolder_.upsweep(d, domain);
         timer.step("Upsweep");

--- a/main/src/propagator/std_hydro_grackle.hpp
+++ b/main/src/propagator/std_hydro_grackle.hpp
@@ -216,7 +216,8 @@ public:
         {
             T u_old  = d.u[i];
             T u_cool = d.u[i];
-            cooling_data.cool_particle(d.minDt, d.rho[i], u_cool,
+            T rhoi   = d.rho[i];
+            cooling_data.cool_particle(T(d.minDt), rhoi, u_cool,
                                        cstone::getPointers(get<CoolingFields>(simData.chem), i));
             const T du = (u_cool - u_old) / d.minDt;
             d.du[i] += du;

--- a/physics/cooling/include/cooling/cooler.hpp
+++ b/physics/cooling/include/cooling/cooler.hpp
@@ -40,7 +40,7 @@
 #include <vector>
 #include <iostream>
 
-#include "cstone/util/traits.hpp"
+#include "cstone/util/type_list.hpp"
 #include "cstone/util/value_list.hpp"
 
 namespace cooling

--- a/physics/cooling/include/cooling/init_chemistry.h
+++ b/physics/cooling/include/cooling/init_chemistry.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <iostream>
-#include "cstone/util/util.hpp"
 #include "cstone/fields/field_get.hpp"
 
 namespace cooling

--- a/ryoanji/src/ryoanji/interface/multipole_holder.cu
+++ b/ryoanji/src/ryoanji/interface/multipole_holder.cu
@@ -235,6 +235,7 @@ const MType* MultipoleHolder<Tc, Th, Tm, Ta, Tf, KeyType, MType>::deviceMultipol
 
 MHOLDER_SPH(double, double, double, double, double, uint64_t, double);
 MHOLDER_SPH(double, double, float, double, double, uint64_t, float);
+MHOLDER_SPH(double, float, float, float, double, uint64_t, float);
 MHOLDER_SPH(float, float, float, float, float, uint64_t, float);
 
 #define MHOLDER_CART(Tc, Th, Tm, Ta, Tf, KeyType, MVal)                                                                \
@@ -242,6 +243,7 @@ MHOLDER_SPH(float, float, float, float, float, uint64_t, float);
 
 MHOLDER_CART(double, double, double, double, double, uint64_t, double);
 MHOLDER_CART(double, double, float, double, double, uint64_t, float);
+MHOLDER_CART(double, float, float, float, double, uint64_t, float);
 MHOLDER_CART(float, float, float, float, float, uint64_t, float);
 
 #define DIRECT_SUM(T)                                                                                                  \

--- a/ryoanji/src/ryoanji/interface/multipole_holder.cu
+++ b/ryoanji/src/ryoanji/interface/multipole_holder.cu
@@ -32,6 +32,7 @@
 #include <thrust/device_vector.h>
 
 #include "cstone/cuda/cuda_utils.cuh"
+#include "cstone/primitives/math.hpp"
 #include "cstone/util/reallocate.hpp"
 #include "ryoanji/nbody/cartesian_qpole.hpp"
 #include "ryoanji/nbody/direct.cuh"
@@ -127,7 +128,7 @@ public:
     {
         int numWarpsPerBlock = TravConfig::numThreads / cstone::GpuConfig::warpSize;
         int numTargets       = targets_.size() - 1;
-        int numBlocks        = iceil(numTargets, numWarpsPerBlock);
+        int numBlocks        = cstone::iceil(numTargets, numWarpsPerBlock);
         numBlocks            = std::min(numBlocks, TravConfig::maxNumActiveBlocks);
         LocalIndex poolSize  = TravConfig::memPerWarp * numWarpsPerBlock * numBlocks;
 

--- a/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
+++ b/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
@@ -80,11 +80,11 @@ auto computeCenterAndSize(const util::array<Vec4<T>, N>& target)
  *
  * Note: acceleration output is added to destination
  */
-template<class MType, class T1, class T2, class Tm, size_t N>
+template<class MType, class T1, class Th, class Tm, size_t N>
 void computeGravityGroup(const util::array<Vec4<T1>, N>& target, const TreeNodeIndex* childOffsets,
                          const TreeNodeIndex* internalToLeaf, const cstone::SourceCenterType<T1>* centers,
                          MType* multipoles, const LocalIndex* layout, const T1* x, const T1* y, const T1* z,
-                         const T2* h, const Tm* m, Vec4<T1>* acc)
+                         const Th* h, const Tm* m, Vec4<T1>* acc)
 {
     Vec3<T1> targetCenter, targetSize;
     std::tie(targetCenter, targetSize) = computeCenterAndSize(target);
@@ -136,7 +136,7 @@ void computeGravityGroup(const util::array<Vec4<T1>, N>& target, const TreeNodeI
             // loop over sources in cell
             for (LocalIndex s = firstSource; s < lastSource; ++s)
             {
-                acc[k] = P2P(acc[k], makeVec3(target[k]), Vec3<T1>{x[s], y[s], z[s]}, m[s], target[k][3], h[s]);
+                acc[k] = P2P(acc[k], makeVec3(target[k]), Vec3<T1>{x[s], y[s], z[s]}, m[s], Th(target[k][3]), h[s]);
             }
         }
     };
@@ -175,7 +175,7 @@ template<class MType, class T1, class T2, class Tm>
 void computeGravity(const TreeNodeIndex* childOffsets, const TreeNodeIndex* internalToLeaf,
                     const cstone::SourceCenterType<T1>* macSpheres, const MType* multipoles, const LocalIndex* layout,
                     TreeNodeIndex firstLeafIndex, TreeNodeIndex lastLeafIndex, const T1* x, const T1* y, const T1* z,
-                    const T2* h, const Tm* m, const cstone::Box<T1>& box, float G, T1* ax, T1* ay, T1* az, T1* egravTot,
+                    const T2* h, const Tm* m, const cstone::Box<T1>& box, float G, T2* ax, T2* ay, T2* az, T1* egravTot,
                     int numShells = 0)
 {
     constexpr LocalIndex groupSize   = 16;

--- a/sph/include/sph/eos.hpp
+++ b/sph/include/sph/eos.hpp
@@ -10,11 +10,11 @@ namespace sph
 {
 
 //! @brief returns the heat capacity for given mean molecular weight
-template<class T>
-HOST_DEVICE_FUN constexpr T idealGasCv(T mui, T gamma)
+template<class T1, class T2>
+HOST_DEVICE_FUN constexpr T1 idealGasCv(T1 mui, T2 gamma)
 {
-    constexpr T R = 8.317e7;
-    return R / mui / (gamma - T(1));
+    constexpr T1 R = 8.317e7;
+    return R / mui / (gamma - T1(1));
 }
 
 /*! @brief Reduced version of Ideal gas EOS for internal energy
@@ -27,10 +27,10 @@ HOST_DEVICE_FUN constexpr T idealGasCv(T mui, T gamma)
  * This EOS is used for simple cases where we don't need the temperature.
  * Returns pressure, speed of sound
  */
-template<class T1, class T2>
-HOST_DEVICE_FUN auto idealGasEOS(T1 temp, T2 rho, T1 mui, T1 gamma)
+template<class T1, class T2, class T3>
+HOST_DEVICE_FUN auto idealGasEOS(T1 temp, T2 rho, T3 mui, T1 gamma)
 {
-    using Tc = std::common_type_t<T1, T2>;
+    using Tc = std::common_type_t<T1, T2, T3>;
 
     Tc tmp = idealGasCv(mui, gamma) * temp * (gamma - Tc(1));
     Tc p   = rho * tmp;

--- a/sph/include/sph/find_neighbors.hpp
+++ b/sph/include/sph/find_neighbors.hpp
@@ -7,9 +7,9 @@ namespace sph
 
 using cstone::LocalIndex;
 
-template<class T, class KeyType>
-void findNeighborsSph(const T* x, const T* y, const T* z, T* h, LocalIndex firstId, LocalIndex lastId,
-                      const cstone::Box<T>& box, const cstone::OctreeNsView<T, KeyType>& treeView, unsigned ng0,
+template<class Tc, class T, class KeyType>
+void findNeighborsSph(const Tc* x, const Tc* y, const Tc* z, T* h, LocalIndex firstId, LocalIndex lastId,
+                      const cstone::Box<Tc>& box, const cstone::OctreeNsView<Tc, KeyType>& treeView, unsigned ng0,
                       unsigned ngmax, LocalIndex* neighbors, unsigned* nc)
 {
     LocalIndex numWork = lastId - firstId;

--- a/sph/include/sph/hydro_std/density_gpu.cu
+++ b/sph/include/sph/hydro_std/density_gpu.cu
@@ -48,7 +48,7 @@ using cstone::TreeNodeIndex;
 __device__ bool nc_h_convergenceFailure = false;
 
 template<class Tc, class Tm, class T, class KeyType>
-__global__ void cudaDensity(T K, unsigned ng0, unsigned ngmax, cstone::Box<T> box, const cstone::LocalIndex* groups,
+__global__ void cudaDensity(Tc K, unsigned ng0, unsigned ngmax, cstone::Box<Tc> box, const cstone::LocalIndex* groups,
                             cstone::LocalIndex numGroups, const cstone::OctreeNsView<Tc, KeyType> tree, unsigned* nc,
                             const Tc* x, const Tc* y, const Tc* z, T* h, const Tm* m, const T* wh, const T* whd, T* rho,
                             LocalIndex* nidx, TreeNodeIndex* globalPool)

--- a/sph/include/sph/hydro_std/density_kern.hpp
+++ b/sph/include/sph/hydro_std/density_kern.hpp
@@ -10,7 +10,7 @@ namespace sph
 {
 
 template<size_t stride = 1, class Tc, class Tm, class T>
-HOST_DEVICE_FUN inline T densityJLoop(cstone::LocalIndex i, T K, const cstone::Box<T>& box,
+HOST_DEVICE_FUN inline T densityJLoop(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box,
                                       const cstone::LocalIndex* neighbors, unsigned neighborsCount, const Tc* x,
                                       const Tc* y, const Tc* z, const T* h, const Tm* m, const T* wh, const T* /*whd*/)
 {

--- a/sph/include/sph/hydro_std/eos_gpu.cu
+++ b/sph/include/sph/hydro_std/eos_gpu.cu
@@ -30,8 +30,8 @@
  */
 
 #include "cstone/cuda/cuda_utils.cuh"
+#include "cstone/primitives/math.hpp"
 #include "cstone/util/tuple.hpp"
-#include "cstone/util/util.hpp"
 
 #include "sph/sph_gpu.hpp"
 #include "sph/eos.hpp"
@@ -56,7 +56,7 @@ void computeEOS_HydroStd(size_t firstParticle, size_t lastParticle, Tt mui, Tt g
                          Tp* p, Tc* c)
 {
     unsigned numThreads = 256;
-    unsigned numBlocks  = iceil(lastParticle - firstParticle, numThreads);
+    unsigned numBlocks  = cstone::iceil(lastParticle - firstParticle, numThreads);
     cudaEOS_HydroStd<<<numBlocks, numThreads>>>(firstParticle, lastParticle, mui, gamma, temp, rho, p, c);
     checkGpuErrors(cudaDeviceSynchronize());
 }

--- a/sph/include/sph/hydro_std/eos_gpu.cu
+++ b/sph/include/sph/hydro_std/eos_gpu.cu
@@ -42,7 +42,7 @@ namespace cuda
 {
 
 template<class Tt, class Trho, class Tp, class Tc>
-__global__ void cudaEOS_HydroStd(size_t firstParticle, size_t lastParticle, Tt mui, Tt gamma, const Tt* temp,
+__global__ void cudaEOS_HydroStd(size_t firstParticle, size_t lastParticle, Trho mui, Tt gamma, const Tt* temp,
                                  const Trho* rho, Tp* p, Tc* c)
 {
     unsigned i = firstParticle + blockDim.x * blockIdx.x + threadIdx.x;
@@ -52,7 +52,7 @@ __global__ void cudaEOS_HydroStd(size_t firstParticle, size_t lastParticle, Tt m
 }
 
 template<class Tt, class Trho, class Tp, class Tc>
-void computeEOS_HydroStd(size_t firstParticle, size_t lastParticle, Tt mui, Tt gamma, const Tt* temp, const Trho* rho,
+void computeEOS_HydroStd(size_t firstParticle, size_t lastParticle, Trho mui, Tt gamma, const Tt* temp, const Trho* rho,
                          Tp* p, Tc* c)
 {
     unsigned numThreads = 256;
@@ -62,7 +62,7 @@ void computeEOS_HydroStd(size_t firstParticle, size_t lastParticle, Tt mui, Tt g
 }
 
 template void computeEOS_HydroStd(size_t, size_t, double, double, const double*, const double*, double*, double*);
-template void computeEOS_HydroStd(size_t, size_t, double, double, const double*, const float*, float*, float*);
+template void computeEOS_HydroStd(size_t, size_t, float, double, const double*, const float*, float*, float*);
 template void computeEOS_HydroStd(size_t, size_t, float, float, const float*, const float*, float*, float*);
 
 } // namespace cuda

--- a/sph/include/sph/hydro_std/iad_gpu.cu
+++ b/sph/include/sph/hydro_std/iad_gpu.cu
@@ -73,7 +73,7 @@ using cstone::TreeNodeIndex;
  * @param[out] c33
  */
 template<class Tc, class Tm, class T, class KeyType>
-__global__ void IADGpuKernel(T K, unsigned ngmax, cstone::Box<T> box, const cstone::LocalIndex* groups,
+__global__ void IADGpuKernel(Tc K, unsigned ngmax, cstone::Box<Tc> box, const cstone::LocalIndex* groups,
                              cstone::LocalIndex numGroups, const cstone::OctreeNsView<Tc, KeyType> tree, const Tc* x,
                              const Tc* y, const Tc* z, const T* h, const Tm* m, const T* rho, const T* wh, const T* whd,
                              T* c11, T* c12, T* c13, T* c22, T* c23, T* c33, LocalIndex* nidx,

--- a/sph/include/sph/hydro_std/iad_kern.hpp
+++ b/sph/include/sph/hydro_std/iad_kern.hpp
@@ -11,7 +11,7 @@ namespace sph
 {
 
 template<size_t stride = 1, class Tc, class Tm, class T>
-HOST_DEVICE_FUN inline void IADJLoopSTD(cstone::LocalIndex i, T K, const cstone::Box<T>& box,
+HOST_DEVICE_FUN inline void IADJLoopSTD(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box,
                                         const cstone::LocalIndex* neighbors, unsigned neighborsCount, const Tc* x,
                                         const Tc* y, const Tc* z, const T* h, const Tm* m, const T* rho, const T* wh,
                                         const T* /*whd*/, T* c11, T* c12, T* c13, T* c22, T* c23, T* c33)

--- a/sph/include/sph/hydro_std/momentum_energy.hpp
+++ b/sph/include/sph/hydro_std/momentum_energy.hpp
@@ -38,9 +38,11 @@
 namespace sph
 {
 
-template<class T, class Dataset>
-void computeMomentumEnergyStdImpl(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
+template<class Tc, class Dataset>
+void computeMomentumEnergyStdImpl(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<Tc>& box)
 {
+    using T = typename Dataset::HydroType;
+
     const cstone::LocalIndex* neighbors      = d.neighbors.data();
     const unsigned*           neighborsCount = d.nc.data();
 

--- a/sph/include/sph/hydro_std/momentum_energy_gpu.cu
+++ b/sph/include/sph/hydro_std/momentum_energy_gpu.cu
@@ -51,7 +51,7 @@ using cstone::TreeNodeIndex;
 static __device__ float minDt_device;
 
 template<class Tc, class Tm, class T, class Tm1, class KeyType>
-__global__ void cudaGradP(T K, T Kcour, unsigned ngmax, cstone::Box<T> box, const cstone::LocalIndex* groups,
+__global__ void cudaGradP(Tc K, Tc Kcour, unsigned ngmax, cstone::Box<Tc> box, const cstone::LocalIndex* groups,
                           cstone::LocalIndex numGroups, const cstone::OctreeNsView<Tc, KeyType> tree, const Tc* x,
                           const Tc* y, const Tc* z, const T* vx, const T* vy, const T* vz, const T* h, const Tm* m,
                           const T* rho, const T* p, const T* c, const T* c11, const T* c12, const T* c13, const T* c22,

--- a/sph/include/sph/hydro_std/momentum_energy_kern.hpp
+++ b/sph/include/sph/hydro_std/momentum_energy_kern.hpp
@@ -12,7 +12,7 @@ namespace sph
 
 template<size_t stride = 1, class Tc, class Tm, class T, class Tm1>
 HOST_DEVICE_FUN inline void
-momentumAndEnergyJLoop(cstone::LocalIndex i, T K, const cstone::Box<T>& box, const cstone::LocalIndex* neighbors,
+momentumAndEnergyJLoop(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box, const cstone::LocalIndex* neighbors,
                        unsigned neighborsCount, const Tc* x, const Tc* y, const Tc* z, const T* vx, const T* vy,
                        const T* vz, const T* h, const Tm* m, const T* rho, const T* p, const T* c, const T* c11,
                        const T* c12, const T* c13, const T* c22, const T* c23, const T* c33, const T* wh,

--- a/sph/include/sph/hydro_turb/stirring_gpu.cu
+++ b/sph/include/sph/hydro_turb/stirring_gpu.cu
@@ -28,9 +28,7 @@
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
-#include <cmath>
-
-#include "cstone/util/util.hpp"
+#include "cstone/primitives/math.hpp"
 
 #include "sph/hydro_turb/stirring.hpp"
 
@@ -60,7 +58,7 @@ void computeStirringGpu(size_t startIndex, size_t endIndex, size_t numDim, const
                         const T* amplitudes, T solWeightNorm)
 {
     unsigned numThreads = 256;
-    unsigned numBlocks  = iceil(endIndex - startIndex, numThreads);
+    unsigned numBlocks  = cstone::iceil(endIndex - startIndex, numThreads);
 
     computeStirringKernel<<<numBlocks, numThreads>>>(startIndex, endIndex, numDim, x, y, z, ax, ay, az, numModes, modes,
                                                      st_aka, st_akb, amplitudes, solWeightNorm);

--- a/sph/include/sph/hydro_ve/av_switches.hpp
+++ b/sph/include/sph/hydro_ve/av_switches.hpp
@@ -65,10 +65,6 @@ void computeAVswitchesImpl(size_t startIndex, size_t endIndex, Dataset& d, const
     const auto* kx   = d.kx.data();
     const auto* xm   = d.xm.data();
 
-    const T alphamin       = d.alphamin;
-    const T alphamax       = d.alphamax;
-    const T decay_constant = d.decay_constant;
-
     auto* alpha = d.alpha.data();
 
 #pragma omp parallel for
@@ -77,8 +73,8 @@ void computeAVswitchesImpl(size_t startIndex, size_t endIndex, Dataset& d, const
         size_t   ni       = i - startIndex;
         unsigned ncCapped = std::min(neighborsCount[i] - 1, d.ngmax);
         alpha[i] = AVswitchesJLoop(i, d.K, box, neighbors + d.ngmax * ni, ncCapped, x, y, z, vx, vy, vz, h, c, c11, c12,
-                                   c13, c22, c23, c33, wh, whd, kx, xm, divv, d.minDt, alphamin, alphamax,
-                                   decay_constant, alpha[i]);
+                                   c13, c22, c23, c33, wh, whd, kx, xm, divv, d.minDt, d.alphamin, d.alphamax,
+                                   d.decay_constant, alpha[i]);
     }
 }
 

--- a/sph/include/sph/hydro_ve/av_switches_gpu.cu
+++ b/sph/include/sph/hydro_ve/av_switches_gpu.cu
@@ -46,11 +46,11 @@ using cstone::TravConfig;
 using cstone::TreeNodeIndex;
 
 template<class Tc, class T, class KeyType>
-__global__ void AVswitchesGpu(T K, unsigned ngmax, const cstone::Box<T> box, size_t first, size_t last,
+__global__ void AVswitchesGpu(Tc K, unsigned ngmax, const cstone::Box<Tc> box, size_t first, size_t last,
                               const cstone::OctreeNsView<Tc, KeyType> tree, const Tc* x, const Tc* y, const Tc* z,
                               const T* vx, const T* vy, const T* vz, const T* h, const T* c, const T* c11, const T* c12,
                               const T* c13, const T* c22, const T* c23, const T* c33, const T* wh, const T* whd,
-                              const T* kx, const T* xm, const T* divv, T minDt, T alphamin, T alphamax,
+                              const T* kx, const T* xm, const T* divv, Tc minDt, T alphamin, T alphamax,
                               T decay_constant, T* alpha, LocalIndex* nidx, TreeNodeIndex* globalPool)
 {
     unsigned laneIdx     = threadIdx.x & (GpuConfig::warpSize - 1);

--- a/sph/include/sph/hydro_ve/av_switches_kern.hpp
+++ b/sph/include/sph/hydro_ve/av_switches_kern.hpp
@@ -43,10 +43,10 @@ namespace sph
 
 template<size_t stride = 1, class Tc, class T>
 HOST_DEVICE_FUN inline T
-AVswitchesJLoop(cstone::LocalIndex i, T K, const cstone::Box<T>& box, const cstone::LocalIndex* neighbors,
+AVswitchesJLoop(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box, const cstone::LocalIndex* neighbors,
                 unsigned neighborsCount, const Tc* x, const Tc* y, const Tc* z, const T* vx, const T* vy, const T* vz,
                 const T* h, const T* c, const T* c11, const T* c12, const T* c13, const T* c22, const T* c23,
-                const T* c33, const T* wh, const T* /*whd*/, const T* kx, const T* xm, const T* divv, const T dt,
+                const T* c33, const T* wh, const T* /*whd*/, const T* kx, const T* xm, const T* divv, const Tc dt,
                 const T alphamin, const T alphamax, const T decay_constant, T alpha_i)
 {
     auto xi  = x[i];

--- a/sph/include/sph/hydro_ve/divv_curlv_kern.hpp
+++ b/sph/include/sph/hydro_ve/divv_curlv_kern.hpp
@@ -43,7 +43,7 @@ namespace sph
 
 template<size_t stride = 1, typename Tc, class T>
 HOST_DEVICE_FUN inline void
-divV_curlVJLoop(cstone::LocalIndex i, T K, const cstone::Box<Tc>& box, const cstone::LocalIndex* neighbors,
+divV_curlVJLoop(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box, const cstone::LocalIndex* neighbors,
                 unsigned neighborsCount, const Tc* x, const Tc* y, const Tc* z, const T* vx, const T* vy, const T* vz,
                 const T* h, const T* c11, const T* c12, const T* c13, const T* c22, const T* c23, const T* c33,
                 const T* wh, const T* /*whd*/, const T* kx, const T* xm, T* divv, T* curlv, T* dV11, T* dV12, T* dV13,

--- a/sph/include/sph/hydro_ve/eos_gpu.cu
+++ b/sph/include/sph/hydro_ve/eos_gpu.cu
@@ -42,7 +42,7 @@ namespace cuda
 {
 
 template<class Tt, class Tm, class Thydro>
-__global__ void cudaEOS(size_t firstParticle, size_t lastParticle, Tt mui, Tt gamma, const Tt* temp, const Tm* m,
+__global__ void cudaEOS(size_t firstParticle, size_t lastParticle, Tm mui, Tt gamma, const Tt* temp, const Tm* m,
                         const Thydro* kx, const Thydro* xm, const Thydro* gradh, Thydro* prho, Thydro* c, Thydro* rho,
                         Thydro* p)
 {
@@ -58,7 +58,7 @@ __global__ void cudaEOS(size_t firstParticle, size_t lastParticle, Tt mui, Tt ga
 }
 
 template<class Tt, class Tm, class Thydro>
-void computeEOS(size_t firstParticle, size_t lastParticle, Tt mui, Tt gamma, const Tt* temp, const Tm* m,
+void computeEOS(size_t firstParticle, size_t lastParticle, Tm mui, Tt gamma, const Tt* temp, const Tm* m,
                 const Thydro* kx, const Thydro* xm, const Thydro* gradh, Thydro* prho, Thydro* c, Thydro* rho,
                 Thydro* p)
 {
@@ -70,7 +70,7 @@ void computeEOS(size_t firstParticle, size_t lastParticle, Tt mui, Tt gamma, con
 }
 
 #define COMPUTE_EOS(Ttemp, Tm, Thydro)                                                                                 \
-    template void computeEOS(size_t firstParticle, size_t lastParticle, Ttemp mui, Ttemp gamma, const Ttemp* temp,     \
+    template void computeEOS(size_t firstParticle, size_t lastParticle, Tm mui, Ttemp gamma, const Ttemp* temp,        \
                              const Tm* m, const Thydro* kx, const Thydro* xm, const Thydro* gradh, Thydro* prho,       \
                              Thydro* c, Thydro* rho, Thydro* p)
 

--- a/sph/include/sph/hydro_ve/eos_gpu.cu
+++ b/sph/include/sph/hydro_ve/eos_gpu.cu
@@ -30,8 +30,8 @@
  */
 
 #include "cstone/cuda/cuda_utils.cuh"
+#include "cstone/primitives/math.hpp"
 #include "cstone/util/tuple.hpp"
-#include "cstone/util/util.hpp"
 
 #include "sph/sph_gpu.hpp"
 #include "sph/eos.hpp"
@@ -63,7 +63,7 @@ void computeEOS(size_t firstParticle, size_t lastParticle, Tt mui, Tt gamma, con
                 Thydro* p)
 {
     unsigned numThreads = 256;
-    unsigned numBlocks  = iceil(lastParticle - firstParticle, numThreads);
+    unsigned numBlocks  = cstone::iceil(lastParticle - firstParticle, numThreads);
     cudaEOS<<<numBlocks, numThreads>>>(firstParticle, lastParticle, mui, gamma, temp, m, kx, xm, gradh, prho, c, rho,
                                        p);
     checkGpuErrors(cudaDeviceSynchronize());

--- a/sph/include/sph/hydro_ve/iad_divv_curlv_gpu.cu
+++ b/sph/include/sph/hydro_ve/iad_divv_curlv_gpu.cu
@@ -48,7 +48,7 @@ using cstone::TravConfig;
 using cstone::TreeNodeIndex;
 
 template<class Tc, class T, class KeyType>
-__global__ void iadDivvCurlvGpu(T K, unsigned ngmax, const cstone::Box<Tc> box, const cstone::LocalIndex* groups,
+__global__ void iadDivvCurlvGpu(Tc K, unsigned ngmax, const cstone::Box<Tc> box, const cstone::LocalIndex* groups,
                                 cstone::LocalIndex numGroups, const cstone::OctreeNsView<Tc, KeyType> tree, const Tc* x,
                                 const Tc* y, const Tc* z, const T* vx, const T* vy, const T* vz, const T* h,
                                 const T* wh, const T* whd, const T* xm, const T* kx, T* c11, T* c12, T* c13, T* c22,

--- a/sph/include/sph/hydro_ve/iad_kern.hpp
+++ b/sph/include/sph/hydro_ve/iad_kern.hpp
@@ -42,9 +42,9 @@ namespace sph
 {
 
 template<size_t stride = 1, class Tc, class T>
-HOST_DEVICE_FUN inline void IADJLoop(cstone::LocalIndex i, T K, const cstone::Box<T>& box,
+HOST_DEVICE_FUN inline void IADJLoop(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box,
                                      const cstone::LocalIndex* neighbors, unsigned neighborsCount, const Tc* x,
-                                     const Tc* y, const Tc* z, const Tc* h, const T* wh, const T* /*whd*/, const T* xm,
+                                     const Tc* y, const Tc* z, const T* h, const T* wh, const T* /*whd*/, const T* xm,
                                      const T* kx, T* c11, T* c12, T* c13, T* c22, T* c23, T* c33)
 {
     T tau11 = 0.0, tau12 = 0.0, tau13 = 0.0, tau22 = 0.0, tau23 = 0.0, tau33 = 0.0;

--- a/sph/include/sph/hydro_ve/momentum_energy.hpp
+++ b/sph/include/sph/hydro_ve/momentum_energy.hpp
@@ -37,9 +37,11 @@
 namespace sph
 {
 
-template<bool avClean, class T, class Dataset>
-void computeMomentumEnergyImpl(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
+template<bool avClean, class Tc, class Dataset>
+void computeMomentumEnergyImpl(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<Tc>& box)
 {
+    using T = typename Dataset::HydroType;
+
     const cstone::LocalIndex* neighbors      = d.neighbors.data();
     const unsigned*           neighborsCount = d.nc.data();
 
@@ -79,10 +81,6 @@ void computeMomentumEnergyImpl(size_t startIndex, size_t endIndex, Dataset& d, c
     const auto* kx  = d.kx.data();
     const auto* xm  = d.xm.data();
 
-    const T Atmin = d.Atmin;
-    const T Atmax = d.Atmax;
-    const T ramp  = d.ramp;
-
     T minDt = INFINITY;
 
 #pragma omp parallel for schedule(static) reduction(min : minDt)
@@ -94,8 +92,8 @@ void computeMomentumEnergyImpl(size_t startIndex, size_t endIndex, Dataset& d, c
         T maxvsignal = 0;
 
         momentumAndEnergyJLoop<avClean>(i, d.K, box, neighbors + d.ngmax * ni, ncCapped, x, y, z, vx, vy, vz, h, m,
-                                        prho, c, c11, c12, c13, c22, c23, c33, Atmin, Atmax, ramp, wh, whd, kx, xm,
-                                        alpha, dV11, dV12, dV13, dV22, dV23, dV33, grad_P_x, grad_P_y, grad_P_z, du,
+                                        prho, c, c11, c12, c13, c22, c23, c33, d.Atmin, d.Atmax, d.ramp, wh, whd, kx,
+                                        xm, alpha, dV11, dV12, dV13, dV22, dV23, dV33, grad_P_x, grad_P_y, grad_P_z, du,
                                         &maxvsignal);
 
         T dt_i = tsKCourant(maxvsignal, h[i], c[i], d.Kcour);

--- a/sph/include/sph/hydro_ve/momentum_energy_gpu.cu
+++ b/sph/include/sph/hydro_ve/momentum_energy_gpu.cu
@@ -53,7 +53,7 @@ using cstone::TreeNodeIndex;
 static __device__ float minDt_ve_device;
 
 template<bool avClean, class Tc, class Tm, class T, class Tm1, class KeyType>
-__global__ void momentumEnergyGpu(T K, T Kcour, T Atmin, T Atmax, T ramp, unsigned ngmax, const cstone::Box<T> box,
+__global__ void momentumEnergyGpu(Tc K, Tc Kcour, T Atmin, T Atmax, T ramp, unsigned ngmax, const cstone::Box<Tc> box,
                                   const cstone::LocalIndex* groups, cstone::LocalIndex numGroups,
                                   const cstone::OctreeNsView<Tc, KeyType> tree, const Tc* x, const Tc* y, const Tc* z,
                                   const T* vx, const T* vy, const T* vz, const T* h, const Tm* m, const T* prho,

--- a/sph/include/sph/hydro_ve/momentum_energy_kern.hpp
+++ b/sph/include/sph/hydro_ve/momentum_energy_kern.hpp
@@ -65,7 +65,7 @@ HOST_DEVICE_FUN T avRvCorrection(util::array<Tc, 3> R, Tc eta_ab, T eta_crit, co
 
 template<bool avClean, size_t stride = 1, class Tc, class Tm, class T, class Tm1>
 HOST_DEVICE_FUN inline void
-momentumAndEnergyJLoop(cstone::LocalIndex i, T K, const cstone::Box<T>& box, const cstone::LocalIndex* neighbors,
+momentumAndEnergyJLoop(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box, const cstone::LocalIndex* neighbors,
                        unsigned neighborsCount, const Tc* x, const Tc* y, const Tc* z, const T* vx, const T* vy,
                        const T* vz, const T* h, const Tm* m, const T* prho, const T* c, const T* c11, const T* c12,
                        const T* c13, const T* c22, const T* c23, const T* c33, const T Atmin, const T Atmax,

--- a/sph/include/sph/hydro_ve/ve_def_gradh_gpu.cu
+++ b/sph/include/sph/hydro_ve/ve_def_gradh_gpu.cu
@@ -47,7 +47,7 @@ using cstone::TravConfig;
 using cstone::TreeNodeIndex;
 
 template<typename Tc, class Tm, class T, class KeyType>
-__global__ void veDefGradhGpu(T K, unsigned ngmax, const cstone::Box<Tc> box, const cstone::LocalIndex* groups,
+__global__ void veDefGradhGpu(Tc K, unsigned ngmax, const cstone::Box<Tc> box, const cstone::LocalIndex* groups,
                               cstone::LocalIndex numGroups, const cstone::OctreeNsView<Tc, KeyType> tree, const Tc* x,
                               const Tc* y, const Tc* z, const T* h, const Tm* m, const T* wh, const T* whd, const T* xm,
                               T* kx, T* gradh, cstone::LocalIndex* nidx, TreeNodeIndex* globalPool)

--- a/sph/include/sph/hydro_ve/ve_def_gradh_kern.hpp
+++ b/sph/include/sph/hydro_ve/ve_def_gradh_kern.hpp
@@ -42,7 +42,7 @@ namespace sph
 {
 
 template<size_t stride = 1, class Tc, class Tm, class T>
-HOST_DEVICE_FUN inline util::tuple<T, T> veDefGradhJLoop(cstone::LocalIndex i, T K, const cstone::Box<T>& box,
+HOST_DEVICE_FUN inline util::tuple<T, T> veDefGradhJLoop(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box,
                                                          const cstone::LocalIndex* neighbors, unsigned neighborsCount,
                                                          const Tc* x, const Tc* y, const Tc* z, const T* h, const Tm* m,
                                                          const T* wh, const T* whd, const T* xm)

--- a/sph/include/sph/hydro_ve/xmass_gpu.cu
+++ b/sph/include/sph/hydro_ve/xmass_gpu.cu
@@ -52,10 +52,11 @@ namespace cuda
 __device__ bool nc_h_convergenceFailure = false;
 
 template<class Tc, class Tm, class T, class KeyType>
-__global__ void xmassGpu(T K, unsigned ng0, unsigned ngmax, const cstone::Box<Tc> box, const cstone::LocalIndex* groups,
-                         cstone::LocalIndex numGroups, const cstone::OctreeNsView<Tc, KeyType> tree, unsigned* nc,
-                         const Tc* x, const Tc* y, const Tc* z, T* h, const Tm* m, const T* wh, const T* whd, T* xm,
-                         cstone::LocalIndex* nidx, TreeNodeIndex* globalPool)
+__global__ void xmassGpu(Tc K, unsigned ng0, unsigned ngmax, const cstone::Box<Tc> box,
+                         const cstone::LocalIndex* groups, cstone::LocalIndex numGroups,
+                         const cstone::OctreeNsView<Tc, KeyType> tree, unsigned* nc, const Tc* x, const Tc* y,
+                         const Tc* z, T* h, const Tm* m, const T* wh, const T* whd, T* xm, cstone::LocalIndex* nidx,
+                         TreeNodeIndex* globalPool)
 {
     unsigned laneIdx     = threadIdx.x & (GpuConfig::warpSize - 1);
     unsigned targetIdx   = 0;

--- a/sph/include/sph/hydro_ve/xmass_kern.hpp
+++ b/sph/include/sph/hydro_ve/xmass_kern.hpp
@@ -49,7 +49,7 @@ HOST_DEVICE_FUN inline T veDefinition(Tm mass, T rhoZero)
 }
 
 template<size_t stride = 1, class Tc, class Tm, class T>
-HOST_DEVICE_FUN inline T xmassJLoop(cstone::LocalIndex i, T K, const cstone::Box<Tc>& box,
+HOST_DEVICE_FUN inline T xmassJLoop(cstone::LocalIndex i, Tc K, const cstone::Box<Tc>& box,
                                     const cstone::LocalIndex* neighbors, unsigned neighborsCount, const Tc* x,
                                     const Tc* y, const Tc* z, const T* h, const Tm* m, const T* wh, const T* /*whd*/)
 {

--- a/sph/include/sph/kernels.hpp
+++ b/sph/include/sph/kernels.hpp
@@ -21,7 +21,7 @@ HOST_DEVICE_FUN inline T compute_3d_k(T n)
 
 //! @brief compute time-step based on the signal velocity
 template<class T1, class T2, class T3>
-HOST_DEVICE_FUN inline auto tsKCourant(T1 maxvsignal, T2 h, T3 c, double Kcour)
+HOST_DEVICE_FUN inline auto tsKCourant(T1 maxvsignal, T2 h, T3 c, float Kcour)
 {
     using T = std::common_type_t<T1, T2, T3>;
     T v     = maxvsignal > T(0) ? maxvsignal : c;

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -61,11 +61,13 @@ template<typename T, typename KeyType_, class AccType>
 class ParticlesData : public cstone::FieldStates<ParticlesData<T, KeyType_, AccType>>
 {
 public:
-    using KeyType         = KeyType_;
-    using RealType        = T;
-    using Tmass           = float;
-    using XM1Type         = float;
     using AcceleratorType = AccType;
+
+    using KeyType   = KeyType_;
+    using RealType  = T;
+    using HydroType = float;
+    using XM1Type   = float;
+    using Tmass     = float;
 
     template<class ValueType>
     using PinnedVec = std::vector<ValueType, PinnedAlloc_t<AcceleratorType, ValueType>>;
@@ -112,7 +114,7 @@ public:
     T gamma{5.0 / 3.0};
 
     //! @brief mean molecular weight of ions for models that use one value for all particles
-    T muiConst{10.0};
+    Tmass muiConst{10.0};
 
     //! @brief Unified interface to attribute initialization, reading and writing
     template<class Archive>
@@ -156,30 +158,31 @@ public:
      * The length of these arrays equals the local number of particles including halos
      * if the field is active and is zero if the field is inactive.
      */
-    FieldVector<T>        x, y, z;                            // Positions
-    FieldVector<XM1Type>  x_m1, y_m1, z_m1;                   // Difference between current and previous positions
-    FieldVector<T>        vx, vy, vz;                         // Velocities
-    FieldVector<T>        rho;                                // Density
-    FieldVector<T>        temp;                               // Temperature
-    FieldVector<T>        u;                                  // Internal Energy
-    FieldVector<T>        p;                                  // Pressure
-    FieldVector<T>        prho;                               // p / (kx * m^2 * gradh)
-    FieldVector<T>        h;                                  // Smoothing Length
-    FieldVector<Tmass>    m;                                  // Mass
-    FieldVector<T>        c;                                  // Speed of sound
-    FieldVector<T>        cv;                                 // Specific heat
-    FieldVector<T>        mue, mui;                           // mean molecular weight (electrons, ions)
-    FieldVector<T>        divv, curlv;                        // Div(velocity), Curl(velocity)
-    FieldVector<T>        ax, ay, az;                         // acceleration
-    FieldVector<XM1Type>  du, du_m1;                          // energy rate of change (du/dt)
-    FieldVector<T>        c11, c12, c13, c22, c23, c33;       // IAD components
-    FieldVector<T>        alpha;                              // AV coeficient
-    FieldVector<T>        xm;                                 // Volume element definition
-    FieldVector<T>        kx;                                 // Volume element normalization
-    FieldVector<T>        gradh;                              // grad(h) term
-    FieldVector<KeyType>  keys;                               // Particle space-filling-curve keys
-    FieldVector<unsigned> nc;                                 // number of neighbors of each particle
-    FieldVector<T>        dV11, dV12, dV13, dV22, dV23, dV33; // Velocity gradient components
+    FieldVector<T>         x, y, z;                            // Positions
+    FieldVector<XM1Type>   x_m1, y_m1, z_m1;                   // Difference between current and previous positions
+    FieldVector<HydroType> vx, vy, vz;                         // Velocities
+    FieldVector<HydroType> rho;                                // Density
+    FieldVector<T>         temp;                               // Temperature
+    FieldVector<T>         u;                                  // Internal Energy
+    FieldVector<HydroType> p;                                  // Pressure
+    FieldVector<HydroType> prho;                               // p / (kx * m^2 * gradh)
+    FieldVector<HydroType> h;                                  // Smoothing Length
+    FieldVector<Tmass>     m;                                  // Mass
+    FieldVector<HydroType> c;                                  // Speed of sound
+    FieldVector<HydroType> cv;                                 // Specific heat
+    FieldVector<HydroType> mue, mui;                           // mean molecular weight (electrons, ions)
+    FieldVector<HydroType> divv, curlv;                        // Div(velocity), Curl(velocity)
+    FieldVector<HydroType> ax, ay, az;                         // acceleration
+    FieldVector<T>         du;                                 // energy rate of change (du/dt)
+    FieldVector<XM1Type>   du_m1;                              // previous energy rate of change (du/dt)
+    FieldVector<HydroType> c11, c12, c13, c22, c23, c33;       // IAD components
+    FieldVector<HydroType> alpha;                              // AV coeficient
+    FieldVector<HydroType> xm;                                 // Volume element definition
+    FieldVector<HydroType> kx;                                 // Volume element normalization
+    FieldVector<HydroType> gradh;                              // grad(h) term
+    FieldVector<KeyType>   keys;                               // Particle space-filling-curve keys
+    FieldVector<unsigned>  nc;                                 // number of neighbors of each particle
+    FieldVector<HydroType> dV11, dV12, dV13, dV22, dV23, dV33; // Velocity gradient components
 
     //! @brief Indices of neighbors for each particle, length is number of assigned particles * ngmax. CPU version only.
     std::vector<cstone::LocalIndex>             neighbors;
@@ -187,8 +190,8 @@ public:
 
     DeviceData_t<AccType, T, KeyType> devData;
 
-    const std::array<T, lt::size> wh  = lt::createWharmonicLookupTable<T, lt::size>(sincIndex);
-    const std::array<T, lt::size> whd = lt::createWharmonicDerivativeLookupTable<T, lt::size>(sincIndex);
+    const std::array<HydroType, lt::size> wh  = lt::createWharmonicTable<HydroType, lt::size>(sincIndex);
+    const std::array<HydroType, lt::size> whd = lt::createWharmonicDerivativeTable<HydroType, lt::size>(sincIndex);
 
     /*! @brief
      * Name of each field as string for use e.g in HDF5 output. Order has to correspond to what's returned by data().
@@ -260,14 +263,14 @@ public:
     // Min. Atwood number in ramp function in momentum equation (crossed/uncrossed selection)
     // Complete uncrossed option (Atmin>=1.d50, Atmax it doesn't matter).
     // Complete crossed (Atmin and Atmax negative)
-    constexpr static T Atmin = 0.1;
-    constexpr static T Atmax = 0.2;
-    constexpr static T ramp  = 1.0 / (Atmax - Atmin);
+    constexpr static HydroType Atmin = 0.1;
+    constexpr static HydroType Atmax = 0.2;
+    constexpr static HydroType ramp  = 1.0 / (Atmax - Atmin);
 
     // AV switches floor and ceiling
-    constexpr static T alphamin       = 0.05;
-    constexpr static T alphamax       = 1.0;
-    constexpr static T decay_constant = 0.2;
+    constexpr static HydroType alphamin       = 0.05;
+    constexpr static HydroType alphamax       = 1.0;
+    constexpr static HydroType decay_constant = 0.2;
 
     // Interpolation kernel normalization constant
     const static T K;

--- a/sph/include/sph/particles_data_gpu.cuh
+++ b/sph/include/sph/particles_data_gpu.cuh
@@ -53,8 +53,9 @@ class DeviceParticlesData : public cstone::FieldStates<DeviceParticlesData<T, Ke
     template<class FType>
     using DevVector = thrust::device_vector<FType>;
 
-    using Tmass   = float;
-    using XM1Type = float;
+    using HydroType = float;
+    using XM1Type   = float;
+    using Tmass     = float;
 
 public:
     // number of CUDA streams to use
@@ -72,34 +73,35 @@ public:
      * The length of these arrays equals the local number of particles including halos
      * if the field is active and is zero if the field is inactive.
      */
-    DevVector<T>        x, y, z;                            // Positions
-    DevVector<XM1Type>  x_m1, y_m1, z_m1;                   // Difference to previous positions
-    DevVector<T>        vx, vy, vz;                         // Velocities
-    DevVector<T>        rho;                                // Density
-    DevVector<T>        temp;                               // Temperature
-    DevVector<T>        u;                                  // Internal Energy
-    DevVector<T>        p;                                  // Pressure
-    DevVector<T>        prho;                               // p / (kx * m^2 * gradh)
-    DevVector<T>        h;                                  // Smoothing Length
-    DevVector<Tmass>    m;                                  // Mass
-    DevVector<T>        c;                                  // Speed of sound
-    DevVector<T>        cv;                                 // Specific heat
-    DevVector<T>        mue, mui;                           // mean molecular weight (electrons, ions)
-    DevVector<T>        divv, curlv;                        // Div(velocity), Curl(velocity)
-    DevVector<T>        ax, ay, az;                         // acceleration
-    DevVector<XM1Type>  du, du_m1;                          // energy rate of change (du/dt)
-    DevVector<T>        c11, c12, c13, c22, c23, c33;       // IAD components
-    DevVector<T>        alpha;                              // AV coeficient
-    DevVector<T>        xm;                                 // Volume element definition
-    DevVector<T>        kx;                                 // Volume element normalization
-    DevVector<T>        gradh;                              // grad(h) term
-    DevVector<KeyType>  keys;                               // Particle space-filling-curve keys
-    DevVector<unsigned> nc;                                 // number of neighbors of each particle
-    DevVector<T>        dV11, dV12, dV13, dV22, dV23, dV33; // Velocity gradient components
+    DevVector<T>         x, y, z;                            // Positions
+    DevVector<XM1Type>   x_m1, y_m1, z_m1;                   // Difference to previous positions
+    DevVector<HydroType> vx, vy, vz;                         // Velocities
+    DevVector<HydroType> rho;                                // Density
+    DevVector<T>         temp;                               // Temperature
+    DevVector<T>         u;                                  // Internal Energy
+    DevVector<HydroType> p;                                  // Pressure
+    DevVector<HydroType> prho;                               // p / (kx * m^2 * gradh)
+    DevVector<HydroType> h;                                  // Smoothing Length
+    DevVector<Tmass>     m;                                  // Mass
+    DevVector<HydroType> c;                                  // Speed of sound
+    DevVector<HydroType> cv;                                 // Specific heat
+    DevVector<HydroType> mue, mui;                           // mean molecular weight (electrons, ions)
+    DevVector<HydroType> divv, curlv;                        // Div(velocity), Curl(velocity)
+    DevVector<HydroType> ax, ay, az;                         // acceleration
+    DevVector<T>         du;                                 // energy rate of change (du/dt)
+    DevVector<XM1Type>   du_m1;                              // previous energy rate of change (du/dt)
+    DevVector<HydroType> c11, c12, c13, c22, c23, c33;       // IAD components
+    DevVector<HydroType> alpha;                              // AV coeficient
+    DevVector<HydroType> xm;                                 // Volume element definition
+    DevVector<HydroType> kx;                                 // Volume element normalization
+    DevVector<HydroType> gradh;                              // grad(h) term
+    DevVector<KeyType>   keys;                               // Particle space-filling-curve keys
+    DevVector<unsigned>  nc;                                 // number of neighbors of each particle
+    DevVector<HydroType> dV11, dV12, dV13, dV22, dV23, dV33; // Velocity gradient components
 
     //! @brief SPH interpolation kernel lookup tables
-    DevVector<T> wh;
-    DevVector<T> whd;
+    DevVector<HydroType> wh;
+    DevVector<HydroType> whd;
 
     DevVector<cstone::LocalIndex> traversalStack;
     DevVector<cstone::LocalIndex> targetGroups;
@@ -177,10 +179,11 @@ public:
         }
     }
 
-    void uploadTables(const std::array<T, ::sph::lt::size>& whTable, const std::array<T, ::sph::lt::size>& whdTable)
+    void uploadTables(const std::array<HydroType, ::sph::lt::size>& whTable,
+                      const std::array<HydroType, ::sph::lt::size>& whdTable)
     {
-        wh  = DevVector<T>(whTable.begin(), whTable.end());
-        whd = DevVector<T>(whdTable.begin(), whdTable.end());
+        wh  = DevVector<HydroType>(whTable.begin(), whTable.end());
+        whd = DevVector<HydroType>(whdTable.begin(), whdTable.end());
     }
 
     ~DeviceParticlesData()

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -50,8 +50,8 @@ HOST_DEVICE_FUN bool fbcCheck(Tc coord, Th h, Tc top, Tc bottom, bool fbc)
 }
 
 //! @brief update the energy according to Adams-Bashforth (2nd order)
-template<class T>
-HOST_DEVICE_FUN double energyUpdate(double u_old, double dt, double dt_m1, T du, T du_m1)
+template<class T1, class T2>
+HOST_DEVICE_FUN double energyUpdate(double u_old, double dt, double dt_m1, T1 du, T2 du_m1)
 {
     double deltaA = 0.5 * dt * dt / dt_m1;
     double deltaB = dt + deltaA;

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -35,11 +35,11 @@
 namespace sph
 {
 
-template<class Tc, class Tv, class Ta, class Tm1, class Tt, class Thydro>
+template<class Tc, class Tv, class Ta, class Tdu, class Tm1, class Tt, class Thydro>
 __global__ void computePositionsKernel(size_t first, size_t last, double dt, double dt_m1, Tc* x, Tc* y, Tc* z, Tv* vx,
                                        Tv* vy, Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az,
-                                       Tt* temp, Tt* u, Tm1* du, Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma,
-                                       Thydro constCv, const cstone::Box<Tc> box)
+                                       Tt* temp, Tt* u, Tdu* du, Tm1* du_m1, Thydro* h, Thydro* mui, Tc gamma,
+                                       Tc constCv, const cstone::Box<Tc> box)
 {
     cstone::LocalIndex i = first + blockDim.x * blockIdx.x + threadIdx.x;
     if (i >= last) { return; }
@@ -82,10 +82,10 @@ __global__ void computePositionsKernel(size_t first, size_t last, double dt, dou
     }
 }
 
-template<class Tc, class Tv, class Ta, class Tm1, class Tt, class Thydro>
+template<class Tc, class Tv, class Ta, class Tdu, class Tm1, class Tt, class Thydro>
 void computePositionsGpu(size_t first, size_t last, double dt, double dt_m1, Tc* x, Tc* y, Tc* z, Tv* vx, Tv* vy,
-                         Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az, Tt* temp, Tt* u, Tm1* du,
-                         Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma, Thydro constCv, const cstone::Box<Tc>& box)
+                         Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az, Tt* temp, Tt* u, Tdu* du,
+                         Tm1* du_m1, Thydro* h, Thydro* mui, Tc gamma, Tc constCv, const cstone::Box<Tc>& box)
 {
     cstone::LocalIndex numParticles = last - first;
     unsigned           numThreads   = 256;
@@ -95,18 +95,16 @@ void computePositionsGpu(size_t first, size_t last, double dt, double dt_m1, Tc*
                                                       ay, az, temp, u, du, du_m1, h, mui, gamma, constCv, box);
 }
 
-#define POS_GPU(Tc, Tv, Ta, Tm1, Tt, Thydro)                                                                           \
+#define POS_GPU(Tc, Tv, Ta, Tdu, Tm1, Tt, Thydro)                                                                      \
     template void computePositionsGpu(size_t first, size_t last, double dt, double dt_m1, Tc* x, Tc* y, Tc* z, Tv* vx, \
                                       Tv* vy, Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az,         \
-                                      Tt* temp, Tt* u, Tm1* du, Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma,      \
-                                      Thydro constCv, const cstone::Box<Tc>& box)
+                                      Tt* temp, Tt* u, Tdu* du, Tm1* du_m1, Thydro* h, Thydro* mui, Tc gamma,          \
+                                      Tc constCv, const cstone::Box<Tc>& box)
 
-POS_GPU(double, double, double, double, double, double);
-POS_GPU(double, double, double, float, double, double);
-POS_GPU(double, double, float, float, double, float);
-POS_GPU(double, double, float, float, float, float);
-POS_GPU(double, float, float, float, double, float);
-POS_GPU(double, float, float, float, float, float);
-POS_GPU(float, float, float, float, float, float);
+//        Tc      Tv     Ta      Tdu     Tm1     Tt      Thydro
+POS_GPU(double, double, double, double, double, double, double);
+POS_GPU(float, float, float, float, float, float, float);
+POS_GPU(double, double, double, float, float, double, double);
+POS_GPU(double, float, float, double, float, double, float);
 
 } // namespace sph

--- a/sph/include/sph/sph_gpu.hpp
+++ b/sph/include/sph/sph_gpu.hpp
@@ -37,18 +37,18 @@ template<bool avClean, class Dataset>
 extern void computeMomentumEnergy(size_t, size_t, Dataset& d, const cstone::Box<typename Dataset::RealType>&);
 
 template<class Tu, class Trho, class Tp, class Tc>
-extern void computeEOS_HydroStd(size_t, size_t, Tu, Tu, const Tu*, const Trho*, Tp*, Tc*);
+extern void computeEOS_HydroStd(size_t, size_t, Trho, Tu, const Tu*, const Trho*, Tp*, Tc*);
 
 template<class Tu, class Tm, class Thydro>
-extern void computeEOS(size_t, size_t, Tu, Tu, const Tu*, const Tm*, const Thydro*, const Thydro*, const Thydro*,
-                       Thydro*, Thydro*, Thydro*, Thydro*);
+extern void computeEOS(size_t, size_t, Tm mui, Tu gamma, const Tu*, const Tm*, const Thydro*, const Thydro*,
+                       const Thydro*, Thydro*, Thydro*, Thydro*, Thydro*);
 
 } // namespace cuda
 
-template<class Tc, class Tv, class Ta, class Tm1, class Tu, class Thydro>
+template<class Tc, class Tv, class Ta, class Tdu, class Tm1, class Tu, class Thydro>
 extern void computePositionsGpu(size_t first, size_t last, double dt, double dt_m1, Tc* x, Tc* y, Tc* z, Tv* vx, Tv* vy,
                                 Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax, Ta* ay, Ta* az, Tu* temp, Tu* u,
-                                Tm1* du, Tm1* du_m1, Thydro* h, Thydro* mui, Thydro gamma, Thydro constCv,
+                                Tdu* du, Tm1* du_m1, Thydro* h, Thydro* mui, Tc gamma, Tc constCv,
                                 const cstone::Box<Tc>& box);
 
 template<class Th>

--- a/sph/include/sph/tables.hpp
+++ b/sph/include/sph/tables.hpp
@@ -12,7 +12,7 @@ constexpr int size = 20000;
 
 //! @brief create a lookup-table for sinc(x)^sincIndex
 template<typename T, std::size_t N>
-std::array<T, N> createWharmonicLookupTable(T sincIndex)
+std::array<T, N> createWharmonicTable(double sincIndex)
 {
     constexpr int    numIntervals = N - 1;
     std::array<T, N> wh;
@@ -28,7 +28,7 @@ std::array<T, N> createWharmonicLookupTable(T sincIndex)
 
 //! @brief create a lookup-table for d(sinc(x)^sincIndex)/dx
 template<typename T, std::size_t N>
-std::array<T, N> createWharmonicDerivativeLookupTable(T sincIndex)
+std::array<T, N> createWharmonicDerivativeTable(double sincIndex)
 {
     constexpr int    numIntervals = N - 1;
     std::array<T, N> whd;

--- a/sph/include/sph/timestep.hpp
+++ b/sph/include/sph/timestep.hpp
@@ -71,7 +71,7 @@ auto accelerationTimestep(size_t first, size_t last, const Dataset& d)
 template<class Dataset>
 auto rhoTimestep(size_t first, size_t last, const Dataset& d)
 {
-    using T = typename Dataset::RealType;
+    using T = std::decay_t<decltype(d.divv[0])>;
 
     T maxDivv = -INFINITY;
     if constexpr (cstone::HaveGpu<typename Dataset::AcceleratorType>{})

--- a/sph/include/sph/update_h_gpu.cu
+++ b/sph/include/sph/update_h_gpu.cu
@@ -30,7 +30,7 @@
 
 #include <cmath>
 
-#include "cstone/util/util.hpp"
+#include "cstone/primitives/math.hpp"
 #include "cstone/tree/definitions.h"
 #include "sph/kernels.hpp"
 
@@ -50,7 +50,7 @@ template<class Th>
 void updateSmoothingLengthGpu(size_t first, size_t last, unsigned ng0, const unsigned* nc, Th* h)
 {
     unsigned numThreads = 256;
-    unsigned numBlocks  = iceil(last - first, 256);
+    unsigned numBlocks  = cstone::iceil(last - first, 256);
 
     updateSmoothingLengthGpuKernel<<<numBlocks, numThreads>>>(first, last, ng0, nc, h);
 }

--- a/sph/test/hydro_std/density_kern.cpp
+++ b/sph/test/hydro_std/density_kern.cpp
@@ -45,8 +45,8 @@ TEST(Density, JLoop)
     T sincIndex = 6.0;
     T K         = compute_3d_k(sincIndex);
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(0, 6, cstone::BoundaryType::open);
 
@@ -82,8 +82,8 @@ TEST(Density, JLoopPBC)
     T sincIndex = 6.0;
     T K         = compute_3d_k(sincIndex);
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     // box length in any dimension must be bigger than 4*h for any particle
     // otherwise the PBC evaluation does not select the closest image

--- a/sph/test/hydro_std/iad_kern.cpp
+++ b/sph/test/hydro_std/iad_kern.cpp
@@ -45,8 +45,8 @@ TEST(IAD, JLoop)
     T sincIndex = 6.0;
     T K         = compute_3d_k(sincIndex);
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(0, 6, cstone::BoundaryType::open);
 

--- a/sph/test/hydro_std/momentum_energy.cpp
+++ b/sph/test/hydro_std/momentum_energy.cpp
@@ -45,8 +45,8 @@ TEST(MomentumEnergy, JLoop)
     T sincIndex = 6.0;
     T K         = compute_3d_k(sincIndex);
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(0, 6, cstone::BoundaryType::open);
 

--- a/sph/test/hydro_ve/av_switches_kern.cpp
+++ b/sph/test/hydro_ve/av_switches_kern.cpp
@@ -53,8 +53,8 @@ TEST(AVswitches, JLoop)
     T mpart = 3.781038064465603e26;
     T dt    = 0.3;
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(-1.e9, 1.e9, cstone::BoundaryType::open);
 

--- a/sph/test/hydro_ve/divv_curlv_kern.cpp
+++ b/sph/test/hydro_ve/divv_curlv_kern.cpp
@@ -48,8 +48,8 @@ TEST(Divv_Curlv, JLoop)
     T K         = compute_3d_k(sincIndex);
     T mpart     = 3.781038064465603e26;
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(-1.e9, 1.e9, cstone::BoundaryType::open);
 

--- a/sph/test/hydro_ve/iad_kern.cpp
+++ b/sph/test/hydro_ve/iad_kern.cpp
@@ -48,8 +48,8 @@ TEST(IAD, JLoop)
     T K         = compute_3d_k(sincIndex);
     T mpart     = 3.781038064465603e26;
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(-1.e9, 1.e9, cstone::BoundaryType::open);
 
@@ -137,8 +137,8 @@ TEST(IAD, JLoopPBC)
     T sincIndex = 6.0;
     T K         = compute_3d_k(sincIndex);
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     // box length in any dimension must be bigger than 4*h for any particle
     // otherwise the PBC evaluation does not select the closest image

--- a/sph/test/hydro_ve/momentum_energy_kern.cpp
+++ b/sph/test/hydro_ve/momentum_energy_kern.cpp
@@ -65,8 +65,8 @@ TEST(MomentumEnergy, JLoop)
     T ramp      = 1.0 / (Atmax - Atmin);
     T mpart     = 3.781038064465603e26;
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(-1.e9, 1.e9, cstone::BoundaryType::open);
 

--- a/sph/test/hydro_ve/ve_norm_gradh.cpp
+++ b/sph/test/hydro_ve/ve_norm_gradh.cpp
@@ -48,8 +48,8 @@ TEST(VeDefGradh, JLoop)
     T K         = compute_3d_k(sincIndex);
     T mpart     = 3.781038064465603e26;
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(-1.e9, 1.e9, cstone::BoundaryType::open);
 
@@ -128,8 +128,8 @@ TEST(VeDefGradh, JLoopPBC)
     T sincIndex = 6.0;
     T K         = compute_3d_k(sincIndex);
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     // box length in any dimension must be bigger than 4*h for any particle
     // otherwise the PBC evaluation does not select the closest image

--- a/sph/test/hydro_ve/xmass_kern.cpp
+++ b/sph/test/hydro_ve/xmass_kern.cpp
@@ -48,8 +48,8 @@ TEST(xmass, JLoop)
     T K         = compute_3d_k(sincIndex);
     T mpart     = 3.781038064465603e26;
 
-    std::array<double, lt::size> wh  = lt::createWharmonicLookupTable<double, lt::size>(sincIndex);
-    std::array<double, lt::size> whd = lt::createWharmonicDerivativeLookupTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> wh  = lt::createWharmonicTable<double, lt::size>(sincIndex);
+    std::array<double, lt::size> whd = lt::createWharmonicDerivativeTable<double, lt::size>(sincIndex);
 
     cstone::Box<T> box(-1.e9, 1.e9, cstone::BoundaryType::open);
 


### PR DESCRIPTION
GPU memory optimizations:
* Replaced Thrust radix sort with lower-level CUB interface that avoids allocation of large temporary arrays by reusing existing buffers
* Separation of GPU buffers used for send/receive staging and GPU buffers used for relocation+swap operations to avoid cyclic swap chain

Performance optimizations:
* Added support for hydro fields in FP32 with only coordinates and temperatur/internal energy stored in FP64.