### PR TITLE
Test named base identification fix for evrard-cooling case

### DIFF
--- a/main/src/init/factory.hpp
+++ b/main/src/init/factory.hpp
@@ -87,7 +87,7 @@ std::unique_ptr<ISimInitializer<Dataset>> initializerFactory(std::string testCas
         if (glassBlock.empty()) { throw std::runtime_error("need a valid glass block for Kelvin-Helmholtz test\n"); }
         else { return SimInitializers<Dataset>::makeKelvinHelmholtz(glassBlock, settingsFile, reader); }
     }
-    if (testCase == "evrard-cooling")
+    if (testNamedBase == "evrard-cooling")
     {
         if (glassBlock.empty()) { throw std::runtime_error("need a valid glass block for evrard-cooling\n"); }
         return SimInitializers<Dataset>::makeEvrardCooling(glassBlock, settingsFile, reader);


### PR DESCRIPTION
@sekelle while testing the id tagging input parameters loading I found a possible small issue with the identification of the evrard-cooling case when a settings file is provided. 