### PR TITLE
Code cleanup: Store SFC keys in assignment

### DIFF
--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -104,16 +104,7 @@ public:
         // sort keys and keep track of ordering for later use
         reorderFunctor.setMapFromCodes(keyView.begin(), keyView.end());
 
-        gsl::span<const KeyType> oldLeaves = tree_.treeLeaves();
-        std::vector<KeyType> oldBoundaries(assignment_.numRanks() + 1);
-        for (size_t rank = 0; rank < oldBoundaries.size() - 1; ++rank)
-        {
-            oldBoundaries[rank] = oldLeaves[assignment_.firstNodeIdx(rank)];
-        }
-        oldBoundaries.back() = nodeRange<KeyType>(0);
-
         updateOctreeGlobal(keyView.begin(), keyView.end(), bucketSize_, tree_, nodeCounts_);
-
         if (firstCall_)
         {
             firstCall_ = false;
@@ -121,12 +112,11 @@ public:
                 ;
         }
 
-        auto newAssignment = singleRangeSfcSplit(nodeCounts_, numRanks_);
-        limitBoundaryShifts<KeyType>(oldBoundaries, tree_.treeLeaves(), nodeCounts_, newAssignment);
+        auto newAssignment = makeSfcAssignment(numRanks_, nodeCounts_, tree_.treeLeaves().data());
+        limitBoundaryShifts<KeyType>(assignment_, newAssignment, tree_.treeLeaves(), nodeCounts_);
         assignment_ = std::move(newAssignment);
 
-        exchanges_ =
-            createSendRanges<KeyType>(assignment_, tree_.treeLeaves(), {particleKeys + bufDesc.start, numParticles});
+        exchanges_ = createSendRanges<KeyType>(assignment_, {particleKeys + bufDesc.start, numParticles});
 
         return domain_exchange::exchangeBufferSize(bufDesc, numPresent(), numAssigned());
     }
@@ -196,7 +186,7 @@ public:
     //! @brief the global coordinate bounding box
     const Box<T>& box() const { return box_; }
     //! @brief return the space filling curve rank assignment of the last call to @a assign()
-    const SpaceCurveAssignment& assignment() const { return assignment_; }
+    const SfcAssignment<KeyType>& assignment() const { return assignment_; }
 
     //! @brief number of local particles to be sent to lower ranks
     LocalIndex numSendDown() const { return exchanges_[myRank_]; }
@@ -211,7 +201,7 @@ private:
     //! @brief global coordinate bounding box
     Box<T> box_;
 
-    SpaceCurveAssignment assignment_;
+    SfcAssignment<KeyType> assignment_;
     SendRanges exchanges_;
     mutable ExchangeLog recvLog_;
 

--- a/domain/include/cstone/domain/assignment_gpu.cuh
+++ b/domain/include/cstone/domain/assignment_gpu.cuh
@@ -113,14 +113,6 @@ public:
         // sort keys and keep track of ordering for later use
         sfcSorter.setMapFromCodes(keyView.begin(), keyView.end(), s0, s1);
 
-        gsl::span<const KeyType> oldLeaves = tree_.treeLeaves();
-        std::vector<KeyType> oldBoundaries(assignment_.numRanks() + 1);
-        for (size_t rank = 0; rank < oldBoundaries.size() - 1; ++rank)
-        {
-            oldBoundaries[rank] = oldLeaves[assignment_.firstNodeIdx(rank)];
-        }
-        oldBoundaries.back() = nodeRange<KeyType>(0);
-
         updateOctreeGlobalGpu(keyView.begin(), keyView.end(), bucketSize_, tree_, d_csTree_, nodeCounts_,
                               d_nodeCounts_);
         if (firstCall_)
@@ -131,13 +123,12 @@ public:
                 ;
         }
 
-        auto newAssignment = singleRangeSfcSplit(nodeCounts_, numRanks_);
-        limitBoundaryShifts<KeyType>(oldBoundaries, tree_.treeLeaves(), nodeCounts_, newAssignment);
+        auto newAssignment = makeSfcAssignment(numRanks_, nodeCounts_, tree_.treeLeaves().data());
+        limitBoundaryShifts<KeyType>(assignment_, newAssignment, tree_.treeLeaves(), nodeCounts_);
         assignment_ = std::move(newAssignment);
 
