### PR TITLE
revert courant condition to the default 0.2 for all test cases

### DIFF
--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -69,7 +69,6 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
 
     T hInt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoInt);
     T hExt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoExt);
-    T hDif = 0.5 * (hExt - hInt);
 
     std::fill(d.m.begin(), d.m.end(), massPart);
     std::fill(d.du_m1.begin(), d.du_m1.end(), 0.0);
@@ -92,43 +91,26 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
         {
             d.h[i]    = hInt;
             u_or_t[i] = uInt;
-            if (d.y[i] > 0.5)
-            {
-                d.vx[i] = vxInt + vDif * std::exp((d.y[i] - 0.75) / ls);
-                d.h[i]  = hInt + hDif * std::exp((d.y[i] - 0.75) / ls);
-            }
-            else
-            {
-                d.vx[i] = vxInt + vDif * std::exp((0.25 - d.y[i]) / ls);
-                d.h[i]  = hInt + hDif * std::exp((0.25 - d.y[i]) / ls);
-            }
+            if (d.y[i] > 0.5) { d.vx[i] = vxInt + vDif * std::exp((d.y[i] - 0.75) / ls); }
+            else { d.vx[i] = vxInt + vDif * std::exp((0.25 - d.y[i]) / ls); }
         }
         else
         {
-            if (d.y[i] > 0.75 + 4 * hExt || d.y[i] < 0.25 - 4 * hExt)
+            if (d.y[i] > 0.75 + 2 * hExt || d.y[i] < 0.25 - 2 * hExt)
             {
                 // more than two smoothing lengths away from the high density band
-                // d.h[i] = hExt;
+                d.h[i] = hExt;
             }
             else
             {
                 T dist = (d.y[i] > 0.75) ? d.y[i] - 0.75 : 0.25 - d.y[i];
                 // linear interpolation from hInt to hExt for particles within 2 * hExt of the high density band
-                // d.h[i] = hInt * (1 - dist / (4 * hExt)) + hExt * dist / (4 * hExt);
-                // d.h[i] = hInt + 0.5 * (hExt - hInt) * (1. + std::tanh(0.5/hExt * (dist - 2 * hExt)));
+                d.h[i] = hInt * (1 - dist / (2 * hExt)) + hExt * dist / (2 * hExt);
             }
 
             u_or_t[i] = uExt;
-            if (d.y[i] < 0.25)
-            {
-                d.vx[i] = vxExt - vDif * std::exp((d.y[i] - 0.25) / ls);
-                d.h[i]  = hExt - hDif * std::exp((d.y[i] - 0.25) / ls);
-            }
-            else
-            {
-                d.vx[i] = vxExt - vDif * std::exp((0.75 - d.y[i]) / ls);
-                d.h[i]  = hExt - hDif * std::exp((0.75 - d.y[i]) / ls);
-            }
+            if (d.y[i] < 0.25) { d.vx[i] = vxExt - vDif * std::exp((d.y[i] - 0.25) / ls); }
+            else { d.vx[i] = vxExt - vDif * std::exp((0.75 - d.y[i]) / ls); }
         }
 
         d.x_m1[i] = d.vx[i] * d.minDt;

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -46,7 +46,7 @@ InitSettings KelvinHelmholtzConstants()
 {
     return {{"rhoInt", 2.},        {"rhoExt", 1.},           {"vxExt", 0.5},
             {"vxInt", -0.5},       {"gamma", 5. / 3.},       {"p", 2.5},
-            {"omega0", 0.01},      {"Kcour", 0.4},           {"ng0", 100},
+            {"omega0", 0.01},      {"Kcour", 0.2},           {"ng0", 100},
             {"ngmax", 150},        {"minDt", 1e-7},          {"minDt_m1", 1e-7},
             {"gravConstant", 0.0}, {"kelvin-helmholtz", 1.0}};
 }
@@ -69,6 +69,7 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
 
     T hInt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoInt);
     T hExt = 0.5 * std::cbrt(3. * d.ng0 * massPart / 4. / M_PI / rhoExt);
+    T hDif = 0.5 * (hExt - hInt);
 
     std::fill(d.m.begin(), d.m.end(), massPart);
     std::fill(d.du_m1.begin(), d.du_m1.end(), 0.0);
