### PR TITLE
SFC-based particle splitting

### DIFF
--- a/main/src/init/turbulence_init.hpp
+++ b/main/src/init/turbulence_init.hpp
@@ -47,11 +47,11 @@ namespace sphexa
 
 std::map<std::string, double> TurbulenceConstants()
 {
-    return {{"solWeight", 0.5},    {"stMaxModes", 100000}, {"Lbox", 1.0},          {"stMachVelocity", 0.3e0},
-            {"minDt", 1e-4},       {"minDt_m1", 1e-4},     {"epsilon", 1e-15},     {"rngSeed", 251299},
-            {"stSpectForm", 1},    {"mTotal", 1.0},        {"powerLawExp", 5 / 3}, {"anglesExp", 2.0},
-            {"gamma", 1.001},      {"mui", 0.62},          {"u0", 1000.},          {"Kcour", 0.4},
-            {"gravConstant", 0.0}, {"ng0", 100},           {"ngmax", 150},         {"turbulence", 1.0}};
+    return {{"solWeight", 0.5},    {"stMaxModes", 100000}, {"Lbox", 1.0},           {"stMachVelocity", 0.3e0},
+            {"minDt", 1e-4},       {"minDt_m1", 1e-4},     {"epsilon", 1e-15},      {"rngSeed", 251299},
+            {"stSpectForm", 1},    {"mTotal", 1.0},        {"powerLawExp", 5. / 3}, {"anglesExp", 2.0},
+            {"gamma", 1.001},      {"mui", 0.62},          {"u0", 1000.},           {"Kcour", 0.4},
+            {"gravConstant", 0.0}, {"ng0", 100},           {"ngmax", 150},          {"turbulence", 1.0}};
 }
 
 //! @brief init particle data fiels. Note: Dataset attributes must be initialized

--- a/sph/include/sph/find_neighbors.hpp
+++ b/sph/include/sph/find_neighbors.hpp
@@ -26,12 +26,12 @@ void findNeighborsSph(const Tc* x, const Tc* y, const Tc* z, T* h, LocalIndex fi
         unsigned   ncSph = 1 + findNeighbors(id, x, y, z, h, treeView, box, ngmax, neighbors + i * ngmax);
 
         int iteration = 0;
-        while (ngmin > ncSph || (ncSph - 1) > ngmax && iteration++ < maxIteration)
+        while ((ngmin > ncSph || (ncSph - 1) > ngmax) && iteration++ < maxIteration)
         {
             h[id] = updateH(ng0, ncSph, h[id]);
             ncSph = 1 + findNeighbors(id, x, y, z, h, treeView, box, ngmax, neighbors + i * ngmax);
         }
-        numFails += (iteration == maxIteration);
+        numFails += (iteration >= maxIteration);
 
         nc[i] = ncSph;
     }


### PR DESCRIPTION
More robust implementation of particle splitting that does not rely on random numbers and thus risk accidental (near-)collions. Instead, the space filling curve is used to insert new particles  in-between existing ones.