### PR TITLE
improved IC generator overwrites existing data 

### DIFF
--- a/main/src/init/grid.hpp
+++ b/main/src/init/grid.hpp
@@ -254,7 +254,7 @@ void assembleCuboid(KeyType keyStart, KeyType keyEnd, const cstone::Box<T>& glob
                     std::span<const T> xBlock, std::span<const T> yBlock, std::span<const T> zBlock, Vector& x,
                     Vector& y, Vector& z)
 {
-
+    assert(x.size() == y.size() == z.size());
     auto outOfBounds = [](auto it1, auto it2)
     { return *std::min_element(it1, it2) < 0.0 || *std::max_element(it1, it2) >= 1.0; };
     if (outOfBounds(xBlock.begin(), xBlock.end()) || outOfBounds(yBlock.begin(), yBlock.end()) ||
@@ -296,7 +296,8 @@ void assembleCuboid(KeyType keyStart, KeyType keyEnd, const cstone::Box<T>& glob
         numTaskSel[i] = countSelection<T>(selectBox, globalBox, {ix, iy, iz}, multiplicity, xBlock, yBlock, zBlock);
     }
 
-    std::exclusive_scan(numTaskSel.begin(), numTaskSel.end(), numTaskSel.begin(), cstone::LocalIndex{0});
+    std::size_t oldSize = x.size();
+    std::exclusive_scan(numTaskSel.begin(), numTaskSel.end(), numTaskSel.begin(), oldSize);
     x.resize(numTaskSel.back());
     y.resize(numTaskSel.back());
     z.resize(numTaskSel.back());

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -160,8 +160,6 @@ public:
         cstone::Box<T> layer2(0, 1, 0.25, 0.75, 0, 0.0625, pbc, pbc, pbc);
         cstone::Box<T> layer3(0, 1, 0.75, 1, 0, 0.0625, pbc, pbc, pbc);
 
-        assembleCuboid<T>(keyStart, keyEnd, layer2, innerMulti, xBlock, yBlock, zBlock, d.x, d.y, d.z);
-
         std::vector<T> x, y, z;
         assembleCuboid<T>(keyStart, keyEnd, layer1, outerMulti, xBlock, yBlock, zBlock, x, y, z);
 
@@ -189,6 +187,8 @@ public:
                 d.z.push_back(X[2]);
             }
         }
+
+        assembleCuboid<T>(keyStart, keyEnd, layer2, innerMulti, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
         size_t numParticlesGlobal = d.x.size();
         MPI_Allreduce(MPI_IN_PLACE, &numParticlesGlobal, 1, MpiType<size_t>{}, MPI_SUM, simData.comm);

--- a/main/src/init/kelvin_helmholtz_init.hpp
+++ b/main/src/init/kelvin_helmholtz_init.hpp
@@ -160,6 +160,8 @@ public:
         cstone::Box<T> layer2(0, 1, 0.25, 0.75, 0, 0.0625, pbc, pbc, pbc);
         cstone::Box<T> layer3(0, 1, 0.75, 1, 0, 0.0625, pbc, pbc, pbc);
 
+        assembleCuboid<T>(keyStart, keyEnd, layer2, innerMulti, xBlock, yBlock, zBlock, d.x, d.y, d.z);
+
         std::vector<T> x, y, z;
         assembleCuboid<T>(keyStart, keyEnd, layer1, outerMulti, xBlock, yBlock, zBlock, x, y, z);
 
@@ -187,8 +189,6 @@ public:
                 d.z.push_back(X[2]);
             }
         }
-
-        assembleCuboid<T>(keyStart, keyEnd, layer2, innerMulti, xBlock, yBlock, zBlock, d.x, d.y, d.z);
 
         size_t numParticlesGlobal = d.x.size();
         MPI_Allreduce(MPI_IN_PLACE, &numParticlesGlobal, 1, MpiType<size_t>{}, MPI_SUM, simData.comm);

