### PR TITLE
Improve LET updates to keep up with block-time-steps

### DIFF
--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -217,18 +217,15 @@ public:
         float invThetaEff      = invThetaMinMac(theta_);
         std::vector<int> peers = findPeersMac(myRank_, global_.assignment(), global_.octree(), box(), invThetaEff);
 
-        if (firstCall_ || convergeTrees)
+        if (firstCall_)
         {
             focusTree_.converge(box(), keyView, peers, global_.assignment(), global_.treeLeaves(), global_.nodeCounts(),
                                 invThetaEff, std::get<0>(scratch));
         }
-        else
-        {
-            focusTree_.updateMinMac(box(), global_.assignment(), invThetaEff);
-            focusTree_.updateTree(peers, global_.assignment(), box());
-            focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
-            focusTree_.updateGeoCenters(box());
-        }
+        focusTree_.updateMinMac(box(), global_.assignment(), invThetaEff);
+        focusTree_.updateTree(peers, global_.assignment(), box());
+        focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
+        focusTree_.updateGeoCenters(box());
 
         auto octreeView            = focusTree_.octreeViewAcc();
         const KeyType* focusLeaves = focusTree_.treeLeavesAcc().data();

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -225,7 +225,7 @@ public:
         else
         {
             focusTree_.updateMinMac(box(), global_.assignment(), invThetaEff);
-            focusTree_.updateTree(peers, global_.assignment());
+            focusTree_.updateTree(peers, global_.assignment(), box());
             focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
             focusTree_.updateGeoCenters(box());
         }
@@ -279,7 +279,7 @@ public:
             int converged = 0, reps = 0;
             while (converged != numRanks_ || reps < 2)
             {
-                converged = focusTree_.updateTree(peers, global_.assignment());
+                converged = focusTree_.updateTree(peers, global_.assignment(), box());
                 focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
                 focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), box(),
                                          std::get<0>(scratch), std::get<1>(scratch));
@@ -293,7 +293,7 @@ public:
         do
         {
             focusTree_.updateMacs(box(), global_.assignment(), centerDriftTol_ / theta_);
-            focusTree_.updateTree(peers, global_.assignment());
+            focusTree_.updateTree(peers, global_.assignment(), box());
             focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
             focusTree_.updateCenters(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(m), global_.octree(), box(),
                                      std::get<0>(scratch), std::get<1>(scratch));

--- a/domain/include/cstone/focus/exchange_focus.hpp
+++ b/domain/include/cstone/focus/exchange_focus.hpp
@@ -49,6 +49,7 @@
 #include "cstone/domain/index_ranges.hpp"
 #include "cstone/primitives/gather.hpp"
 #include "cstone/primitives/mpi_wrappers.hpp"
+#include "cstone/primitives/primitives_gpu.h"
 #include "cstone/tree/csarray.hpp"
 #include "cstone/tree/octree.hpp"
 #include "cstone/util/gsl-lite.hpp"
@@ -308,6 +309,42 @@ void syncTreelets(gsl::span<const int> peers,
     }
 
     indexTreelets<KeyType>(octree.prefixes, octree.levelRange, treelets, treeletIdx);
+}
+
+template<class KeyType, class DAlloc>
+void syncTreeletsGpu(gsl::span<const int> peers,
+                     gsl::span<const IndexPair<TreeNodeIndex>> assignment,
+                     const std::vector<KeyType>& leaves,
+                     OctreeData<KeyType, GpuTag>& octreeAcc,
+                     thrust::device_vector<KeyType, DAlloc>& leavesAcc,
+                     std::vector<std::vector<KeyType>>& treelets,
+                     std::vector<std::vector<TreeNodeIndex>>& treeletIdx)
+{
+    exchangeTreelets<KeyType>(peers, assignment, leaves, treelets);
+    checkTreelets<KeyType>(leaves, treelets, treeletIdx);
+
+    std::vector<TreeNodeIndex> nodeOps(leaves.size(), 1);
+    exchangeRejectedKeys<KeyType>(peers, leaves, treelets, treeletIdx, nodeOps);
+    pruneTreelets<KeyType>(peers, treelets, treeletIdx);
+
+    if (std::count(nodeOps.begin(), nodeOps.end(), 1) != nodeOps.size())
+    {
+        assert(octreeAcc.childOffsets.size() >= nodeOps.size());
+        gsl::span<TreeNodeIndex> nops(rawPtr(octreeAcc.childOffsets), nodeOps.size());
+        memcpyH2D(rawPtr(nodeOps), nodeOps.size(), nops.data());
+
+        exclusiveScanGpu(nops.data(), nops.data() + nops.size(), nops.data());
+        TreeNodeIndex newNumLeafNodes;
+        memcpyD2H(nops.data() + nops.size() - 1, 1, &newNumLeafNodes);
+
+        auto& newLeaves = octreeAcc.prefixes;
+        reallocateDestructive(newLeaves, newNumLeafNodes + 1, 1.05);
+        rebalanceTreeGpu(rawPtr(leavesAcc), nNodes(leavesAcc), newNumLeafNodes, nops.data(), rawPtr(newLeaves));
+        swap(newLeaves, leavesAcc);
+
+        octreeAcc.resize(nNodes(leavesAcc));
+        buildOctreeGpu(rawPtr(leavesAcc), octreeAcc.data());
+    }
 }
 
 template<class T>

--- a/domain/include/cstone/focus/octree_focus.hpp
+++ b/domain/include/cstone/focus/octree_focus.hpp
@@ -290,7 +290,7 @@ public:
         TreeNodeIndex fStart = findNodeAbove(rawPtr(leaves_), nNodes(leaves_), focusStart);
         TreeNodeIndex fEnd   = findNodeAbove(rawPtr(leaves_), nNodes(leaves_), focusEnd);
         markMacs(tree_.prefixes.data(), tree_.childOffsets.data(), centers_.data(), box, rawPtr(leaves_) + fStart,
-                 fEnd - fStart, macs_.data());
+                 fEnd - fStart, false, macs_.data());
 
         leafCounts_.resize(nNodes(leaves_));
         computeNodeCounts(leaves_.data(), leafCounts_.data(), nNodes(leaves_), particleKeys.data(),

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -148,6 +148,11 @@ public:
                                                              enforcedKeys, counts_, macs_);
         }
         downloadOctree();
