### PR TITLE
Particle removal

### DIFF
--- a/cmake/setup_GTest.cmake
+++ b/cmake/setup_GTest.cmake
@@ -18,14 +18,11 @@ if (NOT GTest_FOUND)
     if(NOT googletest_POPULATED)
         message(STATUS "Downloading GTest from github")
         # Fetch the content using previously declared details
-        FetchContent_Populate(googletest)
+        FetchContent_MakeAvailable(googletest)
 
         # Prevent overriding the parent project's compiler/linker
         # settings on Windows
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-        # Bring the populated content into the build
-        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
     endif()
 endif()
 

--- a/domain/cmake/setup_GTest.cmake
+++ b/domain/cmake/setup_GTest.cmake
@@ -18,14 +18,11 @@ if (NOT GTest_FOUND)
     if(NOT googletest_POPULATED)
         message(STATUS "Downloading GTest from github")
         # Fetch the content using previously declared details
-        FetchContent_Populate(googletest)
+        FetchContent_MakeAvailable(googletest)
 
         # Prevent overriding the parent project's compiler/linker
         # settings on Windows
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-        # Bring the populated content into the build
-        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
     endif()
 endif()
 

--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -160,7 +160,7 @@ public:
         gsl::span<KeyType> keyView(keys + newStart, envelopeSize);
 
         auto recvStart = domain_exchange::receiveStart(bufDesc, numPresent(), numAssigned());
-        auto numRecv = numAssigned() - numPresent();
+        auto numRecv   = numAssigned() - numPresent();
 
         computeSfcKeys(x + recvStart, y + recvStart, z + recvStart, sfcKindPointer(keys + recvStart), numRecv, box_);
         std::make_signed_t<LocalIndex> shifts = -numRecv;

--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -143,7 +143,7 @@ public:
     template<class Reorderer, class Vector, class... Arrays>
     auto distribute(BufferDescription bufDesc,
                     Reorderer& reorderFunctor,
-                    Vector& /*scratch1*/,
+                    Vector& s1,
                     Vector& /*scratch2*/,
                     KeyType* keys,
                     T* x,
@@ -159,9 +159,16 @@ public:
         LocalIndex envelopeSize = newEnd - newStart;
         gsl::span<KeyType> keyView(keys + newStart, envelopeSize);
 
-        computeSfcKeys(x + newStart, y + newStart, z + newStart, sfcKindPointer(keyView.begin()), envelopeSize, box_);
+        auto recvStart = domain_exchange::receiveStart(bufDesc, numPresent(), numAssigned());
+        auto numRecv = numAssigned() - numPresent();
+
+        computeSfcKeys(x + recvStart, y + recvStart, z + recvStart, sfcKindPointer(keys + recvStart), numRecv, box_);
+        std::make_signed_t<LocalIndex> shifts = -numRecv;
+        if (newEnd > bufDesc.end) { shifts = numRecv; }
+        reorderFunctor.extendMap(shifts, s1);
+
         // sort keys and keep track of the ordering
-        reorderFunctor.setMapFromCodes(keyView.begin(), keyView.end());
+        reorderFunctor.updateMap(keyView.begin(), keyView.end());
 
         return std::make_tuple(newStart, keyView.subspan(numSendDown(), numAssigned()));
     }

--- a/domain/include/cstone/domain/assignment_gpu.cuh
+++ b/domain/include/cstone/domain/assignment_gpu.cuh
@@ -72,8 +72,8 @@ public:
         tree_.update(init.data(), nNodes(init));
         nodeCounts_ = std::vector<unsigned>(nNodes(init), bucketSize_ - 1);
 