--- a/main/test/init/grid.cpp
+++ b/main/test/init/grid.cpp
@@ -103,9 +103,7 @@ TEST(Grids, assembleCuboid)
 
     cstone::Vec3<int> multiplicity = {1, 3, 4};
 
-    std::vector<T> xb{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9};
-    std::vector<T> yb{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9};
-    std::vector<T> zb{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9};
+    std::vector<T> xb{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9}, yb = xb, zb = xb;
 
     // 3 SFC segments: 0-k1 k1-k2 k2-nodeRange(0)
     KeyType k1 = 01234567012;
@@ -184,6 +182,37 @@ TEST(Grids, assembleCuboid)
     {
         EXPECT_EQ(keys[i], keys2[i]);
     }
+}
+
+TEST(Grids, assembleCuboidAdditive)
+{
+    using T       = double;
+    using KeyType = unsigned;
+    cstone::Box<T> box{-1, 1};
+
+    cstone::Vec3<int> multiplicity = {1, 3, 4};
+
+    std::vector<T> xb{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9}, yb = xb, zb = xb;
+
+    // 3 SFC segments: 0-k1 k1-k2 k2-nodeRange(0)
+    KeyType k1 = 01234567012;
+    KeyType k2 = 05123456701;
+
+    std::vector<T> x, y, z;
+    assembleCuboid<T>(KeyType(0), k1, box, multiplicity, xb, yb, zb, x, y, z);
+    assembleCuboid<T>(k1, k2, box, multiplicity, xb, yb, zb, x, y, z);
+    assembleCuboid<T>(k2, cstone::nodeRange<KeyType>(0), box, multiplicity, xb, yb, zb, x, y, z);
+
+    std::vector<T> xRef, yRef, zRef;
+    assembleCuboid<T>(KeyType(0), cstone::nodeRange<KeyType>(0), box, multiplicity, xb, yb, zb, xRef, yRef, zRef);
+
+    [](auto&&... vecs) {
+        [[maybe_unused]] std::initializer_list<int>{(std::sort(vecs.begin(), vecs.end()), 0)...};
+    }(x, y, z, xRef, yRef, zRef);
+
+    EXPECT_EQ(x, xRef);
+    EXPECT_EQ(y, yRef);
+    EXPECT_EQ(z, zRef);
 }
 
 TEST(IsobaricCube, pyramidStretch)

--- a/main/test/io/h5part_wrapper.cpp
+++ b/main/test/io/h5part_wrapper.cpp
@@ -51,7 +51,7 @@ TEST(H5PartCpp, typesafeStepAttrRead)
         writeH5PartStepAttrib(h5File, "float64Attr", &float64Attr, 1);
         int64_t int64Attr = -42;
         writeH5PartStepAttrib(h5File, "int64Attr", &int64Attr, 1);
-        uint64_t uint64Attr = uint64_t(2) << 40 + uint64_t(1) << 63;
+        uint64_t uint64Attr = (uint64_t(2) << 40) + (uint64_t(1) << 63);
         writeH5PartStepAttrib(h5File, "uint64Attr", &uint64Attr, 1);
         char int8Attr = 1;
         writeH5PartStepAttrib(h5File, "int8Attr", &int8Attr, 1);
@@ -93,7 +93,7 @@ TEST(H5PartCpp, typesafeStepAttrRead)
         {
             std::vector<uint64_t> a(1);
             readH5PartStepAttribute(a.data(), a.size(), 2, h5File);
-            EXPECT_EQ(a[0], uint64_t(2) << 40 + uint64_t(1) << 63);
+            EXPECT_EQ(a[0], (uint64_t(2) << 40) + (uint64_t(1) << 63));
         }
         {
             std::vector<char> a(1);


### PR DESCRIPTION
The commit dd4b678 optimizing the IC generator changed the behaviour of `assembleCuboid` such that existing data in the position vectors is overridden. 

For Kelvin-Helmholtz this is not an issue and is easily fixed, however future tests (e.g the triple point shock) would benefit from being able to sequentially assemble cuboids. I'm opening a PR as I don't know what the best resolution for this is. 