### PR TITLE
Enable calculation of the potential if the field is allocated

### DIFF
--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -39,7 +39,7 @@ template<class KeyType, class T>
 class GlobalAssignment
 {
 public:
-    GlobalAssignment(int rank, int nRanks, unsigned bucketSize, const Box<T>& box = Box<T>{0, 1})
+    GlobalAssignment(int rank, int nRanks, unsigned bucketSize, const Box<T>& box)
         : myRank_(rank)
         , numRanks_(nRanks)
         , bucketSize_(bucketSize)
@@ -77,12 +77,12 @@ public:
         // number of locally assigned particles to consider for global tree building
         LocalIndex numParticles = bufDesc.end - bufDesc.start;
 
-        const auto fittingBox =
-            makeGlobalBox(x + bufDesc.start, y + bufDesc.start, z + bufDesc.start, numParticles, box_);
-        box_ = limitBoxShrinking(fittingBox, box_);
-        gsl::span<KeyType> keyView(particleKeys + bufDesc.start, numParticles);
+        auto fittingBox = makeGlobalBox(x + bufDesc.start, y + bufDesc.start, z + bufDesc.start, numParticles, box_);
+        if (firstCall_) { box_ = fittingBox; }
+        else { box_ = limitBoxShrinking(fittingBox, box_); }
 
         // compute SFC particle keys only for particles participating in tree build
+        gsl::span<KeyType> keyView(particleKeys + bufDesc.start, numParticles);
         computeSfcKeys(x + bufDesc.start, y + bufDesc.start, z + bufDesc.start, sfcKindPointer(keyView.data()),
                        numParticles, box_);
 

--- a/domain/test/integration_mpi/domain_resize.cpp
+++ b/domain/test/integration_mpi/domain_resize.cpp
@@ -54,7 +54,7 @@ TEST(GlobalDomainResize, resize)
     // Add two new particles on each rank
     int n_new = 2;
     // If halos are large enough, no resizing required
-    int add_size = n_new - int(domain.endIndex()) + int(x.size());
+    int add_size = n_new - (int(x.size()) - domain.endIndex());
     // Resize
     if (add_size > 0)
     {

--- a/main/src/propagator/gravity_wrapper.hpp
+++ b/main/src/propagator/gravity_wrapper.hpp
@@ -77,20 +77,18 @@ public:
         bool        usePbc    = box.boundaryX() == cstone::BoundaryType::periodic;
         int         numShells = usePbc ? ewaldSettings_.numReplicaShells : 0;
 
-        d.egrav         = 0;
-        auto* potential = d.potential.empty() ? nullptr : d.potential.data();
-
+        d.egrav = 0;
         ryoanji::computeGravity(octree.childOffsets, octree.internalToLeaf, focusTree.expansionCentersAcc().data(),
                                 multipoles_.data(), domain.layout().data(), domain.startCell(), domain.endCell(),
                                 d.x.data(), d.y.data(), d.z.data(), d.h.data(), d.m.data(), domain.box(), d.g,
-                                potential, d.ax.data(), d.ay.data(), d.az.data(), &d.egrav, numShells);
+                                d.ugrav.data(), d.ax.data(), d.ay.data(), d.az.data(), &d.egrav, numShells);
 
         if (usePbc)
         {
             ryoanji::computeGravityEwald(makeVec3(focusTree.expansionCentersAcc()[0]), multipoles_.front(),
                                          domain.startIndex(), domain.endIndex(), d.x.data(), d.y.data(), d.z.data(),
-                                         d.m.data(), box, d.g, d.potential.data(), d.ax.data(), d.ay.data(),
-                                         d.az.data(), &d.egrav, ewaldSettings_);
+                                         d.m.data(), box, d.g, d.ugrav.data(), d.ax.data(), d.ay.data(), d.az.data(),
+                                         &d.egrav, ewaldSettings_);
         }
     }
 
@@ -137,10 +135,10 @@ public:
         bool        usePbc    = box.boundaryX() == cstone::BoundaryType::periodic;
         int         numShells = usePbc ? ewaldSettings_.numReplicaShells : 0;
 
-        auto* potential = d.devData.potential.empty() ? nullptr : rawPtr(d.devData.potential);
-        d.egrav         = mHolder_.compute(grp, rawPtr(d.devData.x), rawPtr(d.devData.y), rawPtr(d.devData.z),
-                                           rawPtr(d.devData.m), rawPtr(d.devData.h), d.g, numShells, domain.box(), potential,
-                                           rawPtr(d.devData.ax), rawPtr(d.devData.ay), rawPtr(d.devData.az));
+        d.egrav =
+            mHolder_.compute(grp, rawPtr(d.devData.x), rawPtr(d.devData.y), rawPtr(d.devData.z), rawPtr(d.devData.m),
+                             rawPtr(d.devData.h), d.g, numShells, domain.box(), rawPtr(d.devData.ugrav),
+                             rawPtr(d.devData.ax), rawPtr(d.devData.ay), rawPtr(d.devData.az));
 
         auto stats = mHolder_.readStats();
 