-        reallocate(d_boundaryKeys_, numRanks_, 1.0);
-        reallocate(d_boundaryIndices_, numRanks_, 1.0);
+        reallocate(d_boundaryKeys_, numRanks_ + 1, 1.0);
+        reallocate(d_boundaryIndices_, numRanks_ + 1, 1.0);
     }
 
     /*! @brief Update the global tree

--- a/domain/include/cstone/domain/assignment_gpu.cuh
+++ b/domain/include/cstone/domain/assignment_gpu.cuh
@@ -173,9 +173,16 @@ public:
         LocalIndex envelopeSize    = newEnd - newStart;
         gsl::span<KeyType> keyView = gsl::span<KeyType>(keys + newStart, envelopeSize);
 
-        computeSfcKeysGpu(x + newStart, y + newStart, z + newStart, sfcKindPointer(keyView.data()), envelopeSize, box_);
+        auto recvStart = domain_exchange::receiveStart(bufDesc, numPresent(), numAssigned());
+        auto numRecv = numAssigned() - numPresent();
+
+        computeSfcKeysGpu(x + recvStart, y + recvStart, z + recvStart, sfcKindPointer(keys + recvStart), numRecv, box_);
+        std::make_signed_t<LocalIndex> shifts = -numRecv;
+        if (newEnd > bufDesc.end) { shifts = numRecv; }
+        sfcSorter.extendMap(shifts, sendScratch);
+
         // sort keys and keep track of the ordering
-        sfcSorter.setMapFromCodes(keyView.begin(), keyView.end(), sendScratch, receiveScratch);
+        sfcSorter.updateMap(keyView.begin(), keyView.end(), sendScratch, receiveScratch);
 
         return std::make_tuple(newStart, keyView.subspan(numSendDown(), numAssigned()));
     }

--- a/domain/include/cstone/domain/domaindecomp.hpp
+++ b/domain/include/cstone/domain/domaindecomp.hpp
@@ -220,12 +220,11 @@ SendRanges createSendRanges(const SfcAssignment<KeyType>& assignment, gsl::span<
     int numRanks = assignment.numRanks();
 
     SendRanges ret(numRanks + 1);
-    for (int rank = 0; rank < numRanks; ++rank)
+    for (int rank = 0; rank <= numRanks; ++rank)
     {
         KeyType rangeStart = assignment[rank];
         ret[rank] = std::lower_bound(particleKeys.begin(), particleKeys.end(), rangeStart) - particleKeys.begin();
     }
-    ret.back() = particleKeys.size();
 
     return ret;
 }

--- a/domain/include/cstone/domain/domaindecomp_gpu.cuh
+++ b/domain/include/cstone/domain/domaindecomp_gpu.cuh
@@ -58,13 +58,12 @@ SendRanges createSendRangesGpu(const SfcAssignment<KeyType>& assignment,
                                KeyType* d_searchKeys,
                                LocalIndex* d_indices)
 {
-    size_t numRanks = assignment.numRanks();
-    SendRanges ret(numRanks + 1);
+    size_t numSearchKeys = assignment.numRanks() + 1;
+    SendRanges ret(numSearchKeys);
 
-    memcpyH2D(assignment.data(), numRanks, d_searchKeys);
-    lowerBoundGpu(particleKeys.begin(), particleKeys.end(), d_searchKeys, d_searchKeys + numRanks, d_indices);
-    memcpyD2H(d_indices, numRanks, ret.data());
-    ret.back() = particleKeys.size();
+    memcpyH2D(assignment.data(), numSearchKeys, d_searchKeys);
+    lowerBoundGpu(particleKeys.begin(), particleKeys.end(), d_searchKeys, d_searchKeys + numSearchKeys, d_indices);
+    memcpyD2H(d_indices, numSearchKeys, ret.data());
 
     return ret;
 }

--- a/domain/include/cstone/primitives/gather.cuh
+++ b/domain/include/cstone/primitives/gather.cuh
@@ -72,8 +72,8 @@ public:
     void setMapFromCodes(KeyType* first, KeyType* last)
     {
         mapSize_ = std::size_t(last - first);
-        reallocateBytes(buffer_, mapSize_ * sizeof(IndexType));
-        sequenceGpu(ordering(), mapSize_, LocalIndex(0));
+        reallocateBytes(buffer_, mapSize_ * sizeof(IndexType), growthRate_);
+        sequenceGpu(ordering(), mapSize_, IndexType(0));
         sortByKeyGpu(first, last, ordering());
     }
 
@@ -82,7 +82,7 @@ public:
     {
         mapSize_ = std::size_t(last - first);
         reallocateBytes(buffer_, mapSize_ * sizeof(IndexType), growthRate_);
-        sequenceGpu(ordering(), mapSize_, LocalIndex(0));
+        sequenceGpu(ordering(), mapSize_, IndexType(0));
         sortByKeyGpu(first, last, ordering(), keyBuf, valueBuf);
     }
 
@@ -91,7 +91,7 @@ public:
     {
         mapSize_ = std::size_t(last - first);
         reallocateBytes(buffer_, mapSize_ * sizeof(IndexType), growthRate_);
-        sequenceGpu(ordering(), mapSize_, LocalIndex(0));
+        sequenceGpu(ordering(), mapSize_, IndexType(0));
 
         auto s1 = reallocateBytes(keyBuf, mapSize_ * sizeof(KeyType), growthRate_);
         auto s2 = reallocateBytes(valueBuf, mapSize_ * sizeof(IndexType), growthRate_);
@@ -102,7 +102,50 @@ public:
         reallocate(valueBuf, s2, 1.0);
     }
 
+    template<class KeyType, class KeyBuf, class ValueBuf>
+    void updateMap(KeyType* first, KeyType* last, KeyBuf& keyBuf, ValueBuf& valueBuf)
+    {
+        assert(last - first == mapSize_);
+        sortByKeyGpu(first, last, ordering(), (KeyType*)rawPtr(keyBuf), (IndexType*)rawPtr(valueBuf));
+    }
+
     auto gatherFunc() const { return gatherGpuL; }
+
+    /*! @brief extend ordering map to the left or right
+     *
+     * @param[in] shifts    number of shifts
+     * @param[-]  scratch   scratch space for temporary usage
+     *
+     * Negative shift values extends the ordering map to the left, positive value to the right
+     * Examples: map = [1, 0, 3, 2] -> extendMap(-1) -> map = [0, 2, 1, 4, 3]
+     *           map = [1, 0, 3, 2] -> extendMap(1) -> map = [1, 0, 3, 2, 4]
+     *
+     * This is used to extend the key-buffer passed to setMapFromCodes with additional keys, without
+     * having to restore the original unsorted key-sequence.
+     */
+    template<class Vector>
+    void extendMap(std::make_signed_t<IndexType> shifts, Vector& scratch)
+    {
+        if (shifts == 0) { return; }
+
+        auto newMapSize = mapSize_ + std::abs(shifts);
+        reallocateBytes(scratch, newMapSize * sizeof(IndexType), 1.0);
+        auto* tempMap = reinterpret_cast<IndexType*>(rawPtr(scratch));
+
+        if (shifts < 0)
+        {
+            sequenceGpu(tempMap, IndexType(-shifts), IndexType(0));
+            incrementGpu(ordering(), ordering() + mapSize_, tempMap - shifts, IndexType(-shifts));
+        }
+        else if (shifts > 0)
+        {
+            memcpyD2D(ordering(), mapSize_, tempMap);
+            sequenceGpu(tempMap + mapSize_, IndexType(shifts), mapSize_);
+        }
+        reallocateBytes(buffer_, newMapSize * sizeof(IndexType), 1.0);
+        memcpyD2D(tempMap, newMapSize, ordering());
+        mapSize_ = newMapSize;
+    }
 
 private:
     IndexType* ordering() { return reinterpret_cast<IndexType*>(rawPtr(buffer_)); }
