### PR TITLE
Fix atomicMinFloat, add atomicMaxFloat and tests for both

### DIFF
--- a/domain/include/cstone/primitives/warpscan.cuh
+++ b/domain/include/cstone/primitives/warpscan.cuh
@@ -277,13 +277,18 @@ __device__ __forceinline__ int spreadSeg8(int val)
     return shflSync(val, laneIdx >> 3) + (laneIdx & 7);
 }
 
+// source: https://stackoverflow.com/a/72461459 CC BY-SA 4.0 by user timothygiraffe
 __device__ __forceinline__ float atomicMinFloat(float* addr, float value)
 {
-    float old;
-    old = (value >= 0) ? __int_as_float(atomicMin((int*)addr, __float_as_int(value)))
-                       : __uint_as_float(atomicMax((unsigned int*)addr, __float_as_uint(value)));
+    return !signbit(value) ? __int_as_float(atomicMin((int*)addr, __float_as_int(value)))
+                           : __uint_as_float(atomicMax((unsigned int*)addr, __float_as_uint(value)));
+}
 
-    return old;
+// source: https://stackoverflow.com/a/72461459 CC BY-SA 4.0 by user timothygiraffe
+__device__ __forceinline__ float atomicMaxFloat(float* addr, float value)
+{
+    return !signbit(value) ? __int_as_float(atomicMax((int*)addr, __float_as_int(value)))
+                           : __uint_as_float(atomicMin((unsigned int*)addr, __float_as_uint(value)));
 }
 
 } // namespace cstone

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -201,15 +201,15 @@ __global__ void applyAtomicMinFloat(float* addr, float value)
 
 TEST(WarpScan, atomicMinFloat)
 {
-    thrust::device_vector<float> d_values(1);
+    thrust::device_vector<float> d_value(1);
 
     // check especially corner cases -0.0f, 0.0f
     for (float firstSign : {-1.0f, -0.0f, 0.0f, 1.0f})
         for (float secondSign : {-1.0f, -0.0f, 0.0f, 1.0f})
         {
-            d_values[0] = 42.0f * firstSign;
-            applyAtomicMinFloat<<<2, 128>>>(rawPtr(d_values), 37.5f * secondSign);
-            EXPECT_EQ(float(d_values[0]), std::min(42.0f * firstSign, 37.5f * secondSign));
+            d_value[0] = 42.0f * firstSign;
+            applyAtomicMinFloat<<<2, 128>>>(rawPtr(d_value), 37.5f * secondSign);
+            EXPECT_EQ(float(d_value[0]), std::min(42.0f * firstSign, 37.5f * secondSign));
         }
 }
 
@@ -221,14 +221,14 @@ __global__ void applyAtomicMaxFloat(float* addr, float value)
 
 TEST(WarpScan, atomicMaxFloat)
 {
-    thrust::device_vector<float> d_values(1);
+    thrust::device_vector<float> d_value(1);
 
     // check especially corner cases -0.0f, 0.0f
     for (float firstSign : {1.0f, -0.0f, 0.0f, 1.0f})
         for (float secondSign : {-1.0f, -0.0f, 0.0f, 1.0f})
         {
-            d_values[0] = 42.0f * firstSign;
-            applyAtomicMaxFloat<<<2, 128>>>(rawPtr(d_values), 37.5f * secondSign);
-            EXPECT_EQ(float(d_values[0]), std::max(42.0f * firstSign, 37.5f * secondSign));
+            d_value[0] = 42.0f * firstSign;
+            applyAtomicMaxFloat<<<2, 128>>>(rawPtr(d_value), 37.5f * secondSign);
+            EXPECT_EQ(float(d_value[0]), std::max(42.0f * firstSign, 37.5f * secondSign));
         }
 }

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -192,3 +192,45 @@ TEST(WarpScan, spreadSeg8)
 
     EXPECT_EQ(reference, h_values);
 }
+
+__global__ void applyAtomicMinFloat(float* addr, float value)
+{
+    const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+    atomicMinFloat(addr, index == 137 ? value : 2025.0f);
+}
+
+TEST(WarpScan, atomicMinFloat)
+{
+    thrust::device_vector<float> d_values(1);
+
+    // check especially corner cases -0.0f, 0.0f
+    for (float firstSign : {-1.0f, -0.0f, 0.0f, 1.0f})
+        for (float secondSign : {-1.0f, -0.0f, 0.0f, 1.0f})
+        {
+
+            d_values[0] = 42.0f * firstSign;
+            applyAtomicMinFloat<<<2, 128>>>(rawPtr(d_values), 37.5f * secondSign);
+            EXPECT_EQ(float(d_values[0]), std::min(42.0f * firstSign, 37.5f * secondSign));
+        }
+}
+
+__global__ void applyAtomicMaxFloat(float* addr, float value)
+{
+    const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+    atomicMaxFloat(addr, index == 137 ? value : -2025.0f);
+}
+
+TEST(WarpScan, atomicMaxFloat)
+{
+    thrust::device_vector<float> d_values(1);
+
+    // check especially corner cases -0.0f, 0.0f
+    for (float firstSign : {1.0f, -0.0f, 0.0f, 1.0f})
+        for (float secondSign : {-1.0f, -0.0f, 0.0f, 1.0f})
+        {
+
+            d_values[0] = 42.0f * firstSign;
+            applyAtomicMaxFloat<<<2, 128>>>(rawPtr(d_values), 37.5f * secondSign);
+            EXPECT_EQ(float(d_values[0]), std::max(42.0f * firstSign, 37.5f * secondSign));
+        }
+}

--- a/domain/test/unit_cuda/primitives/warpscan.cu
+++ b/domain/test/unit_cuda/primitives/warpscan.cu
@@ -207,7 +207,6 @@ TEST(WarpScan, atomicMinFloat)
     for (float firstSign : {-1.0f, -0.0f, 0.0f, 1.0f})
         for (float secondSign : {-1.0f, -0.0f, 0.0f, 1.0f})
         {
-
             d_values[0] = 42.0f * firstSign;
             applyAtomicMinFloat<<<2, 128>>>(rawPtr(d_values), 37.5f * secondSign);
             EXPECT_EQ(float(d_values[0]), std::min(42.0f * firstSign, 37.5f * secondSign));
@@ -228,7 +227,6 @@ TEST(WarpScan, atomicMaxFloat)
     for (float firstSign : {1.0f, -0.0f, 0.0f, 1.0f})
         for (float secondSign : {-1.0f, -0.0f, 0.0f, 1.0f})
         {
-
             d_values[0] = 42.0f * firstSign;
             applyAtomicMaxFloat<<<2, 128>>>(rawPtr(d_values), 37.5f * secondSign);
             EXPECT_EQ(float(d_values[0]), std::max(42.0f * firstSign, 37.5f * secondSign));


### PR DESCRIPTION
`atomicMinFloat` previously failed in corner cases involving values of `-0.0f`. This adds tests for these special cases and also the missing `atomicMaxFloat`. Based on https://stackoverflow.com/a/72461459