### PR TITLE
Set sound speed per particle

### DIFF
--- a/sph/include/sph/sph_gpu.hpp
+++ b/sph/include/sph/sph_gpu.hpp
@@ -46,8 +46,9 @@ template<class Tu, class Tm, class Thydro>
 extern void computeEOS(size_t, size_t, Tm mui, Tu gamma, const Tu*, const Tm*, const Thydro*, const Thydro*,
                        const Thydro*, Thydro*, Thydro*, Thydro*, Thydro*);
 
-template<typename Dataset>
-extern void computeIsothermalEOS(size_t, size_t, Dataset& d);
+template<class Th, class Tu>
+extern void computeIsothermalEOS(size_t first, size_t last, Th cConst, Th* c, Th* rho, Th* p, const Th* m, const Th* kx,
+                                 const Th* xm, const Th* gradh, Th* prho, Tu* temp);
 
 } // namespace cuda
 


### PR DESCRIPTION
Sound speed needs to be set in the isothermal EOS per particle because
it is used in AVSwitches and MomentumEnergy (which we don't want to adapt at the moment
to use one constant value just for this particular EOS)