### PR TITLE
Fix wind-shock observables

### DIFF
--- a/main/src/observables/factory.hpp
+++ b/main/src/observables/factory.hpp
@@ -53,11 +53,8 @@ std::unique_ptr<IObservables<Dataset>> observablesFactory(const InitSettings& se
     }
     if (settings.count("wind-shock"))
     {
-        double rhoInt       = settings.at("rhoInt");
-        double uExt         = settings.at("uExt");
-        double bubbleVolume = std::pow(settings.at("rSphere"), 3) * 4.0 / 3.0 * M_PI;
-        double bubbleMass   = bubbleVolume * rhoInt;
-        return Observables<Dataset>::makeWindBubbleObs(constantsFile, rhoInt, uExt, bubbleMass);
+        return Observables<Dataset>::makeWindBubbleObs(constantsFile, settings.at("rhoInt"), settings.at("uExt"),
+                                                       settings.at("rSphere"));
     }
     if (settings.count("turbulence"))
     {

--- a/main/src/observables/gpu_reductions.h
+++ b/main/src/observables/gpu_reductions.h
@@ -33,7 +33,6 @@
 
 #include <tuple>
 #include "cstone/sfc/box.hpp"
-#include "cstone/tree/definitions.h"
 
 namespace sphexa
 {
@@ -85,6 +84,6 @@ extern double machSquareSumGpu(const Tv* vx, const Tv* vy, const Tv* vz, const T
  * @return
  */
 template<class T, class Tt, class Tm>
-extern size_t survivorsGpu(const Tt* temp, const T* kx, const T* xmass, const Tm* m, double rhoBubble, double tempWind,
-                           size_t first, size_t last);
+extern double survivingMassGpu(const Tt* temp, const T* kx, const T* xmass, const Tm* m, double rhoBubble,
+                               double tempWind, size_t first, size_t last);
 } // namespace sphexa

--- a/main/src/observables/iobservables.hpp
+++ b/main/src/observables/iobservables.hpp
@@ -42,7 +42,7 @@ class IObservables
 {
 public:
     virtual void computeAndWrite(Dataset& d, size_t firstIndex, size_t lastIndex,
-                                 const cstone::Box<typename Dataset::RealType>& box){/* no-op */};
+                                 const cstone::Box<typename Dataset::RealType>& box) = 0;
 
     virtual ~IObservables() = default;
 };

--- a/main/src/observables/time_energies.hpp
+++ b/main/src/observables/time_energies.hpp
@@ -28,8 +28,6 @@
  * @author Lukas Schmidt
  */
 
-#include <fstream>
-
 #include "conserved_quantities.hpp"
 #include "iobservables.hpp"
 #include "io/file_utils.hpp"


### PR DESCRIPTION
There were several bugs in the wind-shock observables:
* They were never called due to a signature mismatch
* Passed bubbleMass instead of rSphere to constructor
* Accessed particle mass at index 0 on CPU which may be invalid when the GPU is active
* Assumed particle mass is constant. Now the code works for variable particle masses.