@@ -155,7 +153,7 @@ public:
             memcpyD2H(mHolder_.deviceMultipoles(), 1, &rootM);
 
             computeGravityEwaldGpu(makeVec3(rootCenter), rootM, grp, rawPtr(d.devData.x), rawPtr(d.devData.y),
-                                   rawPtr(d.devData.z), rawPtr(d.devData.m), box, d.g, rawPtr(d.devData.potential),
+                                   rawPtr(d.devData.z), rawPtr(d.devData.m), box, d.g, rawPtr(d.devData.ugrav),
                                    rawPtr(d.devData.ax), rawPtr(d.devData.ay), rawPtr(d.devData.az), &d.egrav,
                                    ewaldSettings_);
         }

--- a/main/src/propagator/std_hydro.hpp
+++ b/main/src/propagator/std_hydro.hpp
@@ -70,7 +70,7 @@ protected:
      *
      * x, y, z, h and m are automatically considered conserved and must not be specified in this list
      */
-    using ConservedFields = FieldList<"temp", "vx", "vy", "vz", "x_m1", "y_m1", "z_m1", "du_m1", "id", "potential">;
+    using ConservedFields = FieldList<"temp", "vx", "vy", "vz", "x_m1", "y_m1", "z_m1", "du_m1", "id">;
 
     //! @brief the list of dependent particle fields, these may be used as scratch space during domain sync
     using DependentFields =

--- a/main/src/propagator/std_hydro.hpp
+++ b/main/src/propagator/std_hydro.hpp
@@ -70,7 +70,7 @@ protected:
      *
      * x, y, z, h and m are automatically considered conserved and must not be specified in this list
      */
-    using ConservedFields = FieldList<"temp", "vx", "vy", "vz", "x_m1", "y_m1", "z_m1", "du_m1", "id">;
+    using ConservedFields = FieldList<"temp", "vx", "vy", "vz", "x_m1", "y_m1", "z_m1", "du_m1", "id", "potential">;
 
     //! @brief the list of dependent particle fields, these may be used as scratch space during domain sync
     using DependentFields =

--- a/ryoanji/src/ryoanji/interface/multipole_holder.cu
+++ b/ryoanji/src/ryoanji/interface/multipole_holder.cu
@@ -128,7 +128,7 @@ public:
     }
 
     float compute(GroupView grp, const Tc* x, const Tc* y, const Tc* z, const Tm* m, const Th* h, Tc G, int numShells,
-                  const cstone::Box<Tc>& box, Ta* potential, Ta* ax, Ta* ay, Ta* az)
+                  const cstone::Box<Tc>& box, Ta* ugrav, Ta* ax, Ta* ay, Ta* az)
     {
         int numWarpsPerBlock = TravConfig::numThreads / cstone::GpuConfig::warpSize;
         int numBlocks        = cstone::iceil(grp.numGroups, numWarpsPerBlock);
@@ -140,7 +140,7 @@ public:
         reallocate(traversalStack_, poolSize, 1.01);
         traverse<<<numBlocks, TravConfig::numThreads>>>(
             grp, 1, x, y, z, m, h, octree_.childOffsets, octree_.internalToLeaf, layout_, centers_, rawPtr(multipoles_),
-            G, numShells, Vec3<Tc>{box.lx(), box.ly(), box.lz()}, potential, ax, ay, az, (int*)rawPtr(traversalStack_));
+            G, numShells, Vec3<Tc>{box.lx(), box.ly(), box.lz()}, ugrav, ax, ay, az, (int*)rawPtr(traversalStack_));
         float totalPotential;
         checkGpuErrors(cudaMemcpyFromSymbol(&totalPotential, GPU_SYMBOL(totalPotentialGlob), sizeof(float)));
         return 0.5f * Tc(G) * totalPotential;
