### PR TITLE
Add stirring mode tests for turbulence

### DIFF
--- a/sph/include/sph/hydro_turb/create_modes.hpp
+++ b/sph/include/sph/hydro_turb/create_modes.hpp
@@ -1,28 +1,3 @@
-/*
- * MIT License
- *
- * Copyright (c) 2021 CSCS, ETH Zurich
- *               2021 University of Basel
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 /*! @file
  * @brief Turbulence simulation data initialization
  *
@@ -59,6 +34,10 @@ template<class Dataset, class T>
 void createStirringModes(Dataset& d, T Lx, T Ly, T Lz, size_t st_maxmodes, T stirMax, T stirMin, size_t ndim,
                          size_t spectForm, T powerLawExp, T anglesExp, bool verbose)
 {
+    // TODO: this should not take the whole Dataset, only modes and amplitudes are needed
+    // TODO: st_maxmodes should not be an input parameter. the caller will have determineNumModes
+    // TODO: and it's up to the call-site to decide if they want to create as many as it takes (or skip the check)
+
     const T twopi = 2.0 * M_PI;
 
     // characteristic k for scaling the amplitude below
@@ -73,6 +52,7 @@ void createStirringModes(Dataset& d, T Lx, T Ly, T Lz, size_t st_maxmodes, T sti
     size_t ikymax = (ndim > 1) ? 256 : 0;
     size_t ikzmax = (ndim > 2) ? 256 : 0;
 
+    // TODO: this should be a separate function "determineNumModes".
     // determine the number of required modes (in case of full sampling)
     d.numModes = 0;
     for (size_t ikx = ikxmin; ikx <= ikxmax; ikx++)
@@ -98,6 +78,7 @@ void createStirringModes(Dataset& d, T Lx, T Ly, T Lz, size_t st_maxmodes, T sti
 
     d.numModes = -1;
 
+    // TODO: should be a separate function
     if (spectForm != 2)
     {
         if (verbose) std::cout << "Generating " << st_tot_nmodes << " driving modes..." << std::endl;
@@ -176,18 +157,19 @@ void createStirringModes(Dataset& d, T Lx, T Ly, T Lz, size_t st_maxmodes, T sti
         }             // ikx
     }
 
+    // TODO: should be a separate function
     if (spectForm == 2)
     {
         std::uniform_real_distribution<T> uniDist(0, 1);
         auto                              uniRng = [&d, &uniDist] { return uniDist(d.gen); };
 
         // loop between smallest and largest k
-        size_t ikmin = std::max(1, int(stirMin * Lx / twopi + 0.5));
-        size_t ikmax = int(stirMax * Lx / twopi + 0.5);
+        int ikmin = std::max(1, int(stirMin * Lx / twopi + 0.5));
+        int ikmax = int(stirMax * Lx / twopi + 0.5);
 
         for (int ik = ikmin; ik <= ikmax; ik++)
         {
-            size_t nang = std::pow(2, ndim) * ceil(std::pow(ik, anglesExp));
+            int nang = std::pow(2, ndim) * ceil(std::pow(ik, anglesExp));
             if (verbose) std::cout << "ik = " << ik << " , number of angles = " << nang << std::endl;
 
             for (int iang = 1; iang <= nang; iang++)

--- a/sph/test/hydro_turb/CMakeLists.txt
+++ b/sph/test/hydro_turb/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(UNIT_TESTS
+        create_modes.cpp
         rng.cpp
+        stirring.cpp
         test_main.cpp
         )
 

--- a/sph/test/hydro_turb/create_modes.cpp
+++ b/sph/test/hydro_turb/create_modes.cpp
@@ -1,75 +1,100 @@
+#include <map>
+#include <string>
 
-#include "stir_init.hpp"
-#include "st_ounoise.hpp"
-#include "st_calcPhases.hpp"
-#include "st_calcAccel.hpp"
-#include <vector>
-#include <iostream>
-int main()
+#include "gtest/gtest.h"
+
+#include "sph/hydro_turb/create_modes.hpp"
+
+std::map<std::string, double> TurbulenceConstants()
 {
-    using T            = double;
-    T      dt          = 0.1;
-    T      eps         = 1.e-16;
-    size_t stMaxModes  = 100000;
-    T      Lbox        = 1.0;
-    T      velocity    = 0.3;
-    int    stSeed      = 251299;
-    size_t stSpectForm = 1;
+    return {{"solWeight", 0.5},        {"stMaxModes", 100000}, {"Lbox", 1.0},       {"stEnergyPrefac", 5.0e-3},
+            {"stMachVelocity", 0.3e0}, {"epsilon", 1e-15},     {"rngSeed", 251299}, {"stSpectForm", 1},
+            {"powerLawExp", 5. / 3},   {"anglesExp", 2.0}};
+};
 
-    T twopi     = 8 * std::atan(1.0);
-    T stEnergy  = 5.0e-3 * std::pow(velocity, 3) / Lbox;
-    T stStirMin = (1.0 - eps) * twopi / Lbox;
-    T stStirMax = (3.0 + eps) * twopi / Lbox;
+TEST(Turbulence, spectForm1_unifdimensions)
+{
+    using T = double;
 
-    size_t         dim         = 3;
-    T              stDecay     = Lbox / (2.0 * velocity);
-    T              stSolWeight = 0.5;
-    T              stSolWeightNorm;
-    T              stOUVar;
-    std::vector<T> stAmpl(stMaxModes);
-    std::vector<T> stMode(stMaxModes * dim);
+    const T twopi = 6.283185307179586;
+    const T tol   = 1.e-6;
 
-    size_t stNModes;
+    T      Lx          = 1.0;
+    T      Ly          = 1.0;
+    T      Lz          = 1.0;
+    T      stirMax     = 3.000000000000000 * twopi / Lx;
+    T      stirMin     = (1.0) * twopi / Lx;
+    size_t st_maxmodes = 100000;
+    size_t ndim        = 3;
+    int    numModes    = 0;
+    // T      modes[st_maxmodes];
+    // T      amplitudes[st_maxmodes];
+    bool verbose = true;
 
-    stir_init(stAmpl, stMode, stNModes, stSolWeight, stSolWeightNorm, stOUVar, stDecay, Lbox, Lbox, Lbox, stMaxModes,
-              stEnergy, stStirMax, stStirMin, dim, stSpectForm);
+    sph::TurbulenceData<T, cstone::CpuTag> turbulenceData(TurbulenceConstants(), verbose);
+    sph::createStirringModes(turbulenceData, Lx, Ly, Lz, st_maxmodes, stirMax, stirMin, ndim, 1, 0.0, 0.0, verbose);
 
-    std::vector<T> stOUPhases(6 * stNModes);
-    st_ounoiseinit(stOUPhases, 6 * stNModes, stOUVar, stSeed);
+    numModes         = turbulenceData.numModes;
+    auto& modes      = turbulenceData.modes;
+    auto& amplitudes = turbulenceData.amplitudes;
 
-    st_ounoiseupdate(stOUPhases, 6 * stNModes, stOUVar, dt, stDecay, stSeed);
+    EXPECT_EQ(numModes, 112);
 
-    // Problem!!!, st_OUphases, st_nmodes, st_OUvar & st_seed must be output too, need to store values between
-    // iterations
-    std::vector<T> st_aka(dim * stNModes);
-    std::vector<T> st_akb(dim * stNModes);
+    EXPECT_NEAR(modes[3 * (10 - 1) + 0], 0.0000000000000000, tol);
+    EXPECT_NEAR(modes[3 * (10 - 1) + 1], -0.0000000000000000, tol);
+    EXPECT_NEAR(modes[3 * (10 - 1) + 2], 18.849556446075439, tol);
+    EXPECT_NEAR(0.5 * amplitudes[(10 - 1)], 0.0000000000000000, tol);
 
-    st_calcPhases(stNModes, dim, stOUPhases, stSolWeight, stMode, st_aka, st_akb);
+    EXPECT_NEAR(modes[3 * (54 - 1) + 0], 6.2831854820251465, tol);
+    EXPECT_NEAR(modes[3 * (54 - 1) + 1], -6.2831854820251465, tol);
+    EXPECT_NEAR(modes[3 * (54 - 1) + 2], 0.0000000000000000, tol);
+    EXPECT_NEAR(0.5 * amplitudes[(54 - 1)], 1.1461712345826693, tol);
 
-    std::vector<T> xCoord{-0.4, -0.2, 0.0, 0.2, 0.4, -0.5};
-    std::vector<T> yCoord{0.4, -0.2, 0.0, -0.2, 0.4, -0.5};
-    std::vector<T> zCoord{0.4, 0.2, 0.0, -0.2, -0.4, -0.5};
-    std::vector<T> accx{0.0, 0.0, 0.0, 0.0, 0.0, -0.5};
-    std::vector<T> accy{0.0, 0.0, 0.0, 0.0, 0.0, -0.5};
-    std::vector<T> accz{0.0, 0.0, 0.0, 0.0, 0.0, -0.5};
+    EXPECT_NEAR(modes[3 * (78 - 1) + 0], 12.566370964050293, tol);
+    EXPECT_NEAR(modes[3 * (78 - 1) + 1], -0.0000000000000000, tol);
+    EXPECT_NEAR(modes[3 * (78 - 1) + 2], 0.0000000000000000, tol);
+    EXPECT_NEAR(0.5 * amplitudes[(78 - 1)], 1.0000000000000000, tol);
+}
 
-    size_t npart = 6;
+TEST(Turbulence, spectForm1_nonunifdimensions)
+{
+    using T = double;
 
-    st_calcAccel(0, npart, dim, xCoord, yCoord, zCoord, accx, accy, accz, stNModes, stMode, st_aka, st_akb, stAmpl,
-                 stSolWeightNorm);
+    const T twopi       = 2.0 * M_PI;
+    const T tol         = 1.e-6;
+    T       Lx          = 0.7;
+    T       Ly          = 1.2;
+    T       Lz          = 1.5;
+    T       stirMax     = 3.000000000000001 * twopi / Lx;
+    T       stirMin     = (0.999999999999999) * twopi / Lx;
+    size_t  st_maxmodes = 100000;
+    size_t  ndim        = 3;
+    int     numModes    = 0;
+    // T modes[st_maxmodes];
+    // T amplitudes[st_maxmodes];
+    bool verbose = true;
 
-    for (int i = 0; i < npart; ++i)
-    {
+    sph::TurbulenceData<T, cstone::CpuTag> turbulenceData(TurbulenceConstants(), verbose);
+    sph::createStirringModes(turbulenceData, Lx, Ly, Lz, st_maxmodes, stirMax, stirMin, ndim, 1, 0.0, 0.0, verbose);
 
-        std::cout << accx[i] << ' ' << accy[i] << ' ' << accz[i] << std::endl;
-    }
-    /*
-    accx, accy, accz
-    ----------------
-    3.662459567254532E-01  1.259446841690182E-01 -1.125844123111067E-01
-    1.384560977280313E-02 -3.799734689699691E-02 -1.793841332102599E-01
-   -8.006708921589355E-02  5.960035530834547E-02 -4.877338914905545E-02
-    2.394216045884232E-02 -7.479786887141186E-02 -1.467975759746282E-01
-   -5.687601045457229E-02  1.256956770910929E-01  7.292293303985517E-02
-    */
+    numModes         = turbulenceData.numModes;
+    auto& modes      = turbulenceData.modes;
+    auto& amplitudes = turbulenceData.amplitudes;
+
+    EXPECT_EQ(numModes, 300);
+
+    EXPECT_NEAR(modes[3 * (10 - 1) + 0], 0.0000000000000000, tol);
+    EXPECT_NEAR(modes[3 * (10 - 1) + 1], -0.0000000000000000, tol);
+    EXPECT_NEAR(modes[3 * (10 - 1) + 2], 20.943951606750488, tol);
+    EXPECT_NEAR(0.5 * amplitudes[(10 - 1)], 0.80812206144596110, tol);
+
+    EXPECT_NEAR(modes[3 * (54 - 1) + 0], 0.0000000000000000, tol);
+    EXPECT_NEAR(modes[3 * (54 - 1) + 1], -10.471975387256329, tol);
+    EXPECT_NEAR(modes[3 * (54 - 1) + 2], 16.755161285400391, tol);
+    EXPECT_NEAR(0.5 * amplitudes[(54 - 1)], 0.88997794370873951, tol);
+
+    EXPECT_NEAR(modes[3 * (78 - 1) + 0], 0.0000000000000000, tol);
+    EXPECT_NEAR(modes[3 * (78 - 1) + 1], -15.707963080884493, tol);
+    EXPECT_NEAR(modes[3 * (78 - 1) + 2], 16.755161285400391, tol);
+    EXPECT_NEAR(0.5 * amplitudes[(78 - 1)], 0.64827464011102576, tol);
 }

