### PR TITLE
Apply M2P for remote empty leaves

### DIFF
--- a/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
+++ b/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
@@ -96,14 +96,23 @@ void computeGravityGroup(const util::array<Vec4<T1>, N>& target, const TreeNodeI
      * the traversal routine to keep going. If the MAC passed, the multipole moments are applied
      * to the particles in the target box and traversal is stopped.
      */
-    auto descendOrM2P = [centers, multipoles, &target, &targetCenter, &targetSize, acc](TreeNodeIndex idx)
+    auto descendOrM2P =
+        [internalToLeaf, layout, centers, multipoles, &target, &targetCenter, &targetSize, acc](TreeNodeIndex idx)
     {
         const auto& com = centers[idx];
         const auto& mp  = multipoles[idx];
 
         bool violatesMac = cstone::evaluateMac(makeVec3(com), com[3], targetCenter, targetSize);
 
-        if (!violatesMac)
+        auto lidx = internalToLeaf[idx];
+        // A leaf cell with non-zero multipole mass, but no particles must be remote.
+        // Domain.syncGrav guarantees that such a cell never fails MAC. We may still see a MAC failure here
+        // because target group particle bounding boxes may protrude outside the assigned SFC domain.
+        // In this case we may nevertheless apply M2P because the protruding part that caused the mac to fail
+        // must have contained no particles, because particles can only be inside the SFC domain.
+        bool isRemoteUntaggedLeaf = lidx >= 0 && layout[lidx] == layout[lidx + 1] && mp[Cqi::mass] > 0;
+
+        if (!violatesMac || isRemoteUntaggedLeaf)
         {
 // apply multipole to all particles in group
 #if defined(__llvm__) || defined(__clang__)

--- a/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
+++ b/ryoanji/src/ryoanji/nbody/traversal_cpu.hpp
@@ -104,15 +104,15 @@ void computeGravityGroup(const util::array<Vec4<T1>, N>& target, const TreeNodeI
 
         bool violatesMac = cstone::evaluateMac(makeVec3(com), com[3], targetCenter, targetSize);
 
-        auto lidx = internalToLeaf[idx];
+        auto leafIdx = internalToLeaf[idx];
         // A leaf cell with non-zero multipole mass, but no particles must be remote.
         // Domain.syncGrav guarantees that such a cell never fails MAC. We may still see a MAC failure here
         // because target group particle bounding boxes may protrude outside the assigned SFC domain.
         // In this case we may nevertheless apply M2P because the protruding part that caused the mac to fail
         // must have contained no particles, because particles can only be inside the SFC domain.
-        bool isRemoteUntaggedLeaf = lidx >= 0 && layout[lidx] == layout[lidx + 1] && mp[Cqi::mass] > 0;
+        bool isRemote = leafIdx >= 0 && layout[leafIdx] == layout[leafIdx + 1] && mp[Cqi::mass] > 0;
 
-        if (!violatesMac || isRemoteUntaggedLeaf)
+        if (!violatesMac || isRemote)
         {
 // apply multipole to all particles in group
 #if defined(__llvm__) || defined(__clang__)

--- a/ryoanji/src/ryoanji/nbody/traversal_gpu.cu
+++ b/ryoanji/src/ryoanji/nbody/traversal_gpu.cu
@@ -257,7 +257,8 @@ __device__ util::tuple<unsigned, unsigned, unsigned>
         if (stackUsed > TravConfig::memPerWarp) { return {0xFFFFFFFF, 0xFFFFFFFF, maxStack}; }
 
         // Multipole approximation
-        const bool isApprox    = !isClose && isSource; // Source cell can be used for M2P
+        const bool isRemote    = layout[leafIdx + 1] == layout[leafIdx] && Multipoles[sourceQueue][Cqi::mass] > 0;
+        const bool isApprox    = (!isClose || (!isNode && isRemote)) && isSource; // Source cell can be used for M2P
         int        numKeepWarp = streamCompact(&sourceQueue, isApprox, tempQueue);
         // push valid approx source cell indices into approxQueue
         const int apxTopUp = shflUpSync(sourceQueue, apxFillLevel);


### PR DESCRIPTION
Remote empty leaves with non-zero multipole mass are guaranteed to pass MAC from
anywhere in the local domain. We may still get (rare) MAC failures when an empty part of a target particle group
bounding box protrudes outside the local domain. In this case the correct behavior is to pass MAC and apply M2P.