-        exchanges_ =
-            createSendRangesGpu<KeyType>(assignment_, tree_.treeLeaves(), {particleKeys + bufDesc.start, numParticles},
-                                         rawPtr(d_boundaryKeys_), rawPtr(d_boundaryIndices_));
+        exchanges_ = createSendRangesGpu<KeyType>(assignment_, {particleKeys + bufDesc.start, numParticles},
+                                                  rawPtr(d_boundaryKeys_), rawPtr(d_boundaryIndices_));
 
         return domain_exchange::exchangeBufferSize(bufDesc, numPresent(), numAssigned());
     }
@@ -209,7 +200,7 @@ public:
     //! @brief the global coordinate bounding box
     const Box<T>& box() const { return box_; }
     //! @brief return the space filling curve rank assignment of the last call to @a assign()
-    const SpaceCurveAssignment& assignment() const { return assignment_; }
+    const SfcAssignment<KeyType>& assignment() const { return assignment_; }
 
     //! @brief number of local particles to be sent to lower ranks
     LocalIndex numSendDown() const { return exchanges_[myRank_]; }
@@ -224,7 +215,7 @@ private:
     //! @brief global coordinate bounding box
     Box<T> box_;
 
-    SpaceCurveAssignment assignment_;
+    SfcAssignment<KeyType> assignment_;
     SendRanges exchanges_;
     mutable ExchangeLog recvLog_;
 

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -222,9 +222,9 @@ public:
             focusTree_.converge(box(), keyView, peers, global_.assignment(), global_.treeLeaves(), global_.nodeCounts(),
                                 invThetaEff, std::get<0>(scratch));
         }
-        focusTree_.updateTree(peers, global_.assignment(), global_.treeLeaves());
+        focusTree_.updateTree(peers, global_.assignment());
         focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
-        focusTree_.updateMinMac(box(), global_.assignment(), global_.treeLeaves(), invThetaEff);
+        focusTree_.updateMinMac(box(), global_.assignment(), invThetaEff);
 
         focusTree_.updateGeoCenters(box());
 
@@ -277,21 +277,21 @@ public:
             int converged = 0;
             while (converged != numRanks_)
             {
-                focusTree_.updateMinMac(box(), global_.assignment(), global_.treeLeaves(), invThetaEff);
-                converged = focusTree_.updateTree(peers, global_.assignment(), global_.treeLeaves());
+                focusTree_.updateMinMac(box(), global_.assignment(), invThetaEff);
+                converged = focusTree_.updateTree(peers, global_.assignment());
                 focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
-                focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.assignment(),
-                                         global_.octree(), box(), std::get<0>(scratch), std::get<1>(scratch));
-                focusTree_.updateMacs(box(), global_.assignment(), global_.treeLeaves());
+                focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), box(),
+                                         std::get<0>(scratch), std::get<1>(scratch));
+                focusTree_.updateMacs(box(), global_.assignment());
                 MPI_Allreduce(MPI_IN_PLACE, &converged, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
             }
         }
-        focusTree_.updateMinMac(box(), global_.assignment(), global_.treeLeaves(), invThetaEff);
-        focusTree_.updateTree(peers, global_.assignment(), global_.treeLeaves());
+        focusTree_.updateMinMac(box(), global_.assignment(), invThetaEff);
+        focusTree_.updateTree(peers, global_.assignment());
         focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
-        focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.assignment(), global_.octree(),
-                                 box(), std::get<0>(scratch), std::get<1>(scratch));
-        focusTree_.updateMacs(box(), global_.assignment(), global_.treeLeaves());
+        focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), box(),
+                                 std::get<0>(scratch), std::get<1>(scratch));
+        focusTree_.updateMacs(box(), global_.assignment());
 
         focusTree_.updateGeoCenters(box());
 

--- a/domain/include/cstone/domain/domaindecomp.hpp
+++ b/domain/include/cstone/domain/domaindecomp.hpp
@@ -38,138 +38,87 @@
 #include <vector>
 
 #include "cstone/tree/csarray.hpp"
