### PR TITLE
Initialize CPU groups

### DIFF
--- a/sph/include/sph/groups.hpp
+++ b/sph/include/sph/groups.hpp
@@ -23,8 +23,11 @@ void computeGroups(size_t startIndex, size_t endIndex, Dataset& d, const cstone:
     }
     else
     {
-        groups.firstBody = startIndex;
-        groups.lastBody  = endIndex;
+        groups.firstBody  = startIndex;
+        groups.lastBody   = endIndex;
+        groups.numGroups  = 1;
+        groups.groupStart = &groups.firstBody;
+        groups.groupEnd   = &groups.lastBody;
     }
 }
 


### PR DESCRIPTION
Correctly initialized particle groups on CPUs to a single group holding all particles.