### PR TITLE
Write and read chemistry fields

### DIFF
--- a/main/src/propagator/std_hydro_grackle.hpp
+++ b/main/src/propagator/std_hydro_grackle.hpp
@@ -113,6 +113,7 @@ public:
     {
         std::vector<std::string> ret{"x", "y", "z", "h", "m"};
         for_each_tuple([&ret](auto f) { ret.push_back(f.value); }, make_tuple(ConservedFields{}));
+        for_each_tuple([&ret](auto f) { ret.push_back(f.value); }, make_tuple(CoolingFields{}));
         return ret;
     }
 

--- a/main/src/propagator/ve_hydro.hpp
+++ b/main/src/propagator/ve_hydro.hpp
@@ -236,7 +236,7 @@ public:
                     int column = std::find(d.outputFieldIndices.begin(), d.outputFieldIndices.end(), fidx) -
                                  d.outputFieldIndices.begin();
                     transferToHost(d, first, last, {d.fieldNames[fidx]});
-                    std::visit([writer, c = column, key = d.fieldNames[fidx]](auto field)
+                    std::visit([writer, c = column, key = d.outputFieldNames[i]](auto field)
                                { writer->writeField(key, field->data(), c); },
                                fieldPointers[fidx]);
                     outputFields.erase(outputFields.begin() + i);

--- a/main/src/sphexa/simulation_data.hpp
+++ b/main/src/sphexa/simulation_data.hpp
@@ -60,6 +60,23 @@ public:
     // NuclearData nuclear;
 
     MPI_Comm comm;
+
+    //! @brief record user selection of output fields
+    void setOutputFields(std::vector<std::string> outFields)
+    {
+        hydro.setOutputFields(outFields);
+        chem.setOutputFields(outFields);
+
+        if (!outFields.empty())
+        {
+            std::string msg;
+            for (auto& s : outFields)
+            {
+                msg += s + ", ";
+            }
+            throw std::runtime_error("The following fields for output were not found: " + msg);
+        }
+    }
 };
 
 } // namespace sphexa

--- a/main/src/sphexa/sphexa.cpp
+++ b/main/src/sphexa/sphexa.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv)
 
     auto& d = simData.hydro;
     transferToDevice(d, 0, d.x.size(), propagator->conservedFields());
-    d.setOutputFields(outputFields.empty() ? propagator->conservedFields() : outputFields);
+    simData.setOutputFields(outputFields.empty() ? propagator->conservedFields() : outputFields);
 
     if (parser.exists("--G")) { d.g = parser.get<double>("--G"); }
     bool  haveGrav = (d.g != 0.0);

--- a/main/test/sphexa/particles_data.cpp
+++ b/main/test/sphexa/particles_data.cpp
@@ -197,3 +197,19 @@ TEST(ParticlesData, getFieldList)
     auto& xRef = get<"x">(d);
     EXPECT_EQ(d.x.data(), xRef.data());
 }
+
+TEST(ParticlesData, setOutput)
+{
+    ParticlesData<double, unsigned, cstone::CpuTag> d;
+
+    std::vector<std::string> fields{"x", "y", "rho", "SomeOtherField"};
+
+    d.setOutputFields(fields);
+
+    // "SomeOtherField" is not recognized by ParticlesData, therefore it will be left-over in @a fields
+    EXPECT_EQ(fields.size(), 1);
+    EXPECT_EQ(fields[0], "SomeOtherField");
+
+    std::vector<std::string> ref{"x", "y", "rho"};
+    EXPECT_EQ(d.outputFieldNames, ref);
+}

--- a/physics/cooling/include/cooling/chemistry_data.hpp
+++ b/physics/cooling/include/cooling/chemistry_data.hpp
@@ -82,6 +82,29 @@ public:
         }
     }
 