@@ -110,7 +153,7 @@ private:
 
     //! @brief reference to (non-owning) buffer for ordering
     BufferType& buffer_;
-    std::size_t mapSize_{0};
+    IndexType mapSize_{0};
     float growthRate_ = 1.05;
 };
 

--- a/domain/include/cstone/primitives/gather.hpp
+++ b/domain/include/cstone/primitives/gather.hpp
@@ -70,8 +70,8 @@ void sort_by_key(InoutIterator keyBegin, InoutIterator keyEnd, OutputIterator va
         keyIndexPairs[i] = std::make_tuple(keyBegin[i], valueBegin[i]);
 
     // sort, comparing only the first tuple element
-    std::sort(begin(keyIndexPairs), end(keyIndexPairs),
-              [compare](const auto& t1, const auto& t2) { return compare(std::get<0>(t1), std::get<0>(t2)); });
+    std::stable_sort(begin(keyIndexPairs), end(keyIndexPairs),
+                     [compare](const auto& t1, const auto& t2) { return compare(std::get<0>(t1), std::get<0>(t2)); });
 
 // extract the resulting ordering and store back the sorted keys
 #pragma omp parallel for schedule(static)

--- a/domain/include/cstone/primitives/primitives_acc.hpp
+++ b/domain/include/cstone/primitives/primitives_acc.hpp
@@ -1,0 +1,26 @@
+
+/*! @file
+ * @brief  CPU/GPU Wrapper of basic algorithms
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#pragma once
+
+#include <algorithm>
+
+#include "cstone/primitives/primitives_gpu.h"
+
+namespace cstone
+{
+
+template<bool useGpu, class T>
+void fill(T* first, T* last, T value)
+{
+    if (last <= first) { return; }
+
+    if constexpr (useGpu) { fillGpu(first, last, value); }
+    else { std::fill(first, last, value); }
+}
+
+} // namespace cstone

--- a/domain/include/cstone/primitives/primitives_gpu.cu
+++ b/domain/include/cstone/primitives/primitives_gpu.cu
@@ -82,6 +82,29 @@ void scaleGpu(T* first, T* last, T value)
 template void scaleGpu(double*, double*, double);
 template void scaleGpu(float*, float*, float);
 
+template<class T>
+struct IncrementFunctor
+{
+    const T s;
+
+    IncrementFunctor(T s_)
+        : s(s_)
+    {
+    }
+
+    __host__ __device__ T operator()(const T& x) const { return x + s; }
+};
+
+template<class T>
+void incrementGpu(const T* first, const T* last, T* d_first, T value)
+{
+    thrust::transform(thrust::device, first, last, d_first, IncrementFunctor<T>(value));
+}
+
+#define INCREMENT_GPU(T) template void incrementGpu(const T* first, const T* last, T* d_first, T value)
+INCREMENT_GPU(unsigned);
+INCREMENT_GPU(uint64_t);
+
 template<class T, class IndexType>
 __global__ void gatherGpuKernel(const IndexType* map, size_t n, const T* source, T* destination)
 {

--- a/domain/include/cstone/primitives/primitives_gpu.h
+++ b/domain/include/cstone/primitives/primitives_gpu.h
@@ -42,6 +42,9 @@ extern void fillGpu(T* first, T* last, T value);
 template<class T>
 extern void scaleGpu(T* first, T* last, T value);
 
+template<class T>
+extern void incrementGpu(const T* first, const T* last, T* d_first, T value);
+
 template<class T, class IndexType>
 extern void gatherGpu(const IndexType* ordering, size_t numElements, const T* src, T* buffer);
 

--- a/domain/include/cstone/sfc/sfc.hpp
+++ b/domain/include/cstone/sfc/sfc.hpp
@@ -286,7 +286,7 @@ void computeSfcKeys(const T* x, const T* y, const T* z, KeyType* particleKeys, s
 #pragma omp parallel for schedule(static)
     for (std::size_t i = 0; i < n; ++i)
     {
-        particleKeys[i] = sfc3D<KeyType>(x[i], y[i], z[i], box);
+        if (particleKeys[i] != removeKey<KeyType>::value) { particleKeys[i] = sfc3D<KeyType>(x[i], y[i], z[i], box); }
     }
 }
 

--- a/domain/include/cstone/sfc/sfc_gpu.cu
+++ b/domain/include/cstone/sfc/sfc_gpu.cu
@@ -40,7 +40,10 @@ __global__ void
 computeSfcKeysKernel(KeyType* keys, const T* x, const T* y, const T* z, size_t numKeys, const Box<T> box)
 {
     size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
-    if (tid < numKeys) { keys[tid] = sfc3D<KeyType>(x[tid], y[tid], z[tid], box); }
+    if (tid < numKeys)
+    {
+        if (keys[tid] != removeKey<KeyType>::value) { keys[tid] = sfc3D<KeyType>(x[tid], y[tid], z[tid], box); }
+    }
 }
 
 template<class KeyType, class T>

--- a/domain/include/cstone/traversal/traversal.hpp
+++ b/domain/include/cstone/traversal/traversal.hpp
@@ -139,7 +139,7 @@ void dualTraversal(const TreeType& octree, TreeNodeIndex a, TreeNodeIndex b, MAC
 
     if (octree.isLeaf(a) && octree.isLeaf(b))
     {
-        p2p(a, b);
+        if (continuation(a, b)) { p2p(a, b); }
         return;
     }
 

--- a/domain/include/cstone/tree/csarray.hpp
+++ b/domain/include/cstone/tree/csarray.hpp
@@ -102,15 +102,16 @@ HOST_DEVICE_FUN unsigned calculateNodeCount(
     return stl::min(count, maxCount);
 }
 
-/*! @brief determine search bound for @p targetCode in an array of sorted particle SFC codes
+/*! @brief Narrow search bound for @p targetCode in an array of sorted particle SFC codes
  *
  * @tparam KeyType    32- or 64-bit unsigned integer type
- * @param firstIdx    first (of two) search boundary, must be non-negative, but can exceed the codes range
+ * @param firstIdx    first (of two) search boundaries, may be out of bounds
  *                    (the guess for the location of @p targetCode in [codesStart:codesEnd]
  * @param targetCode  code to look for in [codesStart:codesEnd]
  * @param codesStart  particle SFC code array start
  * @param codesEnd    particle SFC code array end
- * @return            the sub-range in [codesStart:codesEnd] containing @p targetCode
+ * @return            a sub-range of [codesStart:codesEnd] that fulfills
+ *                    lower_bound(codesStart, codesEnd, targetCode) == lower_bound(ret[0], ret[0], targetCode)
  */
 template<class KeyType>
 HOST_DEVICE_FUN util::array<const KeyType*, 2> findSearchBounds(std::make_signed_t<KeyType> firstIdx,
@@ -127,14 +128,10 @@ HOST_DEVICE_FUN util::array<const KeyType*, 2> findSearchBounds(std::make_signed
     firstIdx = stl::min(nCodes - 1, firstIdx);
 
     // the last node in 64-bit is 2^63, which can't be represented as a negative number
-    if (targetCode == nodeRange<KeyType>(0)) { return {codesStart + firstIdx, codesEnd}; }
+    if (targetCode >= nodeRange<KeyType>(0)) { return {stl::lower_bound(codesStart, codesEnd, targetCode), codesEnd}; }
 
-    KeyType firstCode = codesStart[firstIdx];
-    if (firstCode == targetCode) { firstIdx++; }
-
-    // d = 1 : search towards codesEnd
-    // d = -1 : search towards codesStart
-    SI d = (firstCode < targetCode) ? 1 : -1;
+    // d = 1 : search towards codesEnd, d = -1 : search towards codesStart
+    SI d = (codesStart[firstIdx] < targetCode) ? 1 : -1;
 
     SI targetCodeTimesD = targetCode * d;
 

--- a/domain/include/cstone/tree/definitions.h
+++ b/domain/include/cstone/tree/definitions.h
@@ -81,6 +81,14 @@ struct maxTreeLevel<unsigned long> : stl::integral_constant<unsigned, 21>
 {
 };
 
+//! @brief A special key value that cannot result from valid coordinates. Used to flag particles for removal.
+template<class KeyType>
+struct removeKey
+{
+    static constexpr KeyType value = KeyType(1ul << (3 * maxTreeLevel<KeyType>{}));
+    HOST_DEVICE_FUN constexpr operator KeyType() const noexcept { return value; }
+};
+
 //! @brief maximum integer coordinate
 template<class KeyType>
 struct maxCoord : stl::integral_constant<unsigned, (1u << maxTreeLevel<KeyType>{})>

--- a/domain/test/integration_mpi/domain_gpu.cpp
+++ b/domain/test/integration_mpi/domain_gpu.cpp
@@ -189,9 +189,9 @@ TEST(DomainGpu, reapplySync)
     }
 
     std::vector<Real> host_property(d_x.size());
-    for (size_t i = 0; i < x.size(); ++i)
+    for (size_t i = domain.startIndex(); i < domain.endIndex(); ++i)
     {
-        host_property[i] = numParticlesPerRank * rank + i;
+        host_property[i] = numParticlesPerRank * rank + i - domain.startIndex();
     }
     DeviceVector<Real> property = host_property;
 

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -297,9 +297,9 @@ TEST(FocusDomain, reapplySync)
     }
 
     std::vector<Real> property(x.size());
-    for (size_t i = 0; i < domain.nParticles(); ++i)
+    for (size_t i = domain.startIndex(); i < domain.endIndex(); ++i)
     {
-        property[i] = numParticlesPerRank * rank + domain.startIndex() + i;
+        property[i] = numParticlesPerRank * rank + i - domain.startIndex();
     }
 
     std::vector<Real> propertyCpy = property;

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -269,8 +269,8 @@ TEST(FocusDomain, removeParticle)
     using KeyType = unsigned;
 
     Box<Real> box(0, 1);
-    LocalIndex numParticlesPerRank = 10;
-    unsigned bucketSize            = 1024;
+    LocalIndex numParticlesPerRank = 1000;
+    unsigned bucketSize            = 64;
     unsigned bucketSizeFocus       = 8;
     float theta                    = 0.5;
 
@@ -282,7 +282,7 @@ TEST(FocusDomain, removeParticle)
     std::vector<Real> h(numParticlesPerRank, 0.1 / std::cbrt(numRanks));
 
     std::vector<uint64_t> id(x.size());
-    std::iota(begin(id), end(id), 100 + uint64_t(rank * numParticlesPerRank));
+    std::iota(begin(id), end(id), uint64_t(rank * numParticlesPerRank));
 
     Domain<KeyType, Real> domain(rank, numRanks, bucketSize, bucketSizeFocus, theta, box);
 
@@ -292,38 +292,25 @@ TEST(FocusDomain, removeParticle)
     domain.sync(particleKeys, x, y, z, h, std::tie(id), std::tie(s1, s2, s3));
 
     // pick a particle to remove on each rank
-    LocalIndex removeIndex    = domain.startIndex() + numParticlesPerRank / 2;
+    LocalIndex removeIndex    = domain.startIndex() + domain.nParticles() / 2;
+    assert(removeIndex < domain.endIndex());
     particleKeys[removeIndex] = removeKey<KeyType>::value;
     uint64_t removeID = id[removeIndex];
 
-    std::cout << "KEYS: ";
-    for (auto v : particleKeys) std::cout << std::oct << v << " "; std::cout << std::dec << std::endl;
-    std::cout << "id: ";
-    for (auto v : id) std::cout << v << " "; std::cout << std::endl;
-    std::cout << "removeID " << removeID << " removeIndex " << removeIndex << std::endl;
-
-    std::cout << domain.startIndex() << " " << domain.endIndex() << " " << particleKeys.size() << std::endl;
-
     domain.sync(particleKeys, x, y, z, h, std::tie(id), std::tie(s1, s2, s3));
-
-    //std::cout << domain.startIndex() << " " << domain.endIndex() << " " << id.back() << " " << id[removeIndex] << std::endl;
-    std::cout << "KEYS: ";
-    for (auto v : particleKeys) std::cout << std::oct << v << " "; std::cout << std::dec << std::endl;
-    std::cout << "id: ";
-    for (auto v : id) std::cout << v << " "; std::cout << std::endl;
 
     uint64_t numLocalParticles = domain.nParticles();
     uint64_t numGlobalParticles;
     MPI_Allreduce(&numLocalParticles, &numGlobalParticles, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
     EXPECT_EQ(numGlobalParticles, numRanks * numParticlesPerRank - numRanks);
 
-    //// check that removed particles are gone by checking their IDs
-    //std::vector<uint64_t> removedIDs(numRanks);
-    //MPI_Allgather(&removeID, 1, MPI_UNSIGNED_LONG_LONG, removedIDs.data(), 1, MPI_UNSIGNED_LONG_LONG, MPI_COMM_WORLD);
-    //for (uint64_t rid : removedIDs)
-    //{
-    //    EXPECT_EQ(std::count(id.begin(), id.end(), rid), 0);
-    //}
+    // check that removed particles are gone by checking their IDs
+    std::vector<uint64_t> removedIDs(numRanks);
+    MPI_Allgather(&removeID, 1, MPI_UNSIGNED_LONG_LONG, removedIDs.data(), 1, MPI_UNSIGNED_LONG_LONG, MPI_COMM_WORLD);
+    for (uint64_t rid : removedIDs)
+    {
+        EXPECT_EQ(std::count(id.begin() + domain.startIndex(), id.begin() + domain.endIndex(), rid), 0);
+    }
 }
 
 TEST(FocusDomain, reapplySync)

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -292,10 +292,10 @@ TEST(FocusDomain, removeParticle)
     domain.sync(particleKeys, x, y, z, h, std::tie(id), std::tie(s1, s2, s3));
 
     // pick a particle to remove on each rank
-    LocalIndex removeIndex    = domain.startIndex() + domain.nParticles() / 2;
+    LocalIndex removeIndex = domain.startIndex() + domain.nParticles() / 2;
     assert(removeIndex < domain.endIndex());
     particleKeys[removeIndex] = removeKey<KeyType>::value;
-    uint64_t removeID = id[removeIndex];
+    uint64_t removeID         = id[removeIndex];
 
     domain.sync(particleKeys, x, y, z, h, std::tie(id), std::tie(s1, s2, s3));
 

--- a/domain/test/unit/domain/domaindecomp.cpp
+++ b/domain/test/unit/domain/domaindecomp.cpp
@@ -151,29 +151,28 @@ TEST(DomainDecomposition, limitBoundaryShifts)
     }
 }
 