--- a/sph/test/hydro_turb/stirring.cpp
+++ b/sph/test/hydro_turb/stirring.cpp
@@ -1,0 +1,104 @@
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "sph/hydro_turb/stirring.hpp"
+#include "sph/hydro_turb/phases.hpp"
+
+/*! @brief Test stirring forces due to given modes
+ *
+ * 1. define an (x,y,z) particle
+ * 2. create a few modes, amplitudes and phases
+ * 3. apply stirring and check resulting accelerations
+ */
+TEST(Turbulence, stirParticle)
+{
+    using T = double;
+
+    T      tol  = 1.e-8;
+    size_t ndim = 3;
+
+    T xi{0.5}, yi{0.5}, zi{0.5};
+
+    int numModes      = 1;
+    T   modes[3]      = {12.566370614359172, 0, 0}; // 2*k = 4*pi
+    T   phaseReal[3]  = {1.0, 1.0, 1.0};
+    T   phaseImag[3]  = {1.0, 1.0, 1.0};
+    T   amplitudes[1] = {2.0};
+
+    auto [ax, ay, az] = sph::stirParticle<T, T, T>(ndim, xi, yi, zi, numModes, modes, phaseReal, phaseImag, amplitudes);
+
+    // analytic value is 2.0, fortran code somehow is less accurate (1.9999996503088493)
+    EXPECT_NEAR(ax, 2.0, tol);
+    EXPECT_NEAR(ay, 2.0, tol);
+    EXPECT_NEAR(az, 2.0, tol);
+}
+
+TEST(Turbulence, stirParticle2)
+{
+    using T = double;
+
+    T      tol  = 3.e-7;
+    size_t ndim = 3;
+
+    T xi{-0.2}, yi{0.3}, zi{-0.4};
+
+    int numModes      = 1;
+    T   modes[3]      = {10.0, 15.0, 14.0};
+    T   phaseReal[3]  = {1.1, 1.2, 1.3};
+    T   phaseImag[3]  = {0.7, 0.8, 0.9};
+    T   amplitudes[1] = {2.0};
+
+    auto [ax, ay, az] = sph::stirParticle<T, T, T>(ndim, xi, yi, zi, numModes, modes, phaseReal, phaseImag, amplitudes);
+
+    EXPECT_NEAR(ax, -2.1398843541189447, tol);
+    EXPECT_NEAR(ay, -2.3313952836997660, tol);
+    EXPECT_NEAR(az, -2.5229059800250133, tol);
+}
+
+TEST(Turbulence, stirParticle3)
+{
+    using T = double;
+
+    T      tol  = 5.e-7;
+    size_t ndim = 3;
+
+    T xi{-0.2}, yi{0.3}, zi{-0.4};
+
+    int numModes      = 2;
+    T   modes[6]      = {10.0, 15.0, 14.0, 12.566370614359172, 0, 0};
+    T   phaseReal[6]  = {1.1, 1.2, 1.3, 1.0, 1.0, 1.0};
+    T   phaseImag[6]  = {0.7, 0.8, 0.9, 1.0, 1.0, 1.0};
+    T   amplitudes[2] = {2.0, 1.0};
+
+    auto [ax, ay, az] = sph::stirParticle<T, T, T>(ndim, xi, yi, zi, numModes, modes, phaseReal, phaseImag, amplitudes);
+
+    EXPECT_NEAR(ax, -2.1398843541189447 - 0.22123189208356875, tol);
+    EXPECT_NEAR(ay, -2.3313952836997660 - 0.22123189208356875, tol);
+    EXPECT_NEAR(az, -2.5229059800250133 - 0.22123189208356875, tol);
+}
+
+TEST(Turbulence, computePhases)
+{
+    using T = double;
+
+    T              tol        = 1.e-8;
+    size_t         ndim       = 3;
+    size_t         numModes   = 1;
+    std::vector<T> modes      = {10.0, 15.0, 14.0};
+    std::vector<T> phasesReal = {0, 0, 0};
+    std::vector<T> phasesImag = {0, 0, 0};
+    std::vector<T> OUPhases   = {0.7, 0.8, 0.9, 1.0, 1.0, 1.0};
+    T              solWeight  = 0.5;
+
+    sph::computePhases(numModes, ndim, OUPhases, solWeight, modes, phasesReal, phasesImag);
+
+    // comparison against analytical values
+    EXPECT_NEAR(phasesReal[0], 0.35, tol); // fortran value 0.34999999403953552
+    EXPECT_NEAR(phasesReal[1], 0.45, tol); // fortran value 0.44999998807907104
+    EXPECT_NEAR(phasesReal[2], 0.50, tol); // fortran value 0.50000000000000000
+    EXPECT_NEAR(phasesImag[0], 0.40, tol); // fortran value 0.40000000596046448
+    EXPECT_NEAR(phasesImag[1], 0.50, tol); // fortran value 0.50000000000000000
+    EXPECT_NEAR(phasesImag[2], 0.50, tol); // fortran value 0.50000000000000000
+}


### PR DESCRIPTION
Cleaned version of https://github.com/unibas-dmi-hpc/SPH-EXA/pull/420
Not all the Todos have been addressed yet, but at least test coverage is expanded.