+#include "cstone/primitives/gather.hpp"
 #include "cstone/util/gsl-lite.hpp"
 #include "index_ranges.hpp"
 
 namespace cstone
 {
 
-/*! @brief stores which parts of the SFC belong to which rank, on a per-rank basis
- *
- * The storage layout allows fast look-up of the SFC code ranges that a given rank
- * was assigned.
- *
- * Usage constraints of this class:
- *      - Assigned ranges can be empty, but each rank has to be assigned a range (not checked)
- *      - The ranges of two consecutive ranks must not overlap and must not have holes in between,
- *        i.e. lastNodeIdx(n) == firstNodeIdx(n+1) for any rank n < nRanks-1 (checked)
- */
-class SpaceCurveAssignment
+//! @brief determine bins that produce a histogram with uniform number of elements
+template<class IndexType>
+void uniformBins(const std::vector<IndexType>& counts, gsl::span<TreeNodeIndex> bins, gsl::span<LocalIndex> binCounts)
 {
-    static constexpr TreeNodeIndex untouched = -1;
+    std::vector<uint64_t> countScan(counts.size() + 1);
+    exclusiveScan(counts.data(), countScan.data(), countScan.size());
 
+    int numBins   = bins.size() - 1;
+    auto binCount = double(countScan.back()) / numBins;
+
+    bins.front() = 0;
+    bins.back()  = counts.size();
+#pragma omp parallel for
+    for (int i = 1; i < numBins; ++i)
+    {
+        uint64_t targetCount = i * binCount;
+        bins[i]              = std::lower_bound(countScan.begin(), countScan.end(), targetCount) - countScan.begin();
+    }
+    for (int i = 1; i < numBins; ++i)
+    {
+        binCounts[i - 1] = countScan[bins[i]] - countScan[bins[i - 1]];
+    }
+    binCounts.back() = countScan.back() - countScan[bins[numBins - 1]];
+}
+
+//! @brief Stores which parts of the SFC belong to which rank. Each rank as an identical copy
+template<class KeyType>
+class SfcAssignment
+{
 public:
-    SpaceCurveAssignment()
-        : rankAssignment_(1)
+    SfcAssignment()
+        : rankBoundaries_(1)
     {
     }
 
-    explicit SpaceCurveAssignment(int numRanks)
-        : rankAssignment_(numRanks + 1, untouched)
+    explicit SfcAssignment(int numRanks)
+        : rankBoundaries_(numRanks + 1)
         , counts_(numRanks)
     {
     }
 
-    //! @brief add an index/code range to rank @p rank
-    void addRange(int rank, TreeNodeIndex lower, TreeNodeIndex upper, std::size_t cnt)
-    {
-        // make sure that there's no holes or overlap between or with the range of the previous rank
-        assert(rankAssignment_[rank] == lower || rankAssignment_[rank] == untouched);
+    KeyType* data() { return rankBoundaries_.data(); }
+    const KeyType* data() const { return rankBoundaries_.data(); }
 
-        rankAssignment_[rank] = lower;
-        // will be overwritten by @p lower of rank+1, except if rank == numRanks-1
-        rankAssignment_[rank + 1] = upper;
-        counts_[rank]             = cnt;
+    unsigned* counts() { return counts_.data(); }
+
+    void set(int rank, KeyType a, LocalIndex count)
+    {
+        rankBoundaries_[rank] = a;
+        if (rank < int(counts_.size())) { counts_[rank] = count; }
     }
 
-    [[nodiscard]] int numRanks() const { return int(rankAssignment_.size()) - 1; }
+    [[nodiscard]] int numRanks() const { return int(rankBoundaries_.size()) - 1; }
+    [[nodiscard]] KeyType operator[](int rank) const { return rankBoundaries_[rank]; }
+    [[nodiscard]] LocalIndex totalCount(int rank) const { return counts_[rank]; }
 
-    [[nodiscard]] TreeNodeIndex firstNodeIdx(int rank) const { return rankAssignment_[rank]; }
-
-    [[nodiscard]] TreeNodeIndex lastNodeIdx(int rank) const { return rankAssignment_[rank + 1]; }
-
-    [[nodiscard]] int findRank(TreeNodeIndex nodeIdx) const
+    [[nodiscard]] int findRank(KeyType key) const
     {
-        auto it = std::upper_bound(begin(rankAssignment_), end(rankAssignment_), nodeIdx);
-        return int(it - begin(rankAssignment_)) - 1;
+        auto it = std::upper_bound(begin(rankBoundaries_), end(rankBoundaries_), key);
+        return int(it - begin(rankBoundaries_)) - 1;
     }
-
-    //! @brief the sum of number of particles in all ranges, i.e. total number of assigned particles per range
-    [[nodiscard]] const std::size_t& totalCount(int rank) const { return counts_[rank]; }
 
 private:
-    friend bool operator==(const SpaceCurveAssignment& a, const SpaceCurveAssignment& b)
-    {
-        return a.rankAssignment_ == b.rankAssignment_ && a.counts_ == b.counts_;
-    }
-
-    std::vector<TreeNodeIndex> rankAssignment_;
-    std::vector<size_t> counts_;
+    std::vector<KeyType> rankBoundaries_;
+    std::vector<LocalIndex> counts_;
 };
 
-/*! @brief assign the global tree/SFC to nSplits ranks, assigning to each rank only a single Morton code range
- *
- * @param globalCounts       counts per leaf
- * @param nSplits            divide the global tree into nSplits pieces, sensible choice e.g.: nSplits == numRanks
- * @return                   a vector with nSplit elements, each element is a vector of SfcRanges of Morton codes
- *
- * This function acts on global data. All calling ranks should call this function with identical arguments.
- * Therefore each rank will compute the same SpaceCurveAssignment and each rank will thus know the ranges that
- * all the ranks are assigned.
- *
- */
-inline SpaceCurveAssignment singleRangeSfcSplit(const std::vector<unsigned>& globalCounts, int nSplits)
+template<class KeyType>
+SfcAssignment<KeyType> makeSfcAssignment(int numRanks, const std::vector<unsigned>& counts, const KeyType* tree)
 {
-    // one element per rank
-    SpaceCurveAssignment ret(nSplits);
-
-    std::size_t globalNParticles = std::accumulate(begin(globalCounts), end(globalCounts), std::size_t(0));
-
-    // distribute work, every rank gets global count / nSplits,
-    // the remainder gets distributed one by one
-    std::vector<std::size_t> nParticlesPerSplit(nSplits, globalNParticles / nSplits);
-    for (std::size_t split = 0; split < globalNParticles % nSplits; ++split)
-    {
-        nParticlesPerSplit[split]++;
-    }
-
-    TreeNodeIndex leavesDone = 0;
-    for (int split = 0; split < nSplits; ++split)
-    {
-        std::size_t targetCount = nParticlesPerSplit[split];
-        std::size_t splitCount  = 0;
-        TreeNodeIndex j         = leavesDone;
-        while (splitCount < targetCount && j < TreeNodeIndex(globalCounts.size()))
-        {
-            // if adding the particles of the next leaf takes us further away from
-            // the target count than where we're now, we stop
-            if (targetCount < splitCount + globalCounts[j] &&                          // overshoot
-                targetCount - splitCount < splitCount + globalCounts[j] - targetCount) // overshoot more than undershoot
-            {
-                break;
-            }
-
-            splitCount += globalCounts[j++];
-        }
-
-        if (split < nSplits - 1)
-        {
-            // carry over difference of particles over/under assigned to next split
-            // to avoid accumulating round off
-            long int delta = (long int)(targetCount) - (long int)(splitCount);
-            nParticlesPerSplit[split + 1] += delta;
-        }
-        // afaict, j < nNodes(globalTree) can only happen if there are empty nodes at the end
-        else
-        {
-            for (; j < TreeNodeIndex(globalCounts.size()); ++j)
-                splitCount += globalCounts[j];
-        }
-
-        // other distribution strategies might have more than one range per rank
-        ret.addRange(split, leavesDone, j, splitCount);
-        leavesDone = j;
-    }
+    SfcAssignment<KeyType> ret(numRanks);
+    std::vector<TreeNodeIndex> nodeBins(numRanks + 1);
+    uniformBins(counts, nodeBins, {ret.counts(), size_t(numRanks)});
+    gather(gsl::span<const TreeNodeIndex>{nodeBins.data(), nodeBins.size()}, tree, ret.data());
 
     return ret;
 }
@@ -177,63 +126,42 @@ inline SpaceCurveAssignment singleRangeSfcSplit(const std::vector<unsigned>& glo
 /*! @brief limit SFC range assignment transfer to the domain of the rank above or below
  *
  * @tparam        KeyType          32- or 64-bit unsigned integer
- * @param[in]     oldBoundaries    SFC key assignment boundaries to ranks from the previous step
- * @param[in]     newTree          the global octree leaves used for domain decomposition in the current step
- * @param[in]     counts           particle counts per leaf cell in @p newTree
+ * @param[in]     oldAssignment    SFC key assignment boundaries to ranks from the previous step
  * @param[inout]  newAssignment    the current assignment, will be modified if needed
+ * @param[in]     tree             the global octree leaves used for domain decomposition in the current step
+ * @param[in]     counts           particle counts per leaf cell in @p newTree
  *
  * When assignment boundaries change, we limit the growth of any rank downwards or upwards the SFC
  * to the previous assignment of the rank below or above, i.e. rank r can only acquire new SFC areas
- * that belonged to ranks r-1 or r+1 in the previous step. This limitation never kicks in for any
- * halfway reasonable particle configuration as the handover of a rank's entire domain to another rank
- * is quite an extreme scenario. But the limitation is useful for focused torture tests to demonstrate
- * that the domain and octree invariants still hold under such circumstances. Imposing this limitation
- * here is needed to guarantee that the focus tree resolution of any rank in its focus is not exceeded
- * in the trees of any other rank.
+ * that belonged to ranks r-1 or r+1 in the previous step. Only required in extreme cases or testing scenarios
+ * to guarantee that the in-focus LET resolution is never exceeded in the trees of other ranks.
  */
 template<class KeyType>
-void limitBoundaryShifts(gsl::span<const KeyType> oldBoundaries,
-                         gsl::span<const KeyType> newTree,
-                         gsl::span<const unsigned> counts,
-                         SpaceCurveAssignment& newAssignment)
+void limitBoundaryShifts(const SfcAssignment<KeyType> oldAssignment,
+                         SfcAssignment<KeyType>& newAssignment,
+                         gsl::span<const KeyType> tree,
+                         gsl::span<const unsigned> counts)
 {
-    // do nothing on first call when there are no boundaries
-    if (oldBoundaries.size() == 1) { return; }
-
-    int numRanks = newAssignment.numRanks();
-    std::vector<TreeNodeIndex> newIndexBoundaries(numRanks + 1, 0);
-    newIndexBoundaries.back() = newAssignment.lastNodeIdx(numRanks - 1);
+    int numRanks = std::min(oldAssignment.numRanks(), newAssignment.numRanks()); // oldAssignment empty on first call
 
     bool triggerRecount = false;
     for (int rank = 1; rank < numRanks; ++rank)
     {
-        KeyType newBoundary = newTree[newAssignment.firstNodeIdx(rank)];
-
-        KeyType doNotGoBelow = oldBoundaries[rank - 1];
-        KeyType doNotExceed  = oldBoundaries[rank + 1];
-
-        TreeNodeIndex restrictedStart = newAssignment.firstNodeIdx(rank);
-        if (newBoundary < doNotGoBelow)
+        KeyType newBoundary = std::min(std::max(newAssignment[rank], oldAssignment[rank - 1]), oldAssignment[rank + 1]);
+        if (newBoundary != newAssignment[rank])
         {
-            restrictedStart = findNodeAbove(newTree.data(), newTree.size(), doNotGoBelow);
-            triggerRecount  = true;
+            triggerRecount             = true;
+            newAssignment.data()[rank] = newBoundary;
         }
-        else if (newBoundary > doNotExceed)
-        {
-            restrictedStart = findNodeBelow(newTree.data(), newTree.size(), doNotExceed);
-            triggerRecount  = true;
-        }
-        newIndexBoundaries[rank] = restrictedStart;
     }
+    if (!triggerRecount) { return; }
 
-    if (triggerRecount)
+    for (int rank = 0; rank < numRanks; ++rank)
     {
-        for (int rank = 0; rank < numRanks; ++rank)
-        {
-            std::size_t segmentCount = std::accumulate(counts.begin() + newIndexBoundaries[rank],
-                                                       counts.begin() + newIndexBoundaries[rank + 1], std::size_t(0));
-            newAssignment.addRange(rank, newIndexBoundaries[rank], newIndexBoundaries[rank + 1], segmentCount);
-        }
+        auto a                       = findNodeAbove(tree.data(), nNodes(tree), newAssignment[rank]);
+        auto b                       = findNodeAbove(tree.data(), nNodes(tree), newAssignment[rank + 1]);
+        std::size_t rankCount        = std::accumulate(counts.begin() + a, counts.begin() + b, std::size_t(0));
+        newAssignment.counts()[rank] = rankCount;
     }
 }
 
@@ -241,7 +169,6 @@ void limitBoundaryShifts(gsl::span<const KeyType> oldBoundaries,
  *
  * @tparam     KeyType         32- or 64-bit unsigned integer
  * @param[in]  assignment      domain assignment
- * @param[in]  domainTree      domain tree leaves
  * @param[in]  focusTree       focus tree leaves
  * @param[in]  peerRanks       list of peer ranks
  * @param[in]  myRank          executing rank ID
@@ -254,8 +181,7 @@ void limitBoundaryShifts(gsl::span<const KeyType> oldBoundaries,
  * of SpaceCurveAssignment are not met and its findRank() function would not work.
  */
 template<class KeyType>
-void translateAssignment(const SpaceCurveAssignment& assignment,
-                         gsl::span<const KeyType> domainTree,
+void translateAssignment(const SfcAssignment<KeyType>& assignment,
                          gsl::span<const KeyType> focusTree,
                          gsl::span<const int> peerRanks,
                          int myRank,
@@ -265,23 +191,17 @@ void translateAssignment(const SpaceCurveAssignment& assignment,
     std::fill(focusAssignment.begin(), focusAssignment.end(), TreeIndexPair(0, 0));
     for (int peer : peerRanks)
     {
-        KeyType peerSfcStart = domainTree[assignment.firstNodeIdx(peer)];
-        KeyType peerSfcEnd   = domainTree[assignment.lastNodeIdx(peer)];
-
         // Note: start-end range is narrowed down if no exact match is found.
         // the discarded part will not participate in peer/halo exchanges
-        TreeNodeIndex startIndex = findNodeAbove(focusTree.data(), focusTree.size(), peerSfcStart);
-        TreeNodeIndex endIndex   = findNodeBelow(focusTree.data(), focusTree.size(), peerSfcEnd);
+        TreeNodeIndex startIndex = findNodeAbove(focusTree.data(), focusTree.size(), assignment[peer]);
+        TreeNodeIndex endIndex   = findNodeBelow(focusTree.data(), focusTree.size(), assignment[peer + 1]);
 
         if (endIndex < startIndex) { endIndex = startIndex; }
         focusAssignment[peer] = TreeIndexPair(startIndex, endIndex);
     }
 
-    KeyType startKey = domainTree[assignment.firstNodeIdx(myRank)];
-    KeyType endKey   = domainTree[assignment.lastNodeIdx(myRank)];
-
-    TreeNodeIndex newStartIndex = findNodeAbove(focusTree.data(), focusTree.size(), startKey);
-    TreeNodeIndex newEndIndex   = findNodeBelow(focusTree.data(), focusTree.size(), endKey);
+    TreeNodeIndex newStartIndex = findNodeAbove(focusTree.data(), focusTree.size(), assignment[myRank]);
+    TreeNodeIndex newEndIndex   = findNodeBelow(focusTree.data(), focusTree.size(), assignment[myRank + 1]);
     focusAssignment[myRank]     = TreeIndexPair(newStartIndex, newEndIndex);
 }
 
@@ -289,23 +209,20 @@ void translateAssignment(const SpaceCurveAssignment& assignment,
  *
  * @tparam KeyType      32- or 64-bit integer
  * @param assignment    global space curve assignment to ranks
- * @param tree          global cornerstone octree that matches the node counts used to create @p assignment
  * @param particleKeys  sorted list of SFC keys of local particles present on this rank
  * @return              for each rank, a list of index ranges into @p particleKeys to send
  *
  * Converts the global assignment particle keys ranges into particle indices with binary search
  */
 template<class KeyType>
-SendRanges createSendRanges(const SpaceCurveAssignment& assignment,
-                            gsl::span<const KeyType> treeLeaves,
-                            gsl::span<const KeyType> particleKeys)
+SendRanges createSendRanges(const SfcAssignment<KeyType>& assignment, gsl::span<const KeyType> particleKeys)
 {
     int numRanks = assignment.numRanks();
 
     SendRanges ret(numRanks + 1);
     for (int rank = 0; rank < numRanks; ++rank)
     {
-        KeyType rangeStart = treeLeaves[assignment.firstNodeIdx(rank)];
+        KeyType rangeStart = assignment[rank];
         ret[rank] = std::lower_bound(particleKeys.begin(), particleKeys.end(), rangeStart) - particleKeys.begin();
     }
     ret.back() = particleKeys.size();

--- a/domain/test/integration_mpi/exchange_general.cpp
+++ b/domain/test/integration_mpi/exchange_general.cpp
@@ -76,14 +76,14 @@ static void generalExchangeRandomGaussian(int thisRank, int numRanks)
     Octree<KeyType> domainTree;
     domainTree.update(tree.data(), nNodes(tree));
 
-    auto assignment = singleRangeSfcSplit(counts, numRanks);
+    auto assignment = makeSfcAssignment(numRanks, counts, tree.data());
 
     // *******************************
 
     auto peers = findPeersMac(thisRank, assignment, domainTree, box, invThetaEff);
 
-    KeyType focusStart = tree[assignment.firstNodeIdx(thisRank)];
-    KeyType focusEnd   = tree[assignment.lastNodeIdx(thisRank)];
+    KeyType focusStart = assignment[thisRank];
+    KeyType focusEnd   = assignment[thisRank + 1];
 
     // locate particles assigned to thisRank
     auto firstAssignedIndex = findNodeAbove(coords.particleKeys().data(), coords.particleKeys().size(), focusStart);
@@ -183,14 +183,14 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
     Octree<KeyType> domainTree;
     domainTree.update(tree.data(), nNodes(tree));
 
-    auto assignment = singleRangeSfcSplit(counts, numRanks);
+    auto assignment = makeSfcAssignment(numRanks, counts, tree.data());
 
     /*******************************/
 
     auto peers = findPeersMac(thisRank, assignment, domainTree, box, invThetaEff);
 
-    KeyType focusStart = tree[assignment.firstNodeIdx(thisRank)];
-    KeyType focusEnd   = tree[assignment.lastNodeIdx(thisRank)];
+    KeyType focusStart = assignment[thisRank];
+    KeyType focusEnd   = assignment[thisRank + 1];
 
     // locate particles assigned to thisRank
     auto firstAssignedIndex = findNodeAbove(coords.particleKeys().data(), coords.particleKeys().size(), focusStart);
@@ -212,7 +212,7 @@ static void generalExchangeSourceCenter(int thisRank, int numRanks)
 
     auto octree = focusTree.octreeViewAcc();
 
-    focusTree.updateCenters(x.data(), y.data(), z.data(), m.data(), assignment, domainTree, box);
+    focusTree.updateCenters(x.data(), y.data(), z.data(), m.data(), domainTree, box);
     auto sourceCenter = focusTree.expansionCenters();
 
     constexpr T tol = std::is_same_v<T, double> ? 1e-10 : 1e-4;

--- a/domain/test/integration_mpi/focus_tree.cpp
+++ b/domain/test/integration_mpi/focus_tree.cpp
@@ -75,7 +75,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
     Octree<KeyType> domainTree;
     domainTree.update(tree.data(), nNodes(tree));
 
-    auto assignment = singleRangeSfcSplit(counts, numRanks);
+    auto assignment = makeSfcAssignment(numRanks, counts, tree.data());
 
     /*******************************/
 
@@ -85,12 +85,12 @@ void globalRandomGaussian(int thisRank, int numRanks)
     std::vector<KeyType> peerBoundaries;
     for (auto peer : peers)
     {
-        peerBoundaries.push_back(tree[assignment.firstNodeIdx(peer)]);
-        peerBoundaries.push_back(tree[assignment.lastNodeIdx(peer)]);
+        peerBoundaries.push_back(assignment[peer]);
+        peerBoundaries.push_back(assignment[peer + 1]);
     }
 
-    KeyType focusStart = tree[assignment.firstNodeIdx(thisRank)];
-    KeyType focusEnd   = tree[assignment.lastNodeIdx(thisRank)];
+    KeyType focusStart = assignment[thisRank];
+    KeyType focusEnd   = assignment[thisRank + 1];
 
     // build the reference focus tree from the common pool of coordinates, focused on the executing rank
     FocusedOctreeSingleNode<KeyType> referenceFocusTree(bucketSizeLocal, theta);
@@ -127,9 +127,9 @@ void globalRandomGaussian(int thisRank, int numRanks)
     int converged = 0;
     while (converged != numRanks)
     {
-        converged = focusTree.updateTree(peers, assignment, tree);
+        converged = focusTree.updateTree(peers, assignment);
         focusTree.updateCounts(particleKeys, tree, counts);
-        focusTree.updateMinMac(box, assignment, tree, invThetaEff);
+        focusTree.updateMinMac(box, assignment, invThetaEff);
         MPI_Allreduce(MPI_IN_PLACE, &converged, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
 
         // particle counts must always be valid, whatever state of convergence
@@ -158,6 +158,5 @@ TEST(GlobalTreeDomain, randomGaussian)
 
     globalRandomGaussian<unsigned, double>(rank, nRanks);
     globalRandomGaussian<uint64_t, double>(rank, nRanks);
-    globalRandomGaussian<unsigned, float>(rank, nRanks);
     globalRandomGaussian<uint64_t, float>(rank, nRanks);
 }

--- a/domain/test/integration_mpi/treedomain.cpp
+++ b/domain/test/integration_mpi/treedomain.cpp
@@ -89,8 +89,8 @@ void globalRandomGaussian(int thisRank, int numRanks)
     // particles are in SFC order
     std::iota(begin(ordering), end(ordering), 0);
 
-    auto assignment = singleRangeSfcSplit(counts, numRanks);
-    auto sends      = createSendRanges<KeyType>(assignment, tree, coords.particleKeys());
+    auto assignment = makeSfcAssignment(numRanks, counts, tree.data());
+    auto sends      = createSendRanges<KeyType>(assignment, coords.particleKeys());
 
     EXPECT_EQ(std::accumulate(begin(counts), end(counts), std::size_t(0)), numParticles * numRanks);
 
@@ -130,7 +130,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
     EXPECT_EQ(tree, newTree);
     EXPECT_EQ(counts, newCounts);
 
-    auto newSends = createSendRanges<KeyType>(assignment, newTree, {newCodes.data(), numAssigned});
+    auto newSends = createSendRanges<KeyType>(assignment, {newCodes.data(), numAssigned});
 
     for (int rank = 0; rank < numRanks; ++rank)
     {
@@ -149,7 +149,6 @@ TEST(GlobalTreeDomain, randomGaussian)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nRanks);
 
-    globalRandomGaussian<unsigned, double>(rank, nRanks);
     globalRandomGaussian<uint64_t, double>(rank, nRanks);
     globalRandomGaussian<unsigned, float>(rank, nRanks);
     globalRandomGaussian<uint64_t, float>(rank, nRanks);

--- a/domain/test/performance/peers.cpp
+++ b/domain/test/performance/peers.cpp
@@ -52,8 +52,8 @@ int main()
     Octree<KeyType> octree;
     octree.update(treeLeaves.data(), nNodes(treeLeaves));
 
-    SpaceCurveAssignment assignment = singleRangeSfcSplit(counts, numRanks);
-    int probeRank                   = numRanks / 2;
+    auto assignment = makeSfcAssignment(numRanks, counts, treeLeaves.data());
+    int probeRank   = numRanks / 2;
 
     auto tp0                  = std::chrono::high_resolution_clock::now();
     std::vector<int> peersDtt = findPeersMac(probeRank, assignment, octree, box, invThetaMinMac(0.5f));

--- a/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
+++ b/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
@@ -45,9 +45,10 @@ static void sendListMinimalGpu()
     std::vector<KeyType> codes{0, 0, 1, 3, 4, 5, 6, 6, 9};
 
     int numRanks = 2;
-    SpaceCurveAssignment assignment(numRanks);
-    assignment.addRange(0, 0, 2, 0);
-    assignment.addRange(1, 2, 4, 0);
+    SfcAssignment<KeyType> assignment(numRanks);
+    assignment.set(0, tree[0], 0);
+    assignment.set(1, tree[2], 0);
+    assignment.set(2, tree[4], 0);
 
     thrust::device_vector<KeyType> d_keys = codes;
     thrust::device_vector<KeyType> d_searchKeys(numRanks);
@@ -56,7 +57,7 @@ static void sendListMinimalGpu()
     gsl::span<const KeyType> d_keyView{rawPtr(d_keys), d_keys.size()};
 
     // note: codes input needs to be sorted
-    auto sendList = createSendRangesGpu<KeyType>(assignment, tree, d_keyView, rawPtr(d_searchKeys), rawPtr(d_indices));
+    auto sendList = createSendRangesGpu(assignment, d_keyView, rawPtr(d_searchKeys), rawPtr(d_indices));
 
     EXPECT_EQ(sendList.count(0), 6);
     EXPECT_EQ(sendList.count(1), 3);

--- a/main/src/init/evrard_init.hpp
+++ b/main/src/init/evrard_init.hpp
@@ -124,10 +124,10 @@ std::tuple<KeyType, KeyType> estimateEvrardSfcPartition(size_t cbrtNumPart, cons
         else { return T(numParticlesGlobal) / (2 * M_PI * radius); }
     };
 
-    auto [tree, counts]            = cstone::computeContinuumCsarray<KeyType>(oneOverR, box, bucketSize);
-    cstone::SpaceCurveAssignment a = cstone::singleRangeSfcSplit(counts, numRanks);
+    auto [tree, counts] = cstone::computeContinuumCsarray<KeyType>(oneOverR, box, bucketSize);
+    auto a              = cstone::makeSfcAssignment(numRanks, counts, tree.data());
 
-    return {tree[a.firstNodeIdx(rank)], tree[a.lastNodeIdx(rank)]};
+    return {a[rank], a[rank + 1]};
 }
 
 template<class Dataset>


### PR DESCRIPTION
Storing the SFC keys in the assignment instead of tree node indices simplifies the code.