+        translateAssignment<KeyType>(assignment, leaves_, peers_, myRank_, assignment_);
+
+        std::vector<TreeNodeIndex> nodeOps(leaves_.size(), 1);
+        exchangeTreelets<KeyType>(peers_, assignment_, leaves_, treeData_.prefixes, treeData_.levelRange, treelets_,
+                                  nodeOps);
 
         translateAssignment<KeyType>(assignment, leaves_, peers_, myRank_, assignment_);
 
@@ -179,7 +184,6 @@ public:
                       DeviceVector&& /*scratch*/ = std::vector<KeyType>{})
     {
         gsl::span<const KeyType> leaves(leaves_);
-        exchangeTreelets<KeyType>(peers_, assignment_, leaves, treeData_.prefixes, treeData_.levelRange, treelets_);
 
         leafCounts_.resize(nNodes(leaves_));
         if constexpr (HaveGpu<Accelerator>{})
@@ -219,7 +223,7 @@ public:
         }
 
         // counts from neighboring peers
-        constexpr int countTag = static_cast<int>(P2pTags::focusPeerCounts) + 1;
+        constexpr int countTag = static_cast<int>(P2pTags::focusPeerCounts);
         peerExchange(gsl::span<unsigned>(counts_), countTag);
 
         // 2nd upsweep with peer and global data present

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -467,7 +467,7 @@ public:
             reallocate(macsAcc_, octreeAcc_.numNodes, allocGrowthRate_);
             fillGpu(rawPtr(macsAcc_), rawPtr(macsAcc_) + macsAcc_.size(), char(0));
             markMacsGpu(rawPtr(octreeAcc_.prefixes), rawPtr(octreeAcc_.childOffsets), rawPtr(centersAcc_), box,
-                        rawPtr(leavesAcc_) + fAssignStart, fAssignEnd - fAssignStart, rawPtr(macsAcc_));
+                        rawPtr(leavesAcc_) + fAssignStart, fAssignEnd - fAssignStart, false, rawPtr(macsAcc_));
 
             memcpyD2H(rawPtr(macsAcc_), macsAcc_.size(), macs_.data());
         }
@@ -475,7 +475,7 @@ public:
         {
             std::fill(rawPtr(macs_), rawPtr(macs_) + macs_.size(), char(0));
             markMacs(rawPtr(treeData_.prefixes), rawPtr(treeData_.childOffsets), rawPtr(centers_), box,
-                     rawPtr(leaves_) + fAssignStart, fAssignEnd - fAssignStart, rawPtr(macs_));
+                     rawPtr(leaves_) + fAssignStart, fAssignEnd - fAssignStart, false, rawPtr(macs_));
         }
 
         rebalanceStatus_ |= macCriterion;

--- a/domain/include/cstone/focus/rebalance.hpp
+++ b/domain/include/cstone/focus/rebalance.hpp
@@ -87,6 +87,15 @@ inline HOST_DEVICE_FUN int mergeCountAndMacOp(TreeNodeIndex nodeIdx,
     return 1; // default: do nothing
 }
 
+//! @brief refine nodes based on Mac only
+template<class KeyType>
+inline HOST_DEVICE_FUN int macRefineOp(KeyType nodeKey, char mac)
+{
+    unsigned level = decodePrefixLength(nodeKey) / 3;
+    if (level < maxTreeLevel<KeyType>{} && mac) { return 8; }
+    return 1;
+}
+
 /*! @brief Overrides a 0-value of nodeOps[nodeIdx] if @p nodeIdx is the left-most descendant of a non-zero ancestor
  *
  * @tparam KeyType

--- a/domain/include/cstone/focus/rebalance_gpu.h
+++ b/domain/include/cstone/focus/rebalance_gpu.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "cstone/tree/definitions.h"
+#include "cstone/domain/index_ranges.hpp"
 
 namespace cstone
 {
@@ -46,6 +47,23 @@ extern void rebalanceDecisionEssentialGpu(const KeyType* prefixes,
                                           unsigned bucketSize,
                                           TreeNodeIndex* nodeOps,
                                           TreeNodeIndex numNodes);
+
+/*! @brief Take decision how to refine nodes based on Macs
+ *
+ * @param[in]  prefixes       WS-SFC key of each node, length numNodes
+ * @param[in]  macs           mac evaluation result flags, length numNodes
+ * @param[in]  l2i            translates indices in [0:numLeafNodes] to [0:numNodes] to access prefixes and macs
+ * @param[in]  numLeafNodes   number of leaf nodes
+ * @param[in]  focus          index range within [0:numLeafNodes] that corresponds to nodes in focus
+ * @param[out] nodeOps        output refinement decision per leaf node
+ */
+template<class KeyType>
+extern void macRefineDecisionGpu(const KeyType* prefixes,
+                                 const char* macs,
+                                 const TreeNodeIndex* l2i,
+                                 TreeNodeIndex numLeafNodes,
+                                 TreeIndexPair focus,
+                                 TreeNodeIndex* nodeOps);
 
 template<class KeyType>
 extern bool protectAncestorsGpu(const KeyType*, const TreeNodeIndex*, TreeNodeIndex*, TreeNodeIndex);

--- a/domain/include/cstone/focus/source_center.hpp
+++ b/domain/include/cstone/focus/source_center.hpp
@@ -156,4 +156,15 @@ void nodeFpCenters(gsl::span<const KeyType> prefixes, Vec3<T>* centers, Vec3<T>*
     }
 }
 
+//! @brief set @p centers to geometric node centers with Mac radius l * invTheta
+template<class KeyType, class T>
+void geoMacSpheres(gsl::span<const KeyType> prefixes, SourceCenterType<T>* centers, float invTheta, const Box<T>& box)
+{
+#pragma omp parallel for schedule(static)
+    for (TreeNodeIndex i = 0; i < prefixes.ssize(); ++i)
+    {
+        centers[i] = computeMinMacR2(prefixes[i], invTheta, box);
+    }
+}
+
 } // namespace cstone

--- a/domain/include/cstone/focus/source_center_gpu.h
+++ b/domain/include/cstone/focus/source_center_gpu.h
@@ -75,6 +75,11 @@ template<class KeyType, class T>
 extern void computeGeoCentersGpu(
     const KeyType* prefixes, TreeNodeIndex numNodes, Vec3<T>* centers, Vec3<T>* sizes, const Box<T>& box);
 
