### PR TITLE
Fix exclusive_scans and prevent empty grid launches

### DIFF
--- a/domain/include/cstone/domain/domaindecomp.hpp
+++ b/domain/include/cstone/domain/domaindecomp.hpp
@@ -49,8 +49,8 @@ namespace cstone
 template<class IndexType>
 void uniformBins(const std::vector<IndexType>& counts, gsl::span<TreeNodeIndex> bins, gsl::span<LocalIndex> binCounts)
 {
-    std::vector<uint64_t> countScan(counts.size() + 1);
-    std::exclusive_scan(counts.begin(), counts.end() + 1, countScan.begin(), uint64_t(0));
+    std::vector<uint64_t> countScan(counts.size() + 1, 0);
+    std::inclusive_scan(counts.begin(), counts.end(), countScan.begin() + 1, std::plus<>{}, uint64_t(0));
 
     int numBins   = bins.size() - 1;
     auto binCount = double(countScan.back()) / numBins;

--- a/domain/include/cstone/focus/octree_focus.hpp
+++ b/domain/include/cstone/focus/octree_focus.hpp
@@ -204,7 +204,8 @@ struct CombinedUpdate
         if (status == ResolutionStatus::failed)
         {
             converged = false;
-            injectKeysGpu(tree, leaves, d_mandatoryKeys);
+            injectKeysGpu(leaves, {d_mandatoryKeys.data(), d_mandatoryKeys.size()}, tree.prefixes, tree.childOffsets,
+                          tree.internalToLeaf);
         }
 
         tree.resize(nNodes(leaves));

--- a/domain/include/cstone/focus/octree_focus_mpi.hpp
+++ b/domain/include/cstone/focus/octree_focus_mpi.hpp
@@ -369,8 +369,8 @@ public:
             auto* d_layout     = reinterpret_cast<LocalIndex*>(rawPtr(scratch1));
 
             fillGpu(d_layout, d_layout + octree.numLeafNodes + 1, LocalIndex(0));
-            exclusiveScanGpu(rawPtr(leafCountsAcc_) + firstIdx, rawPtr(leafCountsAcc_) + lastIdx + 1,
-                             d_layout + firstIdx);
+            inclusiveScanGpu(rawPtr(leafCountsAcc_) + firstIdx, rawPtr(leafCountsAcc_) + lastIdx,
+                             d_layout + firstIdx + 1);
             computeLeafSourceCenterGpu(x, y, z, m, octree.leafToInternal + octree.numInternalNodes, octree.numLeafNodes,
                                        d_layout, rawPtr(centersAcc_));
             //! upsweep with local data in place
@@ -384,8 +384,8 @@ public:
         {
             //! compute temporary pre-halo exchange particle layout for local particles only
             std::vector<LocalIndex> layout(leafCounts_.size() + 1, 0);
-            std::exclusive_scan(leafCounts_.begin() + firstIdx, leafCounts_.begin() + lastIdx + 1,
-                                layout.begin() + firstIdx, 0);
+            std::inclusive_scan(leafCounts_.begin() + firstIdx, leafCounts_.begin() + lastIdx,
+                                layout.begin() + firstIdx + 1, std::plus<>{}, LocalIndex(0));
 #pragma omp parallel for schedule(static)
             for (TreeNodeIndex leafIdx = 0; leafIdx < treeData_.numLeafNodes; ++leafIdx)
             {

--- a/domain/include/cstone/focus/rebalance_gpu.cu
+++ b/domain/include/cstone/focus/rebalance_gpu.cu
@@ -191,7 +191,10 @@ ResolutionStatus enforceKeysGpu(const KeyType* forcedKeys,
                                 TreeNodeIndex* nodeOps)
 {
     resetEnforceKeyStatus<<<1, 1>>>();
-    enforceKeysKernel<<<numForcedKeys, 1>>>(forcedKeys, nodeKeys, childOffsets, parents, nodeOps);
+    if (numForcedKeys)
+    {
+        enforceKeysKernel<<<numForcedKeys, 1>>>(forcedKeys, nodeKeys, childOffsets, parents, nodeOps);
+    }
 
     int status;
     checkGpuErrors(cudaMemcpyFromSymbol(&status, enforceKeyStatus_device, sizeof(ResolutionStatus)));

--- a/domain/include/cstone/primitives/primitives_gpu.cu
+++ b/domain/include/cstone/primitives/primitives_gpu.cu
@@ -351,6 +351,40 @@ template void exclusiveScanGpu(const int*, const int*, uint64_t*, uint64_t);
 template void exclusiveScanGpu(const unsigned*, const unsigned*, unsigned*, unsigned);
 template void exclusiveScanGpu(const unsigned*, const unsigned*, uint64_t*, uint64_t);
 
+template<class IndexType, class SumType>
+void inclusiveScanGpu(const IndexType* first, const IndexType* last, SumType* output)
+{
+    thrust::inclusive_scan(thrust::device, first, last, output);
+
+    /*! Accumulation in 64-bit from 32-bit inputs only works by explicitly setting the type of the initial
+     *  value, which is only supported in Thrust/CUB version shipped with CUDA 12.7 and later
+     */
+    // thrust::inclusive_scan(thrust::device, first, last, output, SumType(0), thrust::plus<>{});
+    /*
+    SumType init = 0;
+    size_t temp_storage_bytes{};
+    size_t num_elements = last - first;
+    cub::DeviceScan::InclusiveScanInit(nullptr, temp_storage_bytes, first, output, thrust::plus<>{}, init,
+                                       num_elements);
+
+    // Allocate temporary storage for inclusive scan
+    uint8_t* temp_storage;
+    checkGpuErrors(cudaMalloc(&temp_storage, temp_storage_bytes));
+
+    // Run inclusive prefix sum
+    cub::DeviceScan::InclusiveScanInit(temp_storage, temp_storage_bytes, first, output, thrust::plus<>{}, init,
+                                       num_elements);
+
+    checkGpuErrors(cudaFree(temp_storage));
+    */
+}
+
+template void inclusiveScanGpu(const int*, const int*, int*);
+template void inclusiveScanGpu(const int*, const int*, unsigned*);
+// template void inclusiveScanGpu(const int*, const int*, uint64_t*);
+template void inclusiveScanGpu(const unsigned*, const unsigned*, unsigned*);
+// template void inclusiveScanGpu(const unsigned*, const unsigned*, uint64_t*);
+
 template<class ValueType>
 size_t countGpu(const ValueType* first, const ValueType* last, ValueType v)
 {

--- a/domain/include/cstone/primitives/primitives_gpu.h
+++ b/domain/include/cstone/primitives/primitives_gpu.h
@@ -105,6 +105,9 @@ template<class IndexType, class SumType>
 extern void exclusiveScanGpu(const IndexType* first, const IndexType* last, SumType* output, SumType init);
 
 template<class IndexType, class SumType>
+extern void inclusiveScanGpu(const IndexType* first, const IndexType* last, SumType* output);
+
+template<class IndexType, class SumType>
 void exclusiveScanGpu(const IndexType* first, const IndexType* last, SumType* output)
 {
     exclusiveScanGpu(first, last, output, SumType(0));

--- a/domain/include/cstone/traversal/collisions_gpu.cu
+++ b/domain/include/cstone/traversal/collisions_gpu.cu
@@ -156,8 +156,11 @@ void markMacsGpu(const KeyType* prefixes,
     constexpr unsigned numThreads = 128;
     unsigned numBlocks            = iceil(numFocusNodes, numThreads);
 
-    markMacsGpuKernel<<<numBlocks, numThreads>>>(prefixes, childOffsets, centers, box, focusNodes, numFocusNodes,
-                                                 limitSource, markings);
+    if (numFocusNodes)
+    {
+        markMacsGpuKernel<<<numBlocks, numThreads>>>(prefixes, childOffsets, centers, box, focusNodes, numFocusNodes,
+                                                     limitSource, markings);
+    }
 }
 
 #define MARK_MACS_GPU(KeyType, T)                                                                                      \

--- a/domain/include/cstone/tree/octree_gpu.cu
+++ b/domain/include/cstone/tree/octree_gpu.cu
@@ -165,8 +165,11 @@ void buildOctreeGpu(const KeyType* cstoneTree, OctreeView<KeyType> d)
     getLevelRange<<<maxTreeLevel<KeyType>{} + 2, 1>>>(d.prefixes, numNodes, d.levelRange);
 
     thrust::fill(thrust::device, d.childOffsets, d.childOffsets + numNodes, 0);
-    linkTree<<<iceil(d.numInternalNodes, numThreads), numThreads>>>(d.prefixes, d.numInternalNodes, d.leafToInternal,
-                                                                    d.levelRange, d.childOffsets, d.parents);
+    if (d.numInternalNodes)
+    {
+        linkTree<<<iceil(d.numInternalNodes, numThreads), numThreads>>>(
+            d.prefixes, d.numInternalNodes, d.leafToInternal, d.levelRange, d.childOffsets, d.parents);
+    }
 }
 
 template void buildOctreeGpu(const uint32_t*, OctreeView<uint32_t>);

--- a/domain/test/coord_samples/random.hpp
+++ b/domain/test/coord_samples/random.hpp
@@ -247,8 +247,8 @@ void adjustSmoothingLength(LocalIndex numParticles,
     octree.resize(nNodes(csTree));
     updateInternalTree<KeyType>(csTree, octree.data());
 
-    std::vector<LocalIndex> layout(nNodes(csTree) + 1);
-    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), 0);
+    std::vector<LocalIndex> layout(nNodes(csTree) + 1, 0);
+    std::inclusive_scan(counts.begin(), counts.end(), layout.begin() + 1);
 
     gsl::span<const KeyType> nodeKeys(octree.prefixes.data(), octree.numNodes);
     std::vector<Vec3<Tc>> centers(octree.numNodes), sizes(octree.numNodes);

--- a/domain/test/performance/neighbor_driver.cu
+++ b/domain/test/performance/neighbor_driver.cu
@@ -205,8 +205,8 @@ void benchmarkGpu()
     const TreeNodeIndex* childOffsets = octree.childOffsets.data();
     const TreeNodeIndex* toLeafOrder  = octree.internalToLeaf.data();
 
-    std::vector<LocalIndex> layout(nNodes(csTree) + 1);
-    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), 0);
+    std::vector<LocalIndex> layout(nNodes(csTree) + 1, 0);
+    std::inclusive_scan(counts.begin(), counts.end(), layout.begin() + 1);
 
     std::vector<Vec3<T>> centers(octree.numNodes), sizes(octree.numNodes);
     gsl::span<const KeyType> nodeKeys(octree.prefixes.data(), octree.numNodes);

--- a/domain/test/unit/domain/domaindecomp.cpp
+++ b/domain/test/unit/domain/domaindecomp.cpp
@@ -39,15 +39,16 @@ using namespace cstone;
 TEST(DomainDecomposition, uniformBins)
 {
     {
+        unsigned umax = std::numeric_limits<unsigned>::max();
         int numSplits = 2;
-        std::vector<unsigned> counts{5, 5, 5, 5, 5, 6};
+        std::vector<unsigned> counts{umax - 10, 5, 5, umax - 11, 5, 6};
 
         std::vector<TreeNodeIndex> bins(numSplits + 1);
         std::vector<unsigned> binCounts(numSplits);
         uniformBins(counts, bins, binCounts);
 
         std::vector<TreeNodeIndex> ref{0, 3, 6};
-        std::vector<unsigned> refCnt{15, 16};
+        std::vector<unsigned> refCnt{umax, umax};
         EXPECT_EQ(bins, ref);
         EXPECT_EQ(binCounts, refCnt);
     }

--- a/domain/test/unit/focus/source_center.cpp
+++ b/domain/test/unit/focus/source_center.cpp
@@ -91,8 +91,8 @@ static void computeSourceCenter()
     std::generate(begin(masses), end(masses), [numParticles]() { return drand48() / numParticles; });
     std::vector<util::array<T, 4>> centers(octree.numNodes);
 
-    std::vector<LocalIndex> layout(octree.numLeafNodes + 1);
-    std::exclusive_scan(csCounts.begin(), csCounts.end() + 1, layout.begin(), LocalIndex(0));
+    std::vector<LocalIndex> layout(octree.numLeafNodes + 1, 0);
+    std::inclusive_scan(csCounts.begin(), csCounts.end(), layout.begin() + 1);
 
     auto toInternal = leafToInternal(octree);
     computeLeafMassCenter<T, T, T>(coords.x(), coords.y(), coords.z(), masses, toInternal, layout.data(),

--- a/domain/test/unit/neighbors/findneighbors.cpp
+++ b/domain/test/unit/neighbors/findneighbors.cpp
@@ -82,8 +82,8 @@ void neighborCheck(const Coordinates& coords, T radius, const Box<T>& box)
     octree.resize(nNodes(csTree));
     updateInternalTree<KeyType>(csTree, octree.data());
 
-    std::vector<LocalIndex> layout(nNodes(csTree) + 1);
-    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), 0);
+    std::vector<LocalIndex> layout(nNodes(csTree) + 1, 0);
+    std::inclusive_scan(counts.begin(), counts.end(), layout.begin() + 1);
 
     gsl::span<const KeyType> nodeKeys(octree.prefixes.data(), octree.numNodes);
     std::vector<Vec3<T>> centers(octree.numNodes), sizes(octree.numNodes);

--- a/domain/test/unit/traversal/macs.cpp
+++ b/domain/test/unit/traversal/macs.cpp
@@ -155,8 +155,8 @@ static void markMacVector()
     octree.resize(nNodes(leaves));
     updateInternalTree<KeyType>(leaves, octree.data());
 
-    std::vector<LocalIndex> layout(octree.numLeafNodes + 1);
-    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), LocalIndex(0));
+    std::vector<LocalIndex> layout(octree.numLeafNodes + 1, 0);
+    std::inclusive_scan(counts.begin(), counts.end(), layout.begin() + 1);
 
     auto toInternal = leafToInternal(octree);
 