-TEST(DomainDecomposition, createSendList)
+TEST(DomainDecomposition, createSendRanges)
 {
     using KeyType = uint64_t;
 
-    std::vector<KeyType> tree{0, 2, 6, 8, 10};
-    std::vector<KeyType> codes{0, 0, 1, 3, 4, 5, 6, 6, 9};
+    std::vector<KeyType> keys{0, 0, 1, 3, 4, 5, 6, 6, 9, 10};
 
     int numRanks = 2;
     SfcAssignment<KeyType> assignment(numRanks);
-    assignment.set(0, 0, 6);
-    assignment.set(1, 6, 21);
-    assignment.set(2, 10, 0);
+    LocalIndex ignored = -1;
+    assignment.set(0, 0, ignored);
+    assignment.set(1, 6, ignored);
+    assignment.set(2, 10, ignored); // note: this excludes the last key
 
-    // note: codes input needs to be sorted
-    auto sendList = createSendRanges<KeyType>(assignment, codes);
+    // note: input keys need to be sorted
+    auto sendList = createSendRanges<KeyType>(assignment, keys);
 
     EXPECT_EQ(sendList.count(0), 6);
     EXPECT_EQ(sendList.count(1), 3);
 
     EXPECT_EQ(sendList[0], 0);
-    EXPECT_EQ(sendList[0] + sendList.count(0), 6);
     EXPECT_EQ(sendList[1], 6);
-    EXPECT_EQ(sendList[1] + sendList.count(1), 9);
+    EXPECT_EQ(sendList[2], 9);
 }
 
 TEST(DomainDecomposition, initialDomainSplit)