+//! @brief set @p centers to geometric node centers with Mac radius l * invTheta
+template<class KeyType, class T>
+extern void geoMacSpheresGpu(
+    const KeyType* prefixes, TreeNodeIndex numNodes, SourceCenterType<T>* centers, float invTheta, const Box<T>& box);
+
 template<class KeyType, class T>
 extern void
 setMacGpu(const KeyType* prefixes, TreeNodeIndex numNodes, Vec4<T>* macSpheres, float invTheta, const Box<T>& box);

--- a/domain/include/cstone/sfc/common.hpp
+++ b/domain/include/cstone/sfc/common.hpp
@@ -196,6 +196,14 @@ HOST_DEVICE_FUN constexpr KeyType encodePlaceholderBit(KeyType code, int prefixL
     return placeHolderMask | ret;
 }
 
+template<class KeyType>
+HOST_DEVICE_FUN constexpr KeyType encodePlaceholderBit2K(KeyType k1, KeyType k2)
+{
+    //! prefixLength is 3 * treeLevel(endKey - startKey)
+    unsigned prefixLength = countLeadingZeros(k2 - k1 - 1) - unusedBits<KeyType>{};
+    return encodePlaceholderBit(k1, prefixLength);
+}
+
 //! @brief returns the number of key-bits in the input @p code
 template<class KeyType>
 HOST_DEVICE_FUN constexpr unsigned decodePrefixLength(KeyType code)

--- a/domain/include/cstone/traversal/collisions_gpu.cu
+++ b/domain/include/cstone/traversal/collisions_gpu.cu
@@ -121,6 +121,7 @@ __global__ void markMacsGpuKernel(const KeyType* prefixes,
                                   const Box<T> box,
                                   const KeyType* focusNodes,
                                   TreeNodeIndex numFocusNodes,
+                                  bool limitSource,
                                   char* markings)
 {
     unsigned tid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -136,8 +137,10 @@ __global__ void markMacsGpuKernel(const KeyType* prefixes,
     if (containedIn(focusStart, focusEnd, targetExt)) { return; }
 
     auto [targetCenter, targetSize] = centerAndSize<KeyType>(target, box);
-    markMacPerBox(targetCenter, targetSize, maxTreeLevel<KeyType>{}, prefixes, childOffsets, centers, box, focusStart,
-                  focusEnd, markings);
+    unsigned maxLevel               = maxTreeLevel<KeyType>{};
+    if (limitSource) { maxLevel = stl::max(int(treeLevel(focusNodes[tid + 1] - focusNodes[tid])) - 1, 0); }
+    markMacPerBox(targetCenter, targetSize, maxLevel, prefixes, childOffsets, centers, box, focusStart, focusEnd,
+                  markings);
 }
 
 template<class T, class KeyType>
@@ -147,19 +150,20 @@ void markMacsGpu(const KeyType* prefixes,
                  const Box<T>& box,
                  const KeyType* focusNodes,
                  TreeNodeIndex numFocusNodes,
+                 bool limitSource,
                  char* markings)
 {
     constexpr unsigned numThreads = 128;
     unsigned numBlocks            = iceil(numFocusNodes, numThreads);
 
     markMacsGpuKernel<<<numBlocks, numThreads>>>(prefixes, childOffsets, centers, box, focusNodes, numFocusNodes,
-                                                 markings);
+                                                 limitSource, markings);
 }
 
 #define MARK_MACS_GPU(KeyType, T)                                                                                      \
     template void markMacsGpu(const KeyType* prefixes, const TreeNodeIndex* childOffsets, const Vec4<T>* centers,      \
                               const Box<T>& box, const KeyType* focusNodes, TreeNodeIndex numFocusNodes,               \
-                              char* markings)
+                              bool limitSource, char* markings)
 
 MARK_MACS_GPU(uint64_t, double);
 MARK_MACS_GPU(uint64_t, float);

--- a/domain/include/cstone/traversal/collisions_gpu.cu
+++ b/domain/include/cstone/traversal/collisions_gpu.cu
@@ -136,7 +136,8 @@ __global__ void markMacsGpuKernel(const KeyType* prefixes,
     if (containedIn(focusStart, focusEnd, targetExt)) { return; }
 
     auto [targetCenter, targetSize] = centerAndSize<KeyType>(target, box);
-    markMacPerBox(targetCenter, targetSize, prefixes, childOffsets, centers, box, focusStart, focusEnd, markings);
+    markMacPerBox(targetCenter, targetSize, maxTreeLevel<KeyType>{}, prefixes, childOffsets, centers, box, focusStart,
+                  focusEnd, markings);
 }
 
 template<class T, class KeyType>

--- a/domain/include/cstone/traversal/collisions_gpu.h
+++ b/domain/include/cstone/traversal/collisions_gpu.h
@@ -73,6 +73,7 @@ extern void markMacsGpu(const KeyType* prefixes,
                         const Box<T>& box,
                         const KeyType* focusNodes,
                         TreeNodeIndex numFocusNodes,
+                        bool limitSource,
                         char* markings);
 
 } // namespace cstone