@@ -219,10 +219,10 @@ void MultipoleHolder<Tc, Th, Tm, Ta, Tf, KeyType, MType>::upsweep(
 template<class Tc, class Th, class Tm, class Ta, class Tf, class KeyType, class MType>
 float MultipoleHolder<Tc, Th, Tm, Ta, Tf, KeyType, MType>::compute(GroupView grp, const Tc* x, const Tc* y, const Tc* z,
                                                                    const Tm* m, const Th* h, Tc G, int numShells,
-                                                                   const cstone::Box<Tc>& box, Ta* potential, Ta* ax,
+                                                                   const cstone::Box<Tc>& box, Ta* ugrav, Ta* ax,
                                                                    Ta* ay, Ta* az)
 {
-    return impl_->compute(grp, x, y, z, m, h, G, numShells, box, potential, ax, ay, az);
+    return impl_->compute(grp, x, y, z, m, h, G, numShells, box, ugrav, ax, ay, az);
 }
 
 template<class Tc, class Th, class Tm, class Ta, class Tf, class KeyType, class MType>

--- a/ryoanji/src/ryoanji/interface/multipole_holder.cu
+++ b/ryoanji/src/ryoanji/interface/multipole_holder.cu
@@ -128,7 +128,7 @@ public:
     }
 
     float compute(GroupView grp, const Tc* x, const Tc* y, const Tc* z, const Tm* m, const Th* h, Tc G, int numShells,
-                  const cstone::Box<Tc>& box, Ta* ax, Ta* ay, Ta* az)
+                  const cstone::Box<Tc>& box, Ta* potential, Ta* ax, Ta* ay, Ta* az)
     {
         int numWarpsPerBlock = TravConfig::numThreads / cstone::GpuConfig::warpSize;
         int numBlocks        = cstone::iceil(grp.numGroups, numWarpsPerBlock);
@@ -138,10 +138,9 @@ public:
         resetTraversalCounters<<<1, 1>>>();
 
         reallocate(traversalStack_, poolSize, 1.01);
-        traverse<<<numBlocks, TravConfig::numThreads>>>(grp, 1, x, y, z, m, h, octree_.childOffsets,
-                                                        octree_.internalToLeaf, layout_, centers_, rawPtr(multipoles_),
-                                                        G, numShells, Vec3<Tc>{box.lx(), box.ly(), box.lz()},
-                                                        (Ta*)nullptr, ax, ay, az, (int*)rawPtr(traversalStack_));
+        traverse<<<numBlocks, TravConfig::numThreads>>>(
+            grp, 1, x, y, z, m, h, octree_.childOffsets, octree_.internalToLeaf, layout_, centers_, rawPtr(multipoles_),
+            G, numShells, Vec3<Tc>{box.lx(), box.ly(), box.lz()}, potential, ax, ay, az, (int*)rawPtr(traversalStack_));
         float totalPotential;
         checkGpuErrors(cudaMemcpyFromSymbol(&totalPotential, GPU_SYMBOL(totalPotentialGlob), sizeof(float)));
         return 0.5f * Tc(G) * totalPotential;
@@ -220,9 +219,10 @@ void MultipoleHolder<Tc, Th, Tm, Ta, Tf, KeyType, MType>::upsweep(
 template<class Tc, class Th, class Tm, class Ta, class Tf, class KeyType, class MType>
 float MultipoleHolder<Tc, Th, Tm, Ta, Tf, KeyType, MType>::compute(GroupView grp, const Tc* x, const Tc* y, const Tc* z,
                                                                    const Tm* m, const Th* h, Tc G, int numShells,
-                                                                   const cstone::Box<Tc>& box, Ta* ax, Ta* ay, Ta* az)
+                                                                   const cstone::Box<Tc>& box, Ta* potential, Ta* ax,
+                                                                   Ta* ay, Ta* az)
 {
-    return impl_->compute(grp, x, y, z, m, h, G, numShells, box, ax, ay, az);
+    return impl_->compute(grp, x, y, z, m, h, G, numShells, box, potential, ax, ay, az);
 }
 
 template<class Tc, class Th, class Tm, class Ta, class Tf, class KeyType, class MType>

--- a/ryoanji/src/ryoanji/interface/multipole_holder.cuh
+++ b/ryoanji/src/ryoanji/interface/multipole_holder.cuh
@@ -58,7 +58,7 @@ public:
                  MType* multipoles);
 
     float compute(cstone::GroupView grp, const Tc* x, const Tc* y, const Tc* z, const Tm* m, const Th* h, Tc G,
-                  int numShells, const cstone::Box<Tc>& box, Ta* potential, Ta* ax, Ta* ay, Ta* az);
+                  int numShells, const cstone::Box<Tc>& box, Ta* ugrav, Ta* ax, Ta* ay, Ta* az);
 
     util::array<uint64_t, 5> readStats() const;
 

--- a/ryoanji/src/ryoanji/interface/multipole_holder.cuh
+++ b/ryoanji/src/ryoanji/interface/multipole_holder.cuh
@@ -58,7 +58,7 @@ public:
                  MType* multipoles);
 
     float compute(cstone::GroupView grp, const Tc* x, const Tc* y, const Tc* z, const Tm* m, const Th* h, Tc G,
-                  int numShells, const cstone::Box<Tc>& box, Ta* ax, Ta* ay, Ta* az);
+                  int numShells, const cstone::Box<Tc>& box, Ta* potential, Ta* ax, Ta* ay, Ta* az);
 
     util::array<uint64_t, 5> readStats() const;
 