@@ -91,26 +92,43 @@ void initKelvinHelmholtzFields(Dataset& d, const std::map<std::string, double>& 
         {
             d.h[i]    = hInt;
             u_or_t[i] = uInt;
-            if (d.y[i] > 0.5) { d.vx[i] = vxInt + vDif * std::exp((d.y[i] - 0.75) / ls); }
-            else { d.vx[i] = vxInt + vDif * std::exp((0.25 - d.y[i]) / ls); }
+            if (d.y[i] > 0.5)
+            {
+                d.vx[i] = vxInt + vDif * std::exp((d.y[i] - 0.75) / ls);
+                d.h[i]  = hInt + hDif * std::exp((d.y[i] - 0.75) / ls);
+            }
+            else
+            {
+                d.vx[i] = vxInt + vDif * std::exp((0.25 - d.y[i]) / ls);
+                d.h[i]  = hInt + hDif * std::exp((0.25 - d.y[i]) / ls);
+            }
         }
         else
         {
-            if (d.y[i] > 0.75 + 2 * hExt || d.y[i] < 0.25 - 2 * hExt)
+            if (d.y[i] > 0.75 + 4 * hExt || d.y[i] < 0.25 - 4 * hExt)
             {
                 // more than two smoothing lengths away from the high density band
-                d.h[i] = hExt;
+                // d.h[i] = hExt;
             }
             else
             {
                 T dist = (d.y[i] > 0.75) ? d.y[i] - 0.75 : 0.25 - d.y[i];
                 // linear interpolation from hInt to hExt for particles within 2 * hExt of the high density band
-                d.h[i] = hInt * (1 - dist / (2 * hExt)) + hExt * dist / (2 * hExt);
+                // d.h[i] = hInt * (1 - dist / (4 * hExt)) + hExt * dist / (4 * hExt);
+                // d.h[i] = hInt + 0.5 * (hExt - hInt) * (1. + std::tanh(0.5/hExt * (dist - 2 * hExt)));
             }
 
             u_or_t[i] = uExt;
-            if (d.y[i] < 0.25) { d.vx[i] = vxExt - vDif * std::exp((d.y[i] - 0.25) / ls); }
-            else { d.vx[i] = vxExt - vDif * std::exp((0.75 - d.y[i]) / ls); }
+            if (d.y[i] < 0.25)
+            {
+                d.vx[i] = vxExt - vDif * std::exp((d.y[i] - 0.25) / ls);
+                d.h[i]  = hExt - hDif * std::exp((d.y[i] - 0.25) / ls);
+            }
+            else
+            {
+                d.vx[i] = vxExt - vDif * std::exp((0.75 - d.y[i]) / ls);
+                d.h[i]  = hExt - hDif * std::exp((0.75 - d.y[i]) / ls);
+            }
         }
 
         d.x_m1[i] = d.vx[i] * d.minDt;

--- a/main/src/init/turbulence_init.hpp
+++ b/main/src/init/turbulence_init.hpp
@@ -65,7 +65,7 @@ InitSettings TurbulenceConstants()
             {"muiConst", 0.62},
             {"soundSpeedConst", 1.0},
             {"u0", 1000.},
-            {"Kcour", 0.4},
+            {"Kcour", 0.2},
             {"gravConstant", 0.0},
             {"ng0", 100},
             {"ngmax", 150},

--- a/main/src/init/wind_shock_init.hpp
+++ b/main/src/init/wind_shock_init.hpp
@@ -52,7 +52,7 @@ InitSettings WindShockConstants()
 {
     return {{"r", .125},           {"rSphere", .025},   {"rhoInt", 10.}, {"rhoExt", 1.},     {"uExt", 3. / 2.},
             {"vxExt", 2.7},        {"vyExt", .0},       {"vzExt", .0},   {"dim", 3},         {"gamma", 5. / 3.},
-            {"minDt", 1e-10},      {"minDt_m1", 1e-10}, {"Kcour", 0.4},  {"epsilon", 0.},    {"mui", 10.},
+            {"minDt", 1e-10},      {"minDt_m1", 1e-10}, {"Kcour", 0.2},  {"epsilon", 0.},    {"mui", 10.},
             {"gravConstant", 0.0}, {"ng0", 100},        {"ngmax", 150},  {"wind-shock", 1.0}};
 }
 

--- a/scripts/init_file.py
+++ b/scripts/init_file.py
@@ -57,7 +57,7 @@ initStep.attrs["ngmax"] = np.array([150], dtype=np.int32)
 initStep.attrs["gravConstant"] = 1.0
 initStep.attrs["gamma"] = 5. / 3.
 initStep.attrs["muiConst"] = 1.21 * 4.329e13
-initStep.attrs["Kcour"] = 0.4
+initStep.attrs["Kcour"] = 0.2
 
 # BoundaryType: 0 = open, 1 = periodic, 2 = fixed
 initStep.attrs["boundaryType"] = np.array([0, 0, 0], dtype=np.int8)


### PR DESCRIPTION
Previously some values of `Kcour` were pushed to 0.4 mainly for performance reasons at high resolutions to allow for larger time steps. In the case of the turbulence test it lead to some granulation when using artificial viscosity cleaning. I believe with the addition of block time steps mitigating at least some of the performance issues we can revert these changes