--- a/domain/test/unit_cuda/focus/inject.cu
+++ b/domain/test/unit_cuda/focus/inject.cu
@@ -42,12 +42,13 @@ TEST(FocusGpu, injectKeysGpu)
 {
     using KeyType = uint64_t;
 
-    OctreeData<KeyType, GpuTag> tree;
-
     DeviceVector<KeyType> leaves        = std::vector<KeyType>{0, 64};
     DeviceVector<KeyType> mandatoryKeys = std::vector<KeyType>{0, 32, 64};
 
-    injectKeysGpu(tree, leaves, mandatoryKeys);
+    DeviceVector<KeyType> keyScratch;
+    DeviceVector<TreeNodeIndex> s1, s2;
+
+    injectKeysGpu(leaves, {mandatoryKeys.data(), mandatoryKeys.size()}, keyScratch, s1, s2);
 
     DeviceVector<KeyType> ref = std::vector<KeyType>{0, 8, 16, 24, 32, 40, 48, 56, 64};
 

--- a/domain/test/unit_cuda/primitives/primitives_gpu.cu
+++ b/domain/test/unit_cuda/primitives/primitives_gpu.cu
@@ -65,7 +65,7 @@ TEST(PrimitivesGpu, segmentMax)
     unsigned numSegments = 120;
     std::vector<unsigned> h_segments(numSegments + 1, numElements / numSegments);
     h_segments[numSegments - 1] += numElements % numSegments;
-    std::exclusive_scan(h_segments.begin(), h_segments.end() + 1, h_segments.begin(), 0);
+    std::exclusive_scan(h_segments.begin(), h_segments.end(), h_segments.begin(), 0);
 
     thrust::device_vector<unsigned> segments = h_segments;
     thrust::device_vector<double> output(numSegments);

--- a/domain/test/unit_cuda/traversal/groups.cu
+++ b/domain/test/unit_cuda/traversal/groups.cu
@@ -232,8 +232,8 @@ TEST(TargetGroups, groupVolumes)
     // nodeIdx                   0  1 |2  3  4  5  6   7  8  9 |10  11  12 13 14 15
     // fixed groups                |                 |                   |
     std::vector<unsigned> counts{4, 1, 8, 8, 8, 8, 31, 8, 8, 8, 16, 16, 16, 0, 0};
-    std::vector<LocalIndex> layout(counts.size() + 1);
-    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), 0);
+    std::vector<LocalIndex> layout(counts.size() + 1, 0);
+    std::inclusive_scan(counts.begin(), counts.end(), layout.begin() + 1);
 
     // these coordinates do not lie in the leaf cells specified by layout, but this is irrelevant for this test case
     thrust::device_vector<T> x(last), y(last), z(last), h(last);