--- a/ryoanji/src/ryoanji/nbody/ewald.hpp
+++ b/ryoanji/src/ryoanji/nbody/ewald.hpp
@@ -372,7 +372,7 @@ HOST_DEVICE_FUN Vec4<T1> computeEwaldKSpace(Vec3<T1> r, const EwaldParameters<T1
 template<class MType, class Tc, class Ta, class Tm, class Tu>
 void computeGravityEwald(const cstone::Vec3<Tc>& rootCenter, const MType& Mroot, LocalIndex firstTarget,
                          LocalIndex lastTarget, const Tc* x, const Tc* y, const Tc* z, const Tm* m,
-                         const cstone::Box<Tc>& box, float G, Tu* ugrav, Ta* ax, Ta* ay, Ta* az, Tu* ugravTot,
+                         const cstone::Box<Tc>& box, float G, Ta* ugrav, Ta* ax, Ta* ay, Ta* az, Tu* ugravTot,
                          EwaldSettings settings)
 {
     if (box.minExtent() != box.maxExtent()) { throw std::runtime_error("Ewald gravity requires cubic bounding boxes"); }

--- a/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
+++ b/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
@@ -176,7 +176,7 @@ template<class MType, class T1, class T2, class Tm>
 void computeGravity(const TreeNodeIndex* childOffsets, const TreeNodeIndex* internalToLeaf,
                     const cstone::SourceCenterType<T1>* macSpheres, const MType* multipoles, const LocalIndex* layout,
                     TreeNodeIndex firstLeafIndex, TreeNodeIndex lastLeafIndex, const T1* x, const T1* y, const T1* z,
-                    const T2* h, const Tm* m, const cstone::Box<T1>& box, float G, T1* ugrav, T2* ax, T2* ay, T2* az,
+                    const T2* h, const Tm* m, const cstone::Box<T1>& box, float G, T2* ugrav, T2* ax, T2* ay, T2* az,
                     T1* ugravTot, int numShells = 0)
 {
     constexpr LocalIndex groupSize   = 16;

--- a/ryoanji/test/demo_mpi.cpp
+++ b/ryoanji/test/demo_mpi.cpp
@@ -104,7 +104,7 @@ void ryoanjiTest(int thisRank, int numRanks, size_t numParticlesGlobal)
     // compute accelerations for locally owned particles based on globally valid multipoles and
     // halo particles are in [0:domain.startIndex()] and in [domain.endIndex():domain.nParticlesWithHalos()]
     float totalPotential = multipoleHolder.compute(grp, rawPtr(d_x), rawPtr(d_y), rawPtr(d_z), rawPtr(d_m), rawPtr(d_h),
-                                                   G, 0, box, rawPtr(d_ax), rawPtr(d_ay), rawPtr(d_az));
+                                                   G, 0, box, nullptr, rawPtr(d_ax), rawPtr(d_ay), rawPtr(d_az));
 
     auto t1 = std::chrono::high_resolution_clock::now();
     auto dt = std::chrono::duration<double>(t1 - t0).count();

--- a/ryoanji/test/interface/global_forces_gpu.cpp
+++ b/ryoanji/test/interface/global_forces_gpu.cpp
@@ -127,11 +127,12 @@ static int multipoleHolderTest(int thisRank, int numRanks)
         d_ay = std::vector<T>(domain.nParticlesWithHalos(), 0);
         d_az = std::vector<T>(domain.nParticlesWithHalos(), 0);
 
-        auto   grp         = multipoleHolder.computeSpatialGroups(domain.startIndex(), domain.endIndex(), rawPtr(d_x),
-                                                                  rawPtr(d_y), rawPtr(d_z), rawPtr(d_h), domain.focusTree(),
-                                                                  domain.layout().data(), domain.box());
-        double bhPotential = multipoleHolder.compute(grp, rawPtr(d_x), rawPtr(d_y), rawPtr(d_z), rawPtr(d_m),
-                                                     rawPtr(d_h), G, 0, box, rawPtr(d_ax), rawPtr(d_ay), rawPtr(d_az));
+        auto   grp = multipoleHolder.computeSpatialGroups(domain.startIndex(), domain.endIndex(), rawPtr(d_x),
+                                                          rawPtr(d_y), rawPtr(d_z), rawPtr(d_h), domain.focusTree(),
+                                                          domain.layout().data(), domain.box());
+        double bhPotential =
+            multipoleHolder.compute(grp, rawPtr(d_x), rawPtr(d_y), rawPtr(d_z), rawPtr(d_m), rawPtr(d_h), G, 0, box,
+                                    nullptr, rawPtr(d_ax), rawPtr(d_ay), rawPtr(d_az));
 
         // create a host vector and download a device pointer range into it
         auto dl = [](auto* p1, auto* p2)

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -217,7 +217,7 @@ public:
     FieldVector<HydroType> cv;                                 // Specific heat
     FieldVector<HydroType> mue, mui;                           // mean molecular weight (electrons, ions)
     FieldVector<HydroType> divv, curlv;                        // Div(velocity), Curl(velocity)
-    FieldVector<HydroType> potential;                          // Gravitational potential
+    FieldVector<HydroType> ugrav;                              // Gravitational potential
     FieldVector<HydroType> ax, ay, az;                         // acceleration
     FieldVector<RealType>  du;                                 // energy rate of change (du/dt)
     FieldVector<XM1Type>   du_m1;                              // previous energy rate of change (du/dt)
@@ -245,11 +245,10 @@ public:
      * Name of each field as string for use e.g in HDF5 output. Order has to correspond to what's returned by data().
      */
     inline static constexpr std::array fieldNames{
-        "x",   "y",    "z",     "x_m1",     "y_m1", "z_m1", "vx",    "vy",        "vz",    "rho",
-        "u",   "p",    "prho",  "tdpdTrho", "h",    "m",    "c",     "potential", "ax",    "ay",
-        "az",  "du",   "du_m1", "c11",      "c12",  "c13",  "c22",   "c23",       "c33",   "mue",
-        "mui", "temp", "cv",    "xm",       "kx",   "divv", "curlv", "alpha",     "gradh", "keys",
-        "nc",  "dV11", "dV12",  "dV13",     "dV22", "dV23", "dV33",  "rung",      "id"};
+        "x",        "y",   "z",    "x_m1", "y_m1",  "z_m1", "vx",   "vy",   "vz",   "rho",   "u",     "p",     "prho",
+        "tdpdTrho", "h",   "m",    "c",    "ugrav", "ax",   "ay",   "az",   "du",   "du_m1", "c11",   "c12",   "c13",
+        "c22",      "c23", "c33",  "mue",  "mui",   "temp", "cv",   "xm",   "kx",   "divv",  "curlv", "alpha", "gradh",
+        "keys",     "nc",  "dV11", "dV12", "dV13",  "dV22", "dV23", "dV33", "rung", "id"};
 
     //! @brief dataset prefix to be prepended to fieldNames for structured output
     static const inline std::string prefix{};
@@ -263,9 +262,9 @@ public:
      */
     auto dataTuple()
     {
-        auto ret = std::tie(x, y, z, x_m1, y_m1, z_m1, vx, vy, vz, rho, u, p, prho, tdpdTrho, h, m, c, potential, ax,
-                            ay, az, du, du_m1, c11, c12, c13, c22, c23, c33, mue, mui, temp, cv, xm, kx, divv, curlv,
-                            alpha, gradh, keys, nc, dV11, dV12, dV13, dV22, dV23, dV33, rung, id);
+        auto ret = std::tie(x, y, z, x_m1, y_m1, z_m1, vx, vy, vz, rho, u, p, prho, tdpdTrho, h, m, c, ugrav, ax, ay,
+                            az, du, du_m1, c11, c12, c13, c22, c23, c33, mue, mui, temp, cv, xm, kx, divv, curlv, alpha,
+                            gradh, keys, nc, dV11, dV12, dV13, dV22, dV23, dV33, rung, id);
 
 #if defined(__clang__) || __GNUC__ > 11
         static_assert(std::tuple_size_v<decltype(ret)> == fieldNames.size());

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -217,6 +217,7 @@ public:
     FieldVector<HydroType> cv;                                 // Specific heat
     FieldVector<HydroType> mue, mui;                           // mean molecular weight (electrons, ions)
     FieldVector<HydroType> divv, curlv;                        // Div(velocity), Curl(velocity)
+    FieldVector<HydroType> potential;                          // Gravitational potential
     FieldVector<HydroType> ax, ay, az;                         // acceleration
     FieldVector<RealType>  du;                                 // energy rate of change (du/dt)
     FieldVector<XM1Type>   du_m1;                              // previous energy rate of change (du/dt)
@@ -244,10 +245,11 @@ public:
      * Name of each field as string for use e.g in HDF5 output. Order has to correspond to what's returned by data().
      */
     inline static constexpr std::array fieldNames{
-        "x",     "y",        "z",    "x_m1", "y_m1", "z_m1", "vx",   "vy",   "vz",   "rho",   "u",    "p",
-        "prho",  "tdpdTrho", "h",    "m",    "c",    "ax",   "ay",   "az",   "du",   "du_m1", "c11",  "c12",
-        "c13",   "c22",      "c23",  "c33",  "mue",  "mui",  "temp", "cv",   "xm",   "kx",    "divv", "curlv",
-        "alpha", "gradh",    "keys", "nc",   "dV11", "dV12", "dV13", "dV22", "dV23", "dV33",  "rung", "id"};
+        "x",   "y",    "z",     "x_m1",     "y_m1", "z_m1", "vx",    "vy",        "vz",    "rho",
+        "u",   "p",    "prho",  "tdpdTrho", "h",    "m",    "c",     "potential", "ax",    "ay",
+        "az",  "du",   "du_m1", "c11",      "c12",  "c13",  "c22",   "c23",       "c33",   "mue",
+        "mui", "temp", "cv",    "xm",       "kx",   "divv", "curlv", "alpha",     "gradh", "keys",
+        "nc",  "dV11", "dV12",  "dV13",     "dV22", "dV23", "dV33",  "rung",      "id"};
 
     //! @brief dataset prefix to be prepended to fieldNames for structured output
     static const inline std::string prefix{};
@@ -261,9 +263,10 @@ public:
      */
     auto dataTuple()
     {
-        auto ret = std::tie(x, y, z, x_m1, y_m1, z_m1, vx, vy, vz, rho, u, p, prho, tdpdTrho, h, m, c, ax, ay, az, du,
-                            du_m1, c11, c12, c13, c22, c23, c33, mue, mui, temp, cv, xm, kx, divv, curlv, alpha, gradh,
-                            keys, nc, dV11, dV12, dV13, dV22, dV23, dV33, rung, id);
+        auto ret = std::tie(x, y, z, x_m1, y_m1, z_m1, vx, vy, vz, rho, u, p, prho, tdpdTrho, h, m, c, potential, ax,
+                            ay, az, du, du_m1, c11, c12, c13, c22, c23, c33, mue, mui, temp, cv, xm, kx, divv, curlv,
+                            alpha, gradh, keys, nc, dV11, dV12, dV13, dV22, dV23, dV33, rung, id);
+
 #if defined(__clang__) || __GNUC__ > 11
         static_assert(std::tuple_size_v<decltype(ret)> == fieldNames.size());
 #endif

--- a/sph/include/sph/particles_data_gpu.cuh
+++ b/sph/include/sph/particles_data_gpu.cuh
@@ -73,25 +73,24 @@ public:
      * The length of these arrays equals the local number of particles including halos
      * if the field is active and is zero if the field is inactive.
      */
-    DevVector<RealType>  x, y, z;          // Positions
-    DevVector<XM1Type>   x_m1, y_m1, z_m1; // Difference to previous positions
-    DevVector<HydroType> vx, vy, vz;       // Velocities
-    DevVector<HydroType> rho;              // Density
-    DevVector<RealType>  temp;             // Temperature
-    DevVector<RealType>  u;                // Internal Energy
-    DevVector<HydroType> p;                // Pressure
-    DevVector<HydroType> prho;             // p / (kx * m^2 * gradh)
-    DevVector<HydroType> tdpdTrho;         // temp * dp/dT * prho
-    DevVector<HydroType> h;                // Smoothing Length
-    DevVector<Tmass>     m;                // Mass
-    DevVector<HydroType> c;                // Speed of sound
-    DevVector<HydroType> cv;               // Specific heat
-    DevVector<HydroType> mue, mui;         // mean molecular weight (electrons, ions)
-    DevVector<HydroType> divv, curlv;      // Div(velocity), Curl(velocity)
-    DevVector<HydroType> potential;        // Gravitational potential
-    DevVector<HydroType> ax, ay, az;       // acceleration
-    DevVector<RealType>  du;               // energy rate of change (du/dt)
-
+    DevVector<RealType>  x, y, z;                            // Positions
+    DevVector<XM1Type>   x_m1, y_m1, z_m1;                   // Difference to previous positions
+    DevVector<HydroType> vx, vy, vz;                         // Velocities
+    DevVector<HydroType> rho;                                // Density
+    DevVector<RealType>  temp;                               // Temperature
+    DevVector<RealType>  u;                                  // Internal Energy
+    DevVector<HydroType> p;                                  // Pressure
+    DevVector<HydroType> prho;                               // p / (kx * m^2 * gradh)
+    DevVector<HydroType> tdpdTrho;                           // temp * dp/dT * prho
+    DevVector<HydroType> h;                                  // Smoothing Length
+    DevVector<Tmass>     m;                                  // Mass
+    DevVector<HydroType> c;                                  // Speed of sound
+    DevVector<HydroType> cv;                                 // Specific heat
+    DevVector<HydroType> mue, mui;                           // mean molecular weight (electrons, ions)
+    DevVector<HydroType> divv, curlv;                        // Div(velocity), Curl(velocity)
+    DevVector<HydroType> ugrav;                              // Gravitational potential
+    DevVector<HydroType> ax, ay, az;                         // acceleration
+    DevVector<RealType>  du;                                 // energy rate of change (du/dt)
     DevVector<XM1Type>   du_m1;                              // previous energy rate of change (du/dt)
     DevVector<HydroType> c11, c12, c13, c22, c23, c33;       // IAD components
     DevVector<HydroType> alpha;                              // AV coeficient
@@ -116,10 +115,10 @@ public:
      * Name of each field as string for use e.g in HDF5 output. Order has to correspond to what's returned by data().
      */
     inline static constexpr std::array fieldNames{
-        "x",     "y",        "z",     "x_m1", "y_m1", "z_m1",      "vx",   "vy",   "vz",   "rho",  "u",     "p",
-        "prho",  "tdpdTrho", "h",     "m",    "c",    "potential", "ax",   "ay",   "az",   "du",   "du_m1", "c11",
-        "c12",   "c13",      "c22",   "c23",  "c33",  "mue",       "mui",  "temp", "cv",   "xm",   "kx",    "divv",
-        "curlv", "alpha",    "gradh", "keys", "nc",   "dV11",      "dV12", "dV13", "dV22", "dV23", "dV33",  "rung", "id"};
+        "x",        "y",   "z",    "x_m1", "y_m1",  "z_m1", "vx",   "vy",   "vz",   "rho",   "u",     "p",     "prho",
+        "tdpdTrho", "h",   "m",    "c",    "ugrav", "ax",   "ay",   "az",   "du",   "du_m1", "c11",   "c12",   "c13",
+        "c22",      "c23", "c33",  "mue",  "mui",   "temp", "cv",   "xm",   "kx",   "divv",  "curlv", "alpha", "gradh",
+        "keys",     "nc",  "dV11", "dV12", "dV13",  "dV22", "dV23", "dV33", "rung", "id"};
 
     /*! @brief return a tuple of field references
      *
@@ -127,9 +126,9 @@ public:
      */
     auto dataTuple()
     {
-        auto ret = std::tie(x, y, z, x_m1, y_m1, z_m1, vx, vy, vz, rho, u, p, prho, tdpdTrho, h, m, c, potential, ax,
-                            ay, az, du, du_m1, c11, c12, c13, c22, c23, c33, mue, mui, temp, cv, xm, kx, divv, curlv,
-                            alpha, gradh, keys, nc, dV11, dV12, dV13, dV22, dV23, dV33, rung, id);
+        auto ret = std::tie(x, y, z, x_m1, y_m1, z_m1, vx, vy, vz, rho, u, p, prho, tdpdTrho, h, m, c, ugrav, ax, ay,
+                            az, du, du_m1, c11, c12, c13, c22, c23, c33, mue, mui, temp, cv, xm, kx, divv, curlv, alpha,
+                            gradh, keys, nc, dV11, dV12, dV13, dV22, dV23, dV33, rung, id);
 
         static_assert(std::tuple_size_v<decltype(ret)> == fieldNames.size());
         return ret;

--- a/sph/include/sph/particles_data_gpu.cuh
+++ b/sph/include/sph/particles_data_gpu.cuh
@@ -73,23 +73,25 @@ public:
      * The length of these arrays equals the local number of particles including halos
      * if the field is active and is zero if the field is inactive.
      */
-    DevVector<RealType>  x, y, z;                            // Positions
-    DevVector<XM1Type>   x_m1, y_m1, z_m1;                   // Difference to previous positions
-    DevVector<HydroType> vx, vy, vz;                         // Velocities
-    DevVector<HydroType> rho;                                // Density
-    DevVector<RealType>  temp;                               // Temperature
-    DevVector<RealType>  u;                                  // Internal Energy
-    DevVector<HydroType> p;                                  // Pressure
-    DevVector<HydroType> prho;                               // p / (kx * m^2 * gradh)
-    DevVector<HydroType> tdpdTrho;                           // temp * dp/dT * prho
-    DevVector<HydroType> h;                                  // Smoothing Length
-    DevVector<Tmass>     m;                                  // Mass
-    DevVector<HydroType> c;                                  // Speed of sound
-    DevVector<HydroType> cv;                                 // Specific heat
-    DevVector<HydroType> mue, mui;                           // mean molecular weight (electrons, ions)
-    DevVector<HydroType> divv, curlv;                        // Div(velocity), Curl(velocity)
-    DevVector<HydroType> ax, ay, az;                         // acceleration
-    DevVector<RealType>  du;                                 // energy rate of change (du/dt)
+    DevVector<RealType>  x, y, z;          // Positions
+    DevVector<XM1Type>   x_m1, y_m1, z_m1; // Difference to previous positions
+    DevVector<HydroType> vx, vy, vz;       // Velocities
+    DevVector<HydroType> rho;              // Density
+    DevVector<RealType>  temp;             // Temperature
+    DevVector<RealType>  u;                // Internal Energy
+    DevVector<HydroType> p;                // Pressure
+    DevVector<HydroType> prho;             // p / (kx * m^2 * gradh)
+    DevVector<HydroType> tdpdTrho;         // temp * dp/dT * prho
+    DevVector<HydroType> h;                // Smoothing Length
+    DevVector<Tmass>     m;                // Mass
+    DevVector<HydroType> c;                // Speed of sound
+    DevVector<HydroType> cv;               // Specific heat
+    DevVector<HydroType> mue, mui;         // mean molecular weight (electrons, ions)
+    DevVector<HydroType> divv, curlv;      // Div(velocity), Curl(velocity)
+    DevVector<HydroType> potential;        // Gravitational potential
+    DevVector<HydroType> ax, ay, az;       // acceleration
+    DevVector<RealType>  du;               // energy rate of change (du/dt)
+
     DevVector<XM1Type>   du_m1;                              // previous energy rate of change (du/dt)
     DevVector<HydroType> c11, c12, c13, c22, c23, c33;       // IAD components
     DevVector<HydroType> alpha;                              // AV coeficient
@@ -114,10 +116,10 @@ public:
      * Name of each field as string for use e.g in HDF5 output. Order has to correspond to what's returned by data().
      */
     inline static constexpr std::array fieldNames{
-        "x",     "y",        "z",    "x_m1", "y_m1", "z_m1", "vx",   "vy",   "vz",   "rho",   "u",    "p",
-        "prho",  "tdpdTrho", "h",    "m",    "c",    "ax",   "ay",   "az",   "du",   "du_m1", "c11",  "c12",
-        "c13",   "c22",      "c23",  "c33",  "mue",  "mui",  "temp", "cv",   "xm",   "kx",    "divv", "curlv",
-        "alpha", "gradh",    "keys", "nc",   "dV11", "dV12", "dV13", "dV22", "dV23", "dV33",  "rung", "id"};
+        "x",     "y",        "z",     "x_m1", "y_m1", "z_m1",      "vx",   "vy",   "vz",   "rho",  "u",     "p",
+        "prho",  "tdpdTrho", "h",     "m",    "c",    "potential", "ax",   "ay",   "az",   "du",   "du_m1", "c11",
+        "c12",   "c13",      "c22",   "c23",  "c33",  "mue",       "mui",  "temp", "cv",   "xm",   "kx",    "divv",
+        "curlv", "alpha",    "gradh", "keys", "nc",   "dV11",      "dV12", "dV13", "dV22", "dV23", "dV33",  "rung", "id"};
 
     /*! @brief return a tuple of field references
      *
@@ -125,9 +127,9 @@ public:
      */
     auto dataTuple()
     {
-        auto ret = std::tie(x, y, z, x_m1, y_m1, z_m1, vx, vy, vz, rho, u, p, prho, tdpdTrho, h, m, c, ax, ay, az, du,
-                            du_m1, c11, c12, c13, c22, c23, c33, mue, mui, temp, cv, xm, kx, divv, curlv, alpha, gradh,
-                            keys, nc, dV11, dV12, dV13, dV22, dV23, dV33, rung, id);
+        auto ret = std::tie(x, y, z, x_m1, y_m1, z_m1, vx, vy, vz, rho, u, p, prho, tdpdTrho, h, m, c, potential, ax,
+                            ay, az, du, du_m1, c11, c12, c13, c22, c23, c33, mue, mui, temp, cv, xm, kx, divv, curlv,
+                            alpha, gradh, keys, nc, dV11, dV12, dV13, dV22, dV23, dV33, rung, id);
 
         static_assert(std::tuple_size_v<decltype(ret)> == fieldNames.size());
         return ret;

--- a/sph/test/hydro_turb/CMakeLists.txt
+++ b/sph/test/hydro_turb/CMakeLists.txt
@@ -7,7 +7,7 @@ set(UNIT_TESTS
 
 set(testname turbulence_tests)
 add_executable(${testname} ${UNIT_TESTS})
-target_compile_options(${testname} PRIVATE -Wall -Wextra)
+target_compile_options(${testname} PRIVATE -Wall -Wextra -Wno-unknown-pragmas)
 
 target_include_directories(${testname} PRIVATE ${CSTONE_DIR})
 target_include_directories(${testname} PRIVATE ${PROJECT_SOURCE_DIR}/include)


### PR DESCRIPTION
To enable, the potential field has to be activated in the propagator.
Tested with Evrard collapse (np.sum(a['Step#0']['potential'])/2. == gravitational energy)