--- a/domain/test/unit/primitives/gather.cpp
+++ b/domain/test/unit/primitives/gather.cpp
@@ -80,3 +80,41 @@ TEST(GatherCpu, CpuGather)
     CpuGatherTest<double, unsigned, unsigned>();
     CpuGatherTest<double, uint64_t, unsigned>();
 }
+
+TEST(GatherCpu, shiftMapLeft)
+{
+    using KeyType = unsigned;
+
+    std::vector<KeyType> keys{2, 1, 5, 4};
+
+    std::vector<unsigned> scratch, scratch2;
+    SfcSorter<LocalIndex, std::vector<unsigned>> sorter(scratch);
+
+    sorter.setMapFromCodes(keys.data(), keys.data() + keys.size());
+    // map is [1 0 3 2]
+
+    sorter.extendMap(-1, scratch2);
+    std::vector<LocalIndex> probeMap(sorter.getMap(), sorter.getMap() + sorter.size());
+
+    std::vector<LocalIndex> ref{0, 2, 1, 4, 3};
+    EXPECT_EQ(probeMap, ref);
+}
+
+TEST(GatherCpu, shiftMapRight)
+{
+    using KeyType = unsigned;
+
+    std::vector<KeyType> keys{2, 1, 5, 4};
+
+    std::vector<unsigned> scratch, scratch2;
+    SfcSorter<LocalIndex, std::vector<unsigned>> sorter(scratch);
+
+    sorter.setMapFromCodes(keys.data(), keys.data() + keys.size());
+    // map is [1 0 3 2]
+
+    sorter.extendMap(1, scratch2);
+    std::vector<LocalIndex> probeMap(sorter.getMap(), sorter.getMap() + sorter.size());
+
+    std::vector<LocalIndex> ref{1, 0, 3, 2, 4};
+    EXPECT_EQ(probeMap, ref);
+}