+    //! @brief particle fields selected for file output
+    std::vector<int>         outputFieldIndices;
+    std::vector<std::string> outputFieldNames;
+
+    void setOutputFields(std::vector<std::string>& outFields)
+    {
+        auto hasField = [](const std::string& field)
+        { return cstone::getFieldIndex(field, fieldNames) < fieldNames.size(); };
+
+        std::copy_if(outFields.begin(), outFields.end(), std::back_inserter(outputFieldNames), hasField);
+        outputFieldIndices = cstone::fieldStringsToInt(outputFieldNames, fieldNames);
+        std::for_each(outputFieldNames.begin(), outputFieldNames.end(), [](auto& f) { f = prefix + f; });
+
+        outFields.erase(std::remove_if(outFields.begin(), outFields.end(), hasField), outFields.end());
+    }
+
+    template<class Archive>
+    void loadOrStoreAttributes(Archive* /*ar*/)
+    {
+    }
+
+    static const inline std::string prefix{"chem::"};
+
 private:
     template<size_t... Is>
     auto dataTuple_helper(std::index_sequence<Is...>)

--- a/physics/cooling/include/cooling/init_chemistry.h
+++ b/physics/cooling/include/cooling/init_chemistry.h
@@ -26,13 +26,9 @@ void initChemistryData(ChemistryData& d, size_t n)
 
     auto fillVec = [](std::vector<T>& vec, T value) { std::fill(vec.begin(), vec.end(), value); };
 
-    // fillVec(cstone::get<"HI_fraction">(d), non_metal_fraction *
-    // d.cooling_data.get_global_values().data.HydrogenFractionByMass); fillVec(cstone::get<"HeI_fraction">(d),
-    // non_metal_fraction * (1. - d.cooling_data.get_global_values().data.HydrogenFractionByMass));
     fillVec(cstone::get<"HI_fraction">(d), non_metal_fraction * 0.76);
     fillVec(cstone::get<"HeI_fraction">(d), non_metal_fraction * 0.24);
     fillVec(cstone::get<"DI_fraction">(d), 2.0 * 3.4e-5);
-    fillVec(cstone::get<"metal_fraction">(d), metal_fraction);
     fillVec(cstone::get<"HII_fraction">(d), tiny_number);
     fillVec(cstone::get<"HeII_fraction">(d), tiny_number);
     fillVec(cstone::get<"HeIII_fraction">(d), tiny_number);
@@ -43,15 +39,15 @@ void initChemistryData(ChemistryData& d, size_t n)
     fillVec(cstone::get<"DII_fraction">(d), tiny_number);
     fillVec(cstone::get<"HDI_fraction">(d), tiny_number);
     fillVec(cstone::get<"e_fraction">(d), tiny_number);
-    fillVec(cstone::get<"metal_fraction">(d), tiny_number);
-    fillVec(cstone::get<"volumetric_heating_rate">(d), tiny_number);
-    fillVec(cstone::get<"specific_heating_rate">(d), tiny_number);
-    fillVec(cstone::get<"RT_heating_rate">(d), tiny_number);
-    fillVec(cstone::get<"RT_HI_ionization_rate">(d), tiny_number);
-    fillVec(cstone::get<"RT_HeI_ionization_rate">(d), tiny_number);
-    fillVec(cstone::get<"RT_HeII_ionization_rate">(d), tiny_number);
-    fillVec(cstone::get<"RT_H2_dissociation_rate">(d), tiny_number);
-    fillVec(cstone::get<"H2_self_shielding_length">(d), tiny_number);
+    fillVec(cstone::get<"metal_fraction">(d), metal_fraction);
+    fillVec(cstone::get<"volumetric_heating_rate">(d), 0.);
+    fillVec(cstone::get<"specific_heating_rate">(d), 0.);
+    fillVec(cstone::get<"RT_heating_rate">(d), 0.);
+    fillVec(cstone::get<"RT_HI_ionization_rate">(d), 0.);
+    fillVec(cstone::get<"RT_HeI_ionization_rate">(d), 0.);
+    fillVec(cstone::get<"RT_HeII_ionization_rate">(d), 0.);
+    fillVec(cstone::get<"RT_H2_dissociation_rate">(d), 0.);
+    fillVec(cstone::get<"H2_self_shielding_length">(d), 0.);
     std::cout << "resizing: " << d.fields[0].size() << std::endl;
 }
 } // namespace cooling


### PR DESCRIPTION
- Cooling propagator saves also the chemistry fields (with prefix chem::)
- FileInit can read the chemistry fields
- SimulationData forwards setOutputFields based on prefix