--- a/ryoanji/test/nbody/ewald_cpu.cpp
+++ b/ryoanji/test/nbody/ewald_cpu.cpp
@@ -171,8 +171,8 @@ makeTestTree(Coords& coordinates, cstone::Box<T> box, float mass_scale, float th
     updateInternalTree<KeyType>(treeLeaves, octree.data());
 
     // layout[i] is equal to the index in (x,y,z,m) of the first particle in leaf cell with index i
-    std::vector<LocalIndex> layout(octree.numLeafNodes + 1);
-    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), LocalIndex(0));
+    std::vector<LocalIndex> layout(octree.numLeafNodes + 1, 0);
+    std::inclusive_scan(counts.begin(), counts.end(), layout.begin() + 1);
 
     auto toInternal = leafToInternal(octree);
 

--- a/ryoanji/test/nbody/traversal_cpu.cpp
+++ b/ryoanji/test/nbody/traversal_cpu.cpp
@@ -74,8 +74,8 @@ TEST(Gravity, TreeWalk)
     updateInternalTree<KeyType>(treeLeaves, octree.data());
 
     // layout[i] is equal to the index in (x,y,z,m) of the first particle in leaf cell with index i
-    std::vector<LocalIndex> layout(octree.numLeafNodes + 1);
-    std::exclusive_scan(counts.begin(), counts.end() + 1, layout.begin(), LocalIndex(0));
+    std::vector<LocalIndex> layout(octree.numLeafNodes + 1, 0);
+    std::inclusive_scan(counts.begin(), counts.end(), layout.begin() + 1);
 
     auto toInternal = leafToInternal(octree);
 


### PR DESCRIPTION
* prevent out-of-bounds read in exclusiveScan
* clean and document implementation of injectKeysGpu
* revert assembleCubid upper bounds to be exclusive