--- a/domain/include/cstone/traversal/macs.hpp
+++ b/domain/include/cstone/traversal/macs.hpp
@@ -246,7 +246,7 @@ void markMacs(const KeyType* prefixes,
               const Box<T>& box,
               const KeyType* focusNodes,
               TreeNodeIndex numFocusNodes,
-              // bool limitSource,
+              bool limitSource,
               char* markings)
 {
     KeyType focusStart = focusNodes[0];
@@ -261,8 +261,8 @@ void markMacs(const KeyType* prefixes,
         if (containedIn(focusStart, focusEnd, targetExt)) { continue; }
 
         auto [targetCenter, targetSize] = centerAndSize<KeyType>(target, box);
-        auto maxLevel                   = maxTreeLevel<KeyType>{};
-        // if (limitSource) { maxLevel = treeLevel(focusNodes[i + 1] - focusNodes[i]); }
+        unsigned maxLevel               = maxTreeLevel<KeyType>{};
+        if (limitSource) { maxLevel = std::max(int(treeLevel(focusNodes[i + 1] - focusNodes[i])) - 1, 0); }
         markMacPerBox(targetCenter, targetSize, maxLevel, prefixes, childOffsets, centers, box, focusStart, focusEnd,
                       markings);
     }

--- a/domain/include/cstone/traversal/macs.hpp
+++ b/domain/include/cstone/traversal/macs.hpp
@@ -196,6 +196,7 @@ HOST_DEVICE_FUN bool minVecMacMutual(const Vec3<T>& centerA,
 template<class T, class KeyType>
 HOST_DEVICE_FUN void markMacPerBox(const Vec3<T>& targetCenter,
                                    const Vec3<T>& targetSize,
+                                   unsigned maxSourceLevel,
                                    const KeyType* prefixes,
                                    const TreeNodeIndex* childOffsets,
                                    const Vec4<T>* centers,
@@ -204,17 +205,18 @@ HOST_DEVICE_FUN void markMacPerBox(const Vec3<T>& targetCenter,
                                    KeyType focusEnd,
                                    char* markings)
 {
-    auto checkAndMarkMac =
-        [&targetCenter, &targetSize, prefixes, &box, focusStart, focusEnd, centers, markings](TreeNodeIndex idx)
+    auto checkAndMarkMac = [&](TreeNodeIndex idx)
     {
-        KeyType nodePrefix = prefixes[idx];
-        KeyType nodeStart  = decodePlaceholderBit(nodePrefix);
-        KeyType nodeEnd    = nodeStart + nodeRange<KeyType>(decodePrefixLength(nodePrefix) / 3);
+        KeyType nodePrefix   = prefixes[idx];
+        unsigned sourceLevel = decodePrefixLength(nodePrefix) / 3;
+        KeyType nodeStart    = decodePlaceholderBit(nodePrefix);
+        KeyType nodeEnd      = nodeStart + nodeRange<KeyType>(sourceLevel);
         // if the tree node with index idx is fully contained in the focus, we stop traversal
         if (containedIn(nodeStart, nodeEnd, focusStart, focusEnd)) { return false; }
 
-        Vec4<T> center   = centers[idx];
-        bool violatesMac = evaluateMacPbc(makeVec3(center), center[3], targetCenter, targetSize, box);
+        Vec4<T> center = centers[idx];
+        bool violatesMac =
+            evaluateMacPbc(makeVec3(center), center[3], targetCenter, targetSize, box) && sourceLevel <= maxSourceLevel;
         if (violatesMac && !markings[idx]) { markings[idx] = 1; }
 
         return violatesMac;
@@ -232,34 +234,37 @@ HOST_DEVICE_FUN void markMacPerBox(const Vec3<T>& targetCenter,
  * @param[in]  box          global coordinate bounding box
  * @param[in]  focusStart   lower SFC focus code
  * @param[in]  focusEnd     upper SFC focus code
+ * @param[in]  limitSource  if true, source cells are only marked if the tree-level is bigger than the target
  * @param[out] markings     array of length @p octree.numTreeNodes(), each position i
  *                          will be set to 1, if the node of @p octree with index i fails the MAC paired with
  *                          any node contained in the focus range [focusStart:focusEnd]
  */
 template<class T, class KeyType>
-void markMacs(const OctreeView<KeyType>& octree,
+void markMacs(const KeyType* prefixes,
+              const TreeNodeIndex* childOffsets,
               const Vec4<T>* centers,
               const Box<T>& box,
-              KeyType focusStart,
-              KeyType focusEnd,
+              const KeyType* focusNodes,
+              TreeNodeIndex numFocusNodes,
+              // bool limitSource,
               char* markings)
-
 {
-    std::fill(markings, markings + octree.numInternalNodes + octree.numLeafNodes, 0);
-
-    // find the minimum possible number of octree node boxes to cover the entire focus
-    TreeNodeIndex numFocusBoxes = spanSfcRange(focusStart, focusEnd);
-    std::vector<KeyType> focusCodes(numFocusBoxes + 1);
-    spanSfcRange(focusStart, focusEnd, focusCodes.data());
-    focusCodes.back() = focusEnd;
+    KeyType focusStart = focusNodes[0];
+    KeyType focusEnd   = focusNodes[numFocusNodes];
 
 #pragma omp parallel for schedule(dynamic)
-    for (TreeNodeIndex i = 0; i < numFocusBoxes; ++i)
+    for (TreeNodeIndex i = 0; i < numFocusNodes; ++i)
     {
-        IBox target                     = sfcIBox(sfcKey(focusCodes[i]), sfcKey(focusCodes[i + 1]));
+        IBox target    = sfcIBox(sfcKey(focusNodes[i]), sfcKey(focusNodes[i + 1]));
+        IBox targetExt = IBox(target.xmin() - 1, target.xmax() + 1, target.ymin() - 1, target.ymax() + 1,
+                              target.zmin() - 1, target.zmax() + 1);
+        if (containedIn(focusStart, focusEnd, targetExt)) { continue; }
+
         auto [targetCenter, targetSize] = centerAndSize<KeyType>(target, box);
-        markMacPerBox(targetCenter, targetSize, octree.prefixes, octree.childOffsets, centers, box, focusStart,
-                      focusEnd, markings);
+        auto maxLevel                   = maxTreeLevel<KeyType>{};
+        // if (limitSource) { maxLevel = treeLevel(focusNodes[i + 1] - focusNodes[i]); }
+        markMacPerBox(targetCenter, targetSize, maxLevel, prefixes, childOffsets, centers, box, focusStart, focusEnd,
+                      markings);
     }
 }
 

--- a/domain/include/cstone/tree/definitions.h
+++ b/domain/include/cstone/tree/definitions.h
@@ -96,11 +96,12 @@ using Vec4 = util::array<T, 4>;
 enum class P2pTags : int
 {
     focusTransfer    = 1000,
-    focusPeerCounts  = 2000,
-    focusPeerCenters = 3000,
-    haloRequestKeys  = 4000,
-    domainExchange   = 5000,
-    haloExchange     = 6000
+    focusTreelets    = 2000,
+    focusPeerCounts  = 3000,
+    focusPeerCenters = 4000,
+    haloRequestKeys  = 5000,
+    domainExchange   = 6000,
+    haloExchange     = 7000
 };
 
 /*! @brief returns the number of nodes in a tree

--- a/domain/test/integration_mpi/exchange_focus.cpp
+++ b/domain/test/integration_mpi/exchange_focus.cpp
@@ -65,7 +65,7 @@ void exchangeFocusIrregular(int myRank, int numRanks)
         // finer resolution at one location outside the regular grid + cells that don't exist on rank 1
         octreeMaker.divide(7).divide(7, 0);
         treeLeavesRef[0] = octreeMaker.makeTree();
-        octreeMaker.divide(7,0,3);
+        octreeMaker.divide(7, 0, 3);
         treeLeavesInitial[0] = octreeMaker.makeTree();
         EXPECT_EQ(treeLeavesRef[0].size() + 7, treeLeavesInitial[0].size());
     }
@@ -83,7 +83,7 @@ void exchangeFocusIrregular(int myRank, int numRanks)
         }
         // finer resolution at one location outside the regular grid
         octreeMaker.divide(1).divide(1, 6);
-        treeLeavesRef[1] = octreeMaker.makeTree();
+        treeLeavesRef[1]     = octreeMaker.makeTree();
         treeLeavesInitial[1] = treeLeavesRef[1];
     }
 

--- a/domain/test/integration_mpi/focus_tree.cpp
+++ b/domain/test/integration_mpi/focus_tree.cpp
@@ -127,7 +127,7 @@ void globalRandomGaussian(int thisRank, int numRanks)
     int converged = 0;
     while (converged != numRanks)
     {
-        converged = focusTree.updateTree(peers, assignment);
+        converged = focusTree.updateTree(peers, assignment, box);
         focusTree.updateCounts(particleKeys, tree, counts);
         focusTree.updateMinMac(box, assignment, invThetaEff);
         MPI_Allreduce(MPI_IN_PLACE, &converged, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);

--- a/domain/test/performance/octree.cu
+++ b/domain/test/performance/octree.cu
@@ -57,7 +57,7 @@ auto benchmarkMacsCpu(const OctreeView<KeyType>& octree,
     auto findMacsLambda = [&octree, &centers, &box, &leaves, &macs, firstFocusNode, lastFocusNode]()
     {
         markMacs(octree.prefixes, octree.childOffsets, centers, box, leaves.data() + firstFocusNode,
-                 lastFocusNode - firstFocusNode, macs.data());
+                 lastFocusNode - firstFocusNode, false, macs.data());
     };
 
     float macCpuTime = timeGpu(findMacsLambda);
@@ -189,7 +189,7 @@ int main()
     auto findMacsLambda = [octree = octreeView, &centers, &box, &tree, &macs, firstFocusNode, lastFocusNode]()
     {
         markMacsGpu(octree.prefixes, octree.childOffsets, rawPtr(centers), box, rawPtr(tree) + firstFocusNode,
-                    lastFocusNode - firstFocusNode, rawPtr(macs));
+                    lastFocusNode - firstFocusNode, false, rawPtr(macs));
     };
 
     float macTime = timeGpu(findMacsLambda);

--- a/domain/test/performance/octree.cu
+++ b/domain/test/performance/octree.cu
@@ -53,9 +53,12 @@ auto benchmarkMacsCpu(const OctreeView<KeyType>& octree,
                       TreeNodeIndex firstFocusNode,
                       TreeNodeIndex lastFocusNode)
 {
-    std::vector<char> macs(octree.numNodes);
+    std::vector<char> macs(octree.numNodes, 0);
     auto findMacsLambda = [&octree, &centers, &box, &leaves, &macs, firstFocusNode, lastFocusNode]()
-    { markMacs(octree, centers, box, leaves[firstFocusNode], leaves[lastFocusNode], macs.data()); };
+    {
+        markMacs(octree.prefixes, octree.childOffsets, centers, box, leaves.data() + firstFocusNode,
+                 lastFocusNode - firstFocusNode, macs.data());
+    };
 
     float macCpuTime = timeGpu(findMacsLambda);
     std::cout << "CPU mac eval " << macCpuTime / 1000 << " nNodes(tree): " << nNodes(leaves)

--- a/domain/test/performance/octree.cu
+++ b/domain/test/performance/octree.cu
@@ -178,11 +178,10 @@ int main()
         Vec3<T> center_i;
         util::tie(center_i, std::ignore) = centerAndSize<KeyType>(nodeBox, box);
 
-        T mac           = computeVecMacR2(h_octree.prefixes[i], center_i, invTheta, box);
         h_centers[i][0] = center_i[0];
         h_centers[i][1] = center_i[1];
         h_centers[i][2] = center_i[2];
-        h_centers[i][3] = mac;
+        h_centers[i][3] = computeVecMacR2(h_octree.prefixes[i], center_i, invTheta, box);
     }
     centers = h_centers;
 

--- a/domain/test/unit/focus/octree_focus.cpp
+++ b/domain/test/unit/focus/octree_focus.cpp
@@ -426,4 +426,77 @@ TEST(FocusedOctree, compute)
     computeEssentialTree<uint64_t>();
 }
 
+class MacRefinement : public testing::Test
+{
+protected:
+    using KeyType = uint64_t;
+    using T       = double;
+
+    void SetUp() override
+    {
+        OctreeMaker<KeyType> om;
+        om.divide().divide(0);
+        for (int j = 0; j < 8; ++j)
+            om.divide(0, j);
+        om.divide(0, 0, 0);
+
+        // L3 in first octant, L1 otherwise
+        leaves = om.makeTree();
+        octree.resize(nNodes(leaves));
+        ov = octree.data();
+        updateInternalTree<KeyType>(leaves, ov);
+    }
+
+    std::vector<KeyType> leaves;
+    OctreeData<KeyType, CpuTag> octree;
+    OctreeView<KeyType> ov;
+    std::vector<SourceCenterType<T>> centers;
+    std::vector<char> macs;
+};
+
+TEST_F(MacRefinement, fullSurface)
+{
+    Box<T> box(0, 1);
+    float invTheta = sqrt(3) / 2 + 1e-6;
+
+    KeyType focusStart = 0;
+    KeyType focusEnd   = decodePlaceholderBit(KeyType(011));
+    while (!macRefine(octree, leaves, centers, macs, focusEnd, focusEnd, focusStart, focusEnd, invTheta, box)) {}
+
+    int numNodesVertex = 7 + 8;
+    int numNodesEdge = 6 + 2 * 8;
+    int numNodesFace = 4 + 4 * 8;
+    EXPECT_EQ(nNodes(leaves), 64 + 7 + 3 * numNodesFace + 3 * numNodesEdge + numNodesVertex);
+}
+
+TEST_F(MacRefinement, noSurface)
+{
+    Box<T> box(0, 1);
+    float invTheta = sqrt(3) / 2 + 1e-6;
+    TreeNodeIndex numNodesStart = octree.numLeafNodes;
+
+    KeyType oldFStart  = decodePlaceholderBit(KeyType(0101));
+    KeyType oldFEnd    = decodePlaceholderBit(KeyType(011));
+    KeyType focusStart = 0;
+    KeyType focusEnd   = decodePlaceholderBit(KeyType(011));
+    while (!macRefine(octree, leaves, centers, macs, oldFStart, oldFEnd, focusStart, focusEnd, invTheta, box)) {}
+
+    EXPECT_EQ(nNodes(leaves), numNodesStart);
+}
+
+TEST_F(MacRefinement, partialSurface)
+{
+    Box<T> box(0, 1);
+    float invTheta = sqrt(3) / 2 + 1e-6;
+    TreeNodeIndex numNodesStart = octree.numLeafNodes;
+
+    KeyType oldFStart  = 0;
+    KeyType oldFEnd    = decodePlaceholderBit(KeyType(0107));
+    KeyType focusStart = 0;
+    KeyType focusEnd   = decodePlaceholderBit(KeyType(011));
+    while (!macRefine(octree, leaves, centers, macs, oldFStart, oldFEnd, focusStart, focusEnd, invTheta, box)) {}
+
+    EXPECT_EQ(nNodes(leaves), numNodesStart + 5 * 7);
+}
+
 } // namespace cstone

--- a/domain/test/unit/focus/octree_focus.cpp
+++ b/domain/test/unit/focus/octree_focus.cpp
@@ -464,15 +464,15 @@ TEST_F(MacRefinement, fullSurface)
     while (!macRefine(octree, leaves, centers, macs, focusEnd, focusEnd, focusStart, focusEnd, invTheta, box)) {}
 
     int numNodesVertex = 7 + 8;
-    int numNodesEdge = 6 + 2 * 8;
-    int numNodesFace = 4 + 4 * 8;
+    int numNodesEdge   = 6 + 2 * 8;
+    int numNodesFace   = 4 + 4 * 8;
     EXPECT_EQ(nNodes(leaves), 64 + 7 + 3 * numNodesFace + 3 * numNodesEdge + numNodesVertex);
 }
 
 TEST_F(MacRefinement, noSurface)
 {
     Box<T> box(0, 1);
-    float invTheta = sqrt(3) / 2 + 1e-6;
+    float invTheta              = sqrt(3) / 2 + 1e-6;
     TreeNodeIndex numNodesStart = octree.numLeafNodes;
 
     KeyType oldFStart  = decodePlaceholderBit(KeyType(0101));
@@ -487,7 +487,7 @@ TEST_F(MacRefinement, noSurface)
 TEST_F(MacRefinement, partialSurface)
 {
     Box<T> box(0, 1);
-    float invTheta = sqrt(3) / 2 + 1e-6;
+    float invTheta              = sqrt(3) / 2 + 1e-6;
     TreeNodeIndex numNodesStart = octree.numLeafNodes;
 
     KeyType oldFStart  = 0;

--- a/domain/test/unit/traversal/macs.cpp
+++ b/domain/test/unit/traversal/macs.cpp
@@ -171,7 +171,8 @@ static void markMacVector()
     TreeNodeIndex focusIdxStart = 4;
     TreeNodeIndex focusIdxEnd   = 22;
 
-    markMacs(octree.data(), centers.data(), box, leaves[focusIdxStart], leaves[focusIdxEnd], markings.data());
+    markMacs(octree.prefixes.data(), octree.childOffsets.data(), centers.data(), box, leaves.data() + focusIdxStart,
+             focusIdxEnd - focusIdxStart, markings.data());
 
     std::vector<char> reference =
         markVecMacAll2All<KeyType>(leaves.data(), octree.prefixes, centers.data(), focusIdxStart, focusIdxEnd, box);

--- a/domain/test/unit/traversal/macs.cpp
+++ b/domain/test/unit/traversal/macs.cpp
@@ -195,17 +195,15 @@ TEST(Macs, limitSource4x4)
     float invTheta = sqrt(3.) / 2;
 
     std::vector<KeyType> leaves = makeUniformNLevelTree<KeyType>(64, 1);
-    Octree<KeyType> fullTree;
-    fullTree.update(leaves.data(), nNodes(leaves));
+    OctreeData<KeyType, CpuTag> fullTree;
+    fullTree.resize(nNodes(leaves));
     OctreeView<KeyType> ov = fullTree.data();
+    updateInternalTree<KeyType>(leaves, ov);
 
     std::vector<SourceCenterType<T>> centers(ov.numNodes);
-    for (TreeNodeIndex i = 0; i < ov.numNodes; ++i)
-    {
-        centers[i] = computeMinMacR2(ov.prefixes[i], invTheta, box);
-    }
+    geoMacSpheres<KeyType>({ov.prefixes, size_t(ov.numNodes)}, centers.data(), invTheta, box);
 
-    std::vector<char> macs(fullTree.numTreeNodes(), 0);
+    std::vector<char> macs(ov.numNodes, 0);
     markMacs(ov.prefixes, ov.childOffsets, centers.data(), box, leaves.data() + 0, 32, true, macs.data());
 
     std::vector<char> macRef{1, 0, 0, 0, 0, 1, 1, 1, 1};

--- a/domain/test/unit_cuda/CMakeLists.txt
+++ b/domain/test/unit_cuda/CMakeLists.txt
@@ -7,6 +7,7 @@ set(UNIT_TEST_SOURCES_GPU
         primitives/primitives_gpu.cu
         primitives/warpscan.cu
         focus/inject.cu
+        focus/octree_focus.cu
         sfc/common.cu
         traversal/groups.cu
         traversal/macs.cu

--- a/domain/test/unit_cuda/CMakeLists.txt
+++ b/domain/test/unit_cuda/CMakeLists.txt
@@ -1,26 +1,28 @@
 include(cstone_add_test)
 
+set(UNIT_TEST_SOURCES_GPU
+        domain/domaindecomp_gpu.cu
+        halos/gather_halos_gpu.cu
+        primitives/clz.cu
+        primitives/primitives_gpu.cu
+        primitives/warpscan.cu
+        focus/inject.cu
+        sfc/common.cu
+        traversal/groups.cu
+        traversal/macs.cu
+        tree/btree.cu
+        tree/csarray.cu
+        tree/octree.cu
+)
+
 if(CMAKE_HIP_COMPILER)
-    set_source_files_properties(domain/domaindecomp_gpu.cu primitives/primitives_gpu.cu primitives/warpscan.cu
-            primitives/clz.cu sfc/common.cu traversal/groups.cu tree/btree.cu tree/csarray.cu tree/octree.cu
-            PROPERTIES LANGUAGE HIP)
+    set_source_files_properties(${UNIT_TEST_SOURCES_GPU} PROPERTIES LANGUAGE HIP)
 endif()
 
 set(testname component_units_cuda)
 
 if(CMAKE_CUDA_COMPILER OR CMAKE_HIP_COMPILER)
-    add_library(gpu_unit_obj OBJECT
-            domain/domaindecomp_gpu.cu
-            halos/gather_halos_gpu.cu
-            primitives/clz.cu
-            primitives/primitives_gpu.cu
-            primitives/warpscan.cu
-            focus/inject.cu
-            sfc/common.cu
-            traversal/groups.cu
-            tree/btree.cu
-            tree/csarray.cu
-            tree/octree.cu)
+    add_library(gpu_unit_obj OBJECT ${UNIT_TEST_SOURCES_GPU})
     target_link_libraries(gpu_unit_obj PUBLIC cstone_gpu OpenMP::OpenMP_CXX GTest::gtest_main)
     target_include_directories(gpu_unit_obj PRIVATE ${PROJECT_SOURCE_DIR}/include)
     target_include_directories(gpu_unit_obj PRIVATE ${PROJECT_SOURCE_DIR}/test)

--- a/domain/test/unit_cuda/focus/octree_focus.cu
+++ b/domain/test/unit_cuda/focus/octree_focus.cu
@@ -32,7 +32,7 @@ protected:
 
         // L3 in first octant, L1 otherwise
         h_leaves = om.makeTree();
-        leaves = h_leaves;
+        leaves   = h_leaves;
 
         octree.resize(nNodes(h_leaves));
         buildOctreeGpu<KeyType>(rawPtr(leaves), octree.data());
@@ -57,15 +57,15 @@ TEST_F(MacRefinementGpu, fullSurface)
     while (!macRefineGpu(octree, leaves, centers, macs, focusEnd, focusEnd, focusStart, focusEnd, invTheta, box)) {}
 
     int numNodesVertex = 7 + 8;
-    int numNodesEdge = 6 + 2 * 8;
-    int numNodesFace = 4 + 4 * 8;
+    int numNodesEdge   = 6 + 2 * 8;
+    int numNodesFace   = 4 + 4 * 8;
     EXPECT_EQ(nNodes(leaves), 64 + 7 + 3 * numNodesFace + 3 * numNodesEdge + numNodesVertex);
 }
 
 TEST_F(MacRefinementGpu, noSurface)
 {
     Box<T> box(0, 1);
-    float invTheta = sqrt(3) / 2 + 1e-6;
+    float invTheta              = sqrt(3) / 2 + 1e-6;
     TreeNodeIndex numNodesStart = octree.numLeafNodes;
 
     KeyType oldFStart  = decodePlaceholderBit(KeyType(0101));
@@ -80,7 +80,7 @@ TEST_F(MacRefinementGpu, noSurface)
 TEST_F(MacRefinementGpu, partialSurface)
 {
     Box<T> box(0, 1);
-    float invTheta = sqrt(3) / 2 + 1e-6;
+    float invTheta              = sqrt(3) / 2 + 1e-6;
     TreeNodeIndex numNodesStart = octree.numLeafNodes;
 
     KeyType oldFStart  = 0;

--- a/domain/test/unit_cuda/focus/octree_focus.cu
+++ b/domain/test/unit_cuda/focus/octree_focus.cu
@@ -1,0 +1,93 @@
+/*! @file
+ * @brief Cornerstone octree GPU testing
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ *
+ */
+
+#include "gtest/gtest.h"
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include "cstone/cuda/cuda_utils.cuh"
+#include "cstone/tree/cs_util.hpp"
+#include "cstone/focus/octree_focus.hpp"
+
+using namespace cstone;
+
+class MacRefinementGpu : public testing::Test
+{
+protected:
+    using KeyType = uint64_t;
+    using T       = double;
+
+    void SetUp() override
+    {
+        OctreeMaker<KeyType> om;
+        om.divide().divide(0);
+        for (int j = 0; j < 8; ++j)
+            om.divide(0, j);
+        om.divide(0, 0, 0);
+
+        // L3 in first octant, L1 otherwise
+        h_leaves = om.makeTree();
+        leaves = h_leaves;
+
+        octree.resize(nNodes(h_leaves));
+        buildOctreeGpu<KeyType>(rawPtr(leaves), octree.data());
+        ov = octree.data();
+    }
+
+    std::vector<KeyType> h_leaves;
+    thrust::device_vector<KeyType> leaves;
+    OctreeData<KeyType, GpuTag> octree;
+    OctreeView<KeyType> ov;
+    thrust::device_vector<SourceCenterType<T>> centers;
+    thrust::device_vector<char> macs;
+};
+
+TEST_F(MacRefinementGpu, fullSurface)
+{
+    Box<T> box(0, 1);
+    float invTheta = sqrt(3) / 2 + 1e-6;
+
+    KeyType focusStart = 0;
+    KeyType focusEnd   = decodePlaceholderBit(KeyType(011));
+    while (!macRefineGpu(octree, leaves, centers, macs, focusEnd, focusEnd, focusStart, focusEnd, invTheta, box)) {}
+
+    int numNodesVertex = 7 + 8;
+    int numNodesEdge = 6 + 2 * 8;
+    int numNodesFace = 4 + 4 * 8;
+    EXPECT_EQ(nNodes(leaves), 64 + 7 + 3 * numNodesFace + 3 * numNodesEdge + numNodesVertex);
+}
+
+TEST_F(MacRefinementGpu, noSurface)
+{
+    Box<T> box(0, 1);
+    float invTheta = sqrt(3) / 2 + 1e-6;
+    TreeNodeIndex numNodesStart = octree.numLeafNodes;
+
+    KeyType oldFStart  = decodePlaceholderBit(KeyType(0101));
+    KeyType oldFEnd    = decodePlaceholderBit(KeyType(011));
+    KeyType focusStart = 0;
+    KeyType focusEnd   = decodePlaceholderBit(KeyType(011));
+    while (!macRefineGpu(octree, leaves, centers, macs, oldFStart, oldFEnd, focusStart, focusEnd, invTheta, box)) {}
+
+    EXPECT_EQ(nNodes(leaves), numNodesStart);
+}
+
+TEST_F(MacRefinementGpu, partialSurface)
+{
+    Box<T> box(0, 1);
+    float invTheta = sqrt(3) / 2 + 1e-6;
+    TreeNodeIndex numNodesStart = octree.numLeafNodes;
+
+    KeyType oldFStart  = 0;
+    KeyType oldFEnd    = decodePlaceholderBit(KeyType(0107));
+    KeyType focusStart = 0;
+    KeyType focusEnd   = decodePlaceholderBit(KeyType(011));
+    while (!macRefineGpu(octree, leaves, centers, macs, oldFStart, oldFEnd, focusStart, focusEnd, invTheta, box)) {}
+
+    EXPECT_EQ(nNodes(leaves), numNodesStart + 5 * 7);
+}

--- a/domain/test/unit_cuda/traversal/macs.cu
+++ b/domain/test/unit_cuda/traversal/macs.cu
@@ -35,10 +35,7 @@ TEST(Macs, limitSource4x4_matchCPU)
 
     thrust::host_vector<KeyType> h_prefixes = fullTree.prefixes;
     std::vector<SourceCenterType<T>> h_centers(ov.numNodes);
-    for (TreeNodeIndex i = 0; i < ov.numNodes; ++i)
-    {
-        h_centers[i] = computeMinMacR2(h_prefixes[i], invTheta, box);
-    }
+    geoMacSpheres<KeyType>(h_prefixes, h_centers.data(), invTheta, box);
     thrust::device_vector<char> macs(ov.numNodes, 0);
     thrust::device_vector<SourceCenterType<T>> centers = h_centers;
 

--- a/domain/test/unit_cuda/traversal/macs.cu
+++ b/domain/test/unit_cuda/traversal/macs.cu
@@ -1,0 +1,57 @@
+/*! @file
+ * @brief Cornerstone octree GPU testing
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ *
+ */
+
+#include "gtest/gtest.h"
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include "cstone/cuda/cuda_utils.cuh"
+#include "cstone/focus/source_center.hpp"
+#include "cstone/traversal/collisions_gpu.h"
+#include "cstone/traversal/macs.hpp"
+#include "cstone/tree/cs_util.hpp"
+#include "cstone/tree/octree_gpu.h"
+
+using namespace cstone;
+
+TEST(Macs, limitSource4x4_matchCPU)
+{
+    using KeyType = uint64_t;
+    using T       = double;
+
+    Box<T> box(0, 1);
+    float invTheta = sqrt(3.) / 2;
+
+    thrust::device_vector<KeyType> leaves = makeUniformNLevelTree<KeyType>(64, 1);
+    OctreeData<KeyType, GpuTag> fullTree;
+    fullTree.resize(nNodes(leaves));
+    buildOctreeGpu(rawPtr(leaves), fullTree.data());
+    OctreeView<KeyType> ov = fullTree.data();
+
+    thrust::host_vector<KeyType> h_prefixes = fullTree.prefixes;
+    std::vector<SourceCenterType<T>> h_centers(ov.numNodes);
+    for (TreeNodeIndex i = 0; i < ov.numNodes; ++i)
+    {
+        h_centers[i] = computeMinMacR2(h_prefixes[i], invTheta, box);
+    }
+    thrust::device_vector<char> macs(ov.numNodes, 0);
+    thrust::device_vector<SourceCenterType<T>> centers = h_centers;
+
+    markMacsGpu(ov.prefixes, ov.childOffsets, rawPtr(centers), box, rawPtr(leaves) + 0, 32, true, rawPtr(macs));
+    thrust::host_vector<char> h_macs = macs;
+
+    thrust::host_vector<char> macRef{1, 0, 0, 0, 0, 1, 1, 1, 1};
+    macRef.resize(ov.numNodes);
+    EXPECT_EQ(macRef, h_macs);
+
+    thrust::fill(macs.begin(), macs.end(), 0);
+    markMacsGpu(ov.prefixes, ov.childOffsets, rawPtr(centers), box, rawPtr(leaves) + 0, 32, false, rawPtr(macs));
+    h_macs = macs;
+    int numMacs = std::accumulate(h_macs.begin(), h_macs.end(), 0);
+    EXPECT_EQ(numMacs, 5 + 16);
+}

--- a/domain/test/unit_cuda/traversal/macs.cu
+++ b/domain/test/unit_cuda/traversal/macs.cu
@@ -13,7 +13,6 @@
 #include "cstone/cuda/cuda_utils.cuh"
 #include "cstone/focus/source_center.hpp"
 #include "cstone/traversal/collisions_gpu.h"
-#include "cstone/traversal/macs.hpp"
 #include "cstone/tree/cs_util.hpp"
 #include "cstone/tree/octree_gpu.h"
 
@@ -42,13 +41,13 @@ TEST(Macs, limitSource4x4_matchCPU)
     markMacsGpu(ov.prefixes, ov.childOffsets, rawPtr(centers), box, rawPtr(leaves) + 0, 32, true, rawPtr(macs));
     thrust::host_vector<char> h_macs = macs;
 
-    thrust::host_vector<char> macRef{1, 0, 0, 0, 0, 1, 1, 1, 1};
+    thrust::host_vector<char> macRef = std::vector<char>{1, 0, 0, 0, 0, 1, 1, 1, 1};
     macRef.resize(ov.numNodes);
     EXPECT_EQ(macRef, h_macs);
 
     thrust::fill(macs.begin(), macs.end(), 0);
     markMacsGpu(ov.prefixes, ov.childOffsets, rawPtr(centers), box, rawPtr(leaves) + 0, 32, false, rawPtr(macs));
-    h_macs = macs;
+    h_macs      = macs;
     int numMacs = std::accumulate(h_macs.begin(), h_macs.end(), 0);
     EXPECT_EQ(numMacs, 5 + 16);
 }

--- a/main/src/propagator/ve_hydro_bdt.hpp
+++ b/main/src/propagator/ve_hydro_bdt.hpp
@@ -212,7 +212,9 @@ public:
 
     void sync(DomainType& domain, DataType& simData) override
     {
+        domain.setTreeConv(true);
         domain.setHaloFactor(1.0 + float(timestep_.numRungs) / 40);
+
         if (activeRung(timestep_.substep, timestep_.numRungs) == 0) { fullSync(domain, simData); }
         else { partialSync(domain, simData); }
     }


### PR DESCRIPTION
This PR dramatically improves the speed with which the locally essential tree adapts to changing domain boundaries.