--- a/domain/test/unit/tree/csarray.cpp
+++ b/domain/test/unit/tree/csarray.cpp
@@ -41,115 +41,33 @@ using namespace cstone;
 template<class T>
 using pair = util::array<T, 2>;
 
-template<class KeyType>
-static void findSearchBounds()
+static void testBounds(LocalIndex guess, uint64_t searchKey, pair<LocalIndex> ref)
 {
-    //                          0   1   2   3   4   5   6   7   8   9
-    std::vector<KeyType> codes{3, 10, 11, 14, 16, 16, 16, 18, 19, 21};
+    using KeyType = uint64_t;
+    auto e        = nodeRange<KeyType>(0);
+    //                         0   1   2   3   4   5   6   7   8   9 10 11 12
+    std::vector<KeyType> codes{3, 10, 11, 14, 16, 16, 16, 18, 19, 21, e, e, e};
     const KeyType* c = codes.data();
 
-    {
-        // upward search direction, guess distance from target: 0
-        int guess  = 3;
-        auto probe = findSearchBounds(guess, KeyType(14), c, c + codes.size());
-        pair<const KeyType*> reference{c + 2, c + 4};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // upward search direction, guess distance from target: 1
-        int guess  = 3;
-        auto probe = findSearchBounds(guess, KeyType(15), c, c + codes.size());
-        pair<const KeyType*> reference{c + 3, c + 4};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // upward search direction, guess distance from target: 1
-        int guess  = 3;
-        auto probe = findSearchBounds(guess, KeyType(16), c, c + codes.size());
-        pair<const KeyType*> reference{c + 3, c + 7};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // upward search direction, guess distance from target: 6
-        int guess  = 0;
-        auto probe = findSearchBounds(guess, KeyType(17), c, c + codes.size());
-        pair<const KeyType*> reference{c + 0, c + 8};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // downward search direction
-        int guess  = 4;
-        auto probe = findSearchBounds(guess, KeyType(12), c, c + codes.size());
-        pair<const KeyType*> reference{c + 2, c + 4};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // downward search direction
-        int guess  = 4;
-        auto probe = findSearchBounds(guess, KeyType(11), c, c + codes.size());
-        pair<const KeyType*> reference{c + 0, c + 4};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // downward search direction
-        int guess  = 4;
-        auto probe = findSearchBounds(guess, KeyType(10), c, c + codes.size());
-        pair<const KeyType*> reference{c + 0, c + 4};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // downward search direction
-        int guess  = 8;
-        auto probe = findSearchBounds(guess, KeyType(16), c, c + codes.size());
-        pair<const KeyType*> reference{c + 0, c + 8};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // downward search direction
-        int guess  = 6;
-        auto probe = findSearchBounds(guess, KeyType(16), c, c + codes.size());
-        pair<const KeyType*> reference{c + 3, c + 7};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // direct hit on the last element
-        int guess  = 9;
-        auto probe = findSearchBounds(guess, KeyType(21), c, c + codes.size());
-        pair<const KeyType*> reference{c + 8, c + 10};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // must be able to handle out-of-bounds guess
-        int guess  = 12;
-        auto probe = findSearchBounds(guess, KeyType(16), c, c + codes.size());
-        pair<const KeyType*> reference{c + 1, c + 9};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
-    {
-        // must be able to handle the upper bound of the last node
-        std::make_signed_t<KeyType> guess = 8;
-        KeyType targetKey                 = nodeRange<KeyType>(0);
-        auto probe                        = findSearchBounds(guess, targetKey, c, c + codes.size());
-        pair<const KeyType*> reference{c + 8, c + 10};
-        EXPECT_EQ(probe[0] - c, reference[0] - c);
-        EXPECT_EQ(probe[1] - c, reference[1] - c);
-    }
+    auto x = findSearchBounds(guess, searchKey, c, c + codes.size());
+    EXPECT_EQ(x[0], c + ref[0]);
+    EXPECT_EQ(x[1], c + ref[1]);
+    EXPECT_EQ(stl::lower_bound(c, c + codes.size(), searchKey) - c, stl::lower_bound(x[0], x[1], searchKey) - c);
 }
 
-TEST(CornerstoneOctree, findSearchBounds32) { findSearchBounds<unsigned>(); }
-
-TEST(CornerstoneOctree, findSearchBounds64) { findSearchBounds<uint64_t>(); }
+TEST(CornerstoneOctree, searchBounds1) { testBounds(3, 14, {2, 3}); }
+TEST(CornerstoneOctree, searchBounds2) { testBounds(3, 15, {3, 4}); }
+TEST(CornerstoneOctree, searchBounds3) { testBounds(3, 16, {3, 7}); }
+TEST(CornerstoneOctree, searchBounds4) { testBounds(4, 16, {3, 4}); }
+TEST(CornerstoneOctree, searchBounds5) { testBounds(0, 17, {0, 8}); }
+TEST(CornerstoneOctree, searchBounds6) { testBounds(4, 12, {2, 4}); }
+TEST(CornerstoneOctree, searchBounds7) { testBounds(4, 11, {0, 4}); }
+TEST(CornerstoneOctree, searchBounds8) { testBounds(4, 10, {0, 4}); }
+TEST(CornerstoneOctree, searchBounds9) { testBounds(8, 16, {0, 8}); }
+TEST(CornerstoneOctree, searchBounds10) { testBounds(6, 16, {2, 6}); }
+TEST(CornerstoneOctree, searchBounds11) { testBounds(9, 21, {8, 9}); }
+TEST(CornerstoneOctree, searchBounds12) { testBounds(12, 16, {0, 12}); }
+TEST(CornerstoneOctree, searchBounds13) { testBounds(8, nodeRange<uint64_t>(0), {10, 13}); }
 
 //! @brief test that computeNodeCounts correctly counts the number of codes for each node
 template<class CodeType>

--- a/domain/test/unit_cuda/CMakeLists.txt
+++ b/domain/test/unit_cuda/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UNIT_TEST_SOURCES_GPU
         domain/domaindecomp_gpu.cu
         halos/gather_halos_gpu.cu
         primitives/clz.cu
+        primitives/gather.cu
         primitives/primitives_gpu.cu
         primitives/warpscan.cu
         focus/inject.cu

--- a/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
+++ b/domain/test/unit_cuda/domain/domaindecomp_gpu.cu
@@ -42,7 +42,7 @@ template<class KeyType>
 static void sendListMinimalGpu()
 {
     std::vector<KeyType> tree{0, 2, 6, 8, 10};
-    std::vector<KeyType> codes{0, 0, 1, 3, 4, 5, 6, 6, 9};
+    std::vector<KeyType> keys{0, 0, 1, 3, 4, 5, 6, 6, 7, 11};
 
     int numRanks = 2;
     SfcAssignment<KeyType> assignment(numRanks);
@@ -50,13 +50,13 @@ static void sendListMinimalGpu()
     assignment.set(1, tree[2], 0);
     assignment.set(2, tree[4], 0);
 
-    thrust::device_vector<KeyType> d_keys = codes;
-    thrust::device_vector<KeyType> d_searchKeys(numRanks);
-    thrust::device_vector<LocalIndex> d_indices(numRanks);
+    thrust::device_vector<KeyType> d_keys = keys;
+    thrust::device_vector<KeyType> d_searchKeys(numRanks + 1);
+    thrust::device_vector<LocalIndex> d_indices(numRanks + 1);
 
     gsl::span<const KeyType> d_keyView{rp(d_keys), d_keys.size()};
 
-    // note: codes input needs to be sorted
+    // note: key input needs to be sorted
     auto sendList = createSendRangesGpu(assignment, d_keyView, rp(d_searchKeys), rp(d_indices));
 
     EXPECT_EQ(sendList.count(0), 6);
@@ -64,6 +64,7 @@ static void sendListMinimalGpu()
 
     EXPECT_EQ(sendList[0], 0);
     EXPECT_EQ(sendList[1], 6);
+    EXPECT_EQ(sendList[2], 9);
 }
 
 TEST(DomainDecomposition, createSendListGpu)

--- a/domain/test/unit_cuda/primitives/gather.cu
+++ b/domain/test/unit_cuda/primitives/gather.cu
@@ -19,7 +19,7 @@ using namespace cstone;
 
 TEST(SfcSorterGpu, shiftMapLeft)
 {
-    using KeyType = unsigned;
+    using KeyType   = unsigned;
     using IndexType = unsigned;
     using thrust::raw_pointer_cast;
 
@@ -46,7 +46,7 @@ TEST(SfcSorterGpu, shiftMapLeft)
 
 TEST(SfcSorterGpu, shiftMapRight)
 {
-    using KeyType = unsigned;
+    using KeyType   = unsigned;
     using IndexType = unsigned;
     using thrust::raw_pointer_cast;
 

--- a/domain/test/unit_cuda/primitives/gather.cu
+++ b/domain/test/unit_cuda/primitives/gather.cu
@@ -1,0 +1,66 @@
+
+/*! @file
+ * @brief GPU SFC sorter unit tests
+ *
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ *
+ */
+
+#include <vector>
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include "gtest/gtest.h"
+
+#include "cstone/cuda/thrust_util.cuh"
+#include "cstone/primitives/gather.cuh"
+
+using namespace cstone;
+
+TEST(SfcSorterGpu, shiftMapLeft)
+{
+    using KeyType = unsigned;
+    using IndexType = unsigned;
+    using thrust::raw_pointer_cast;
+
+    thrust::device_vector<KeyType> keys = std::vector<KeyType>{2, 1, 5, 4};
+
+    thrust::device_vector<IndexType> obuf, keyBuf, valBuf;
+    GpuSfcSorter<IndexType, thrust::device_vector<unsigned>> sorter(obuf);
+
+    sorter.setMapFromCodes(raw_pointer_cast(keys.data()), raw_pointer_cast(keys.data()) + keys.size(), keyBuf, valBuf);
+    // map is [1 0 3 2]
+
+    {
+        thrust::device_vector<IndexType> ref = std::vector<IndexType>{1, 0, 3, 2};
+        EXPECT_EQ(obuf, ref);
+    }
+
+    sorter.extendMap(-1, keyBuf);
+
+    {
+        thrust::device_vector<IndexType> ref = std::vector<IndexType>{0, 2, 1, 4, 3};
+        EXPECT_EQ(obuf, ref);
+    }
+}
+
+TEST(SfcSorterGpu, shiftMapRight)
+{
+    using KeyType = unsigned;
+    using IndexType = unsigned;
+    using thrust::raw_pointer_cast;
+
+    thrust::device_vector<KeyType> keys = std::vector<KeyType>{2, 1, 5, 4};
+
+    thrust::device_vector<IndexType> obuf, keyBuf, valBuf;
+    GpuSfcSorter<IndexType, thrust::device_vector<unsigned>> sorter(obuf);
+
+    sorter.setMapFromCodes(raw_pointer_cast(keys.data()), raw_pointer_cast(keys.data()) + keys.size(), keyBuf, valBuf);
+    // map is [1 0 3 2]
+
+    sorter.extendMap(1, keyBuf);
+    {
+        thrust::device_vector<IndexType> ref = std::vector<IndexType>{1, 0, 3, 2, 4};
+        EXPECT_EQ(obuf, ref);
+    }
+}

--- a/ryoanji/cmake/setup_GTest.cmake
+++ b/ryoanji/cmake/setup_GTest.cmake
@@ -18,14 +18,11 @@ if (NOT GTest_FOUND)
     if(NOT googletest_POPULATED)
         message(STATUS "Downloading GTest from github")
         # Fetch the content using previously declared details
-        FetchContent_Populate(googletest)
+        FetchContent_MakeAvailable(googletest)
 
         # Prevent overriding the parent project's compiler/linker
         # settings on Windows
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-        # Bring the populated content into the build
-        add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
     endif()
 endif()
 


### PR DESCRIPTION
Adds support for removing particles to `domain.sync` and `domain.syncGrav`.
Particles whose SFC keys are set to `removeKey<KeyType>::value` will be removed by calling `domain.sync`.