### PR TITLE
Fixed Boundary Conditions

### DIFF
--- a/domain/include/cstone/sfc/box_mpi.hpp
+++ b/domain/include/cstone/sfc/box_mpi.hpp
@@ -68,26 +68,23 @@ struct MinMax
 template<class T, class Op = MinMax<T>>
 auto makeGlobalBox(const T* x, const T* y, const T* z, size_t numElements, const Box<T>& previousBox = Box<T>(0, 1))
 {
-    bool pbcX = (previousBox.boundaryX() == BoundaryType::periodic);
-    bool pbcY = (previousBox.boundaryY() == BoundaryType::periodic);
-    bool pbcZ = (previousBox.boundaryZ() == BoundaryType::periodic);
-    bool fbcX = (previousBox.boundaryX() == BoundaryType::fixed);
-    bool fbcY = (previousBox.boundaryY() == BoundaryType::fixed);
-    bool fbcZ = (previousBox.boundaryZ() == BoundaryType::fixed);
+    bool keepX = previousBox.boundaryX() == BoundaryType::periodic || previousBox.boundaryX() == BoundaryType::fixed;
+    bool keepY = previousBox.boundaryY() == BoundaryType::periodic || previousBox.boundaryY() == BoundaryType::fixed;
+    bool keepZ = previousBox.boundaryZ() == BoundaryType::periodic || previousBox.boundaryZ() == BoundaryType::fixed;
 
     std::array<T, 6> extrema{previousBox.xmin(), previousBox.xmax(), previousBox.ymin(),
                              previousBox.ymax(), previousBox.zmin(), previousBox.zmax()};
     if (numElements)
     {
         std::tie(extrema[0], extrema[1]) =
-            pbcX || fbcX ? std::make_tuple(previousBox.xmin(), previousBox.xmax()) : Op{}(x, x + numElements);
+            keepX ? std::make_tuple(previousBox.xmin(), previousBox.xmax()) : Op{}(x, x + numElements);
         std::tie(extrema[2], extrema[3]) =
-            pbcY || fbcY ? std::make_tuple(previousBox.ymin(), previousBox.ymax()) : Op{}(y, y + numElements);
+            keepY ? std::make_tuple(previousBox.ymin(), previousBox.ymax()) : Op{}(y, y + numElements);
         std::tie(extrema[4], extrema[5]) =
-            pbcZ || fbcZ ? std::make_tuple(previousBox.zmin(), previousBox.zmax()) : Op{}(z, z + numElements);
+            keepZ ? std::make_tuple(previousBox.zmin(), previousBox.zmax()) : Op{}(z, z + numElements);
     }
 
-    if (!pbcX || !pbcY || !pbcZ)
+    if (!keepX || !keepY || !keepZ)
     {
         extrema[1] = -extrema[1];
         extrema[3] = -extrema[3];

--- a/domain/include/cstone/sfc/box_mpi.hpp
+++ b/domain/include/cstone/sfc/box_mpi.hpp
@@ -71,17 +71,20 @@ auto makeGlobalBox(const T* x, const T* y, const T* z, size_t numElements, const
     bool pbcX = (previousBox.boundaryX() == BoundaryType::periodic);
     bool pbcY = (previousBox.boundaryY() == BoundaryType::periodic);
     bool pbcZ = (previousBox.boundaryZ() == BoundaryType::periodic);
+    bool fbcX = (previousBox.boundaryX() == BoundaryType::fixed);
+    bool fbcY = (previousBox.boundaryY() == BoundaryType::fixed);
+    bool fbcZ = (previousBox.boundaryZ() == BoundaryType::fixed);
 
     std::array<T, 6> extrema{previousBox.xmin(), previousBox.xmax(), previousBox.ymin(),
                              previousBox.ymax(), previousBox.zmin(), previousBox.zmax()};
     if (numElements)
     {
         std::tie(extrema[0], extrema[1]) =
-            pbcX ? std::make_tuple(previousBox.xmin(), previousBox.xmax()) : Op{}(x, x + numElements);
+            pbcX || fbcX ? std::make_tuple(previousBox.xmin(), previousBox.xmax()) : Op{}(x, x + numElements);
         std::tie(extrema[2], extrema[3]) =
-            pbcY ? std::make_tuple(previousBox.ymin(), previousBox.ymax()) : Op{}(y, y + numElements);
+            pbcY || fbcY ? std::make_tuple(previousBox.ymin(), previousBox.ymax()) : Op{}(y, y + numElements);
         std::tie(extrema[4], extrema[5]) =
-            pbcZ ? std::make_tuple(previousBox.zmin(), previousBox.zmax()) : Op{}(z, z + numElements);
+            pbcZ || fbcZ ? std::make_tuple(previousBox.zmin(), previousBox.zmax()) : Op{}(z, z + numElements);
     }
 
     if (!pbcX || !pbcY || !pbcZ)

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -53,7 +53,7 @@ HOST_DEVICE_FUN Tc fbcAdjustFactor(const cstone::Vec3<Tc> X, const cstone::Box<T
         constexpr Th width    = 2.;
         constexpr Th invWidth = 1 / width;
         // width of particles that are held at zero, in smoothing lengths
-        constexpr Th       offset          = 2.;
+        constexpr Th       offset          = 1.;
         cstone::Vec3<bool> isBoundaryFixed = {
             box.boundaryX() == cstone::BoundaryType::fixed,
             box.boundaryY() == cstone::BoundaryType::fixed,

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -144,10 +144,10 @@ void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone
 
     bool haveMui      = !d.mui.empty();
     auto constCv      = idealGasCv(d.muiConst, d.gamma);
-    auto adjustForFBC = 1.0;
+    auto adjustForFBC = T(1);
 
 #pragma omp parallel for schedule(static)
-    for (size_t i = startIndex; i < endIndex; i++)
+    for (std::size_t i = startIndex; i < endIndex; i++)
     {
         if (anyFBC) { adjustForFBC = min(fbcAdjustFactors({d.x[i], d.y[i], d.z[i]}, box, d.h[i])); }
         auto cv    = haveMui ? idealGasCv(d.mui[i], d.gamma) : constCv;
@@ -155,7 +155,7 @@ void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone
         // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
         // we divide out dt_m1 by that factor so it applies only once to each of the updating terms
         d.temp[i] =
-            energyUpdate(u_old, d.minDt * adjustForFBC, d.minDt_m1 * (1. / adjustForFBC), d.du[i], d.du_m1[i]) / cv;
+            energyUpdate(u_old, d.minDt * adjustForFBC, d.minDt_m1 * (T(1) / adjustForFBC), d.du[i], d.du_m1[i]) / cv;
         d.du_m1[i] = d.du[i];
     }
 }
@@ -166,15 +166,15 @@ void updateIntEnergyHost(size_t startIndex, size_t endIndex, Dataset& d, const c
     bool anyFBC = box.boundaryX() == cstone::BoundaryType::fixed || box.boundaryY() == cstone::BoundaryType::fixed ||
                   box.boundaryZ() == cstone::BoundaryType::fixed;
 
-    auto adjustForFBC = 1.0;
+    auto adjustForFBC = T(1);
 
 #pragma omp parallel for schedule(static)
-    for (size_t i = startIndex; i < endIndex; i++)
+    for (std::size_t i = startIndex; i < endIndex; i++)
     {
         if (anyFBC) { adjustForFBC = min(fbcAdjustFactors({d.x[i], d.y[i], d.z[i]}, box, d.h[i])); }
         // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
         // we divide out dt_m1 by that factor so it applies only once to each of the updating terms
-        d.u[i] = energyUpdate(d.u[i], d.minDt * adjustForFBC, d.minDt_m1 * (1. / adjustForFBC), d.du[i], d.du_m1[i]);
+        d.u[i] = energyUpdate(d.u[i], d.minDt * adjustForFBC, d.minDt_m1 * (T(1) / adjustForFBC), d.du[i], d.du_m1[i]);
         d.du_m1[i] = d.du[i];
     }
 }

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -118,7 +118,7 @@ void updatePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const c
                                               box.boundaryY() == cstone::BoundaryType::fixed,
                                               box.boundaryZ() == cstone::BoundaryType::fixed};
 
-    bool anyFBC = isAxisFixedBoundary[0] || isAxisFixedBoundary[1] || isAxisFixedBoundary[2];
+    bool            anyFBC = isAxisFixedBoundary[0] || isAxisFixedBoundary[1] || isAxisFixedBoundary[2];
     cstone::Vec3<T> adjustForFBC{T(1.), T(1.), T(1.)};
 
 #pragma omp parallel for schedule(static)

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -45,33 +45,32 @@ namespace sph
 
 //! @brief checks whether a particle is close to a fixed boundary and returns a modification factor if so
 template<class Tc, class Th>
-HOST_DEVICE_FUN Tc fbcAdjustFactor(const cstone::Vec3<Tc> X, const cstone::Box<Tc>& box, const Th hi, bool doCorrection)
+HOST_DEVICE_FUN cstone::Vec3<Tc> fbcAdjustFactors(const cstone::Vec3<Tc> X, const cstone::Box<Tc>& box, const Th hi)
 {
-    if (doCorrection)
-    {
-        // half the width of the sigmoid, in smoothing lengths
-        constexpr Th width    = 2.;
-        constexpr Th invWidth = 1 / width;
-        // width of particles that are held at zero, in smoothing lengths
-        constexpr Th       offset          = 1.;
-        cstone::Vec3<bool> isBoundaryFixed = {
-            box.boundaryX() == cstone::BoundaryType::fixed,
-            box.boundaryY() == cstone::BoundaryType::fixed,
-            box.boundaryZ() == cstone::BoundaryType::fixed,
-        };
-        cstone::Vec3<Tc> boxMax      = {box.xmax(), box.ymax(), box.zmax()};
-        cstone::Vec3<Tc> boxMin      = {box.xmin(), box.ymin(), box.zmin()};
-        cstone::Vec3<Tc> minDistance = min(abs(boxMax - X), abs(boxMin - X)) * (Th(1.0) / hi);
+    cstone::Vec3<Tc> factors{1., 1., 1.};
+    // half the width of the sigmoid, in smoothing lengths
+    constexpr Th width    = 2.;
+    constexpr Th invWidth = 1 / width;
+    // width of particles that are held at zero, in smoothing lengths
+    constexpr Th       offset          = 1.;
+    cstone::Vec3<bool> isBoundaryFixed = {
+        box.boundaryX() == cstone::BoundaryType::fixed,
+        box.boundaryY() == cstone::BoundaryType::fixed,
+        box.boundaryZ() == cstone::BoundaryType::fixed,
+    };
+    cstone::Vec3<Tc> boxMax      = {box.xmax(), box.ymax(), box.zmax()};
+    cstone::Vec3<Tc> boxMin      = {box.xmin(), box.ymin(), box.zmin()};
+    cstone::Vec3<Tc> minDistance = min(abs(boxMax - X), abs(boxMin - X)) * (Th(1.0) / hi);
 
-        for (int j = 0; j < 3; ++j)
+    for (int j = 0; j < 3; ++j)
+    {
+        if (isBoundaryFixed[j] && minDistance[j] < 2 * width + offset)
         {
-            if (isBoundaryFixed[j] && minDistance[j] < 2 * width + offset)
-            {
-                return Tc(0.5 * (std::tanh(4 * (minDistance[j] - offset) * invWidth - 4) + 1));
-            }
+            factors[j] = Tc(0.5 * (std::tanh(4 * (minDistance[j] - offset) * invWidth - 4) + 1));
         }
     }
-    return Tc(1.0);
+
+    return factors;
 }
 
 //! @brief update the energy according to Adams-Bashforth (2nd order)
@@ -114,11 +113,9 @@ HOST_DEVICE_FUN auto positionUpdate(double dt, double dt_m1, cstone::Vec3<T> Xn,
 template<class T, class Dataset>
 void updatePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
 {
-    cstone::Vec3<bool> isAxisFixedBoundary = {box.boundaryX() == cstone::BoundaryType::fixed,
-                                              box.boundaryY() == cstone::BoundaryType::fixed,
-                                              box.boundaryZ() == cstone::BoundaryType::fixed};
+    bool anyFBC = box.boundaryX() == cstone::BoundaryType::fixed || box.boundaryY() == cstone::BoundaryType::fixed ||
+                  box.boundaryZ() == cstone::BoundaryType::fixed;
 
-    bool            anyFBC = isAxisFixedBoundary[0] || isAxisFixedBoundary[1] || isAxisFixedBoundary[2];
     cstone::Vec3<T> adjustForFBC{T(1.), T(1.), T(1.)};
 
 #pragma omp parallel for schedule(static)
@@ -126,13 +123,7 @@ void updatePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const c
     {
         cstone::Vec3<T> X{d.x[i], d.y[i], d.z[i]};
 
-        if (anyFBC)
-        {
-            for (size_t j = 0; j < 3; ++j)
-            {
-                adjustForFBC[j] = fbcAdjustFactor(X, box, d.h[i], isAxisFixedBoundary[j]);
-            }
-        }
+        if (anyFBC) { adjustForFBC = fbcAdjustFactors(X, box, d.h[i]); }
         // To keep particles belonging to the fixed boundaries from moving, these two quantities need to be adjusted
         cstone::Vec3<T> A{d.ax[i] * adjustForFBC[0], d.ay[i] * adjustForFBC[1], d.az[i] * adjustForFBC[2]};
         cstone::Vec3<T> X_m1{d.x_m1[i] * adjustForFBC[0], d.y_m1[i] * adjustForFBC[1], d.z_m1[i] * adjustForFBC[2]};
@@ -148,10 +139,8 @@ void updatePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const c
 template<class Dataset, class T>
 void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
 {
-    bool fbcX   = (box.boundaryX() == cstone::BoundaryType::fixed);
-    bool fbcY   = (box.boundaryY() == cstone::BoundaryType::fixed);
-    bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
-    bool anyFBC = fbcX || fbcY || fbcZ;
+    bool anyFBC = box.boundaryX() == cstone::BoundaryType::fixed || box.boundaryY() == cstone::BoundaryType::fixed ||
+                  box.boundaryZ() == cstone::BoundaryType::fixed;
 
     bool haveMui      = !d.mui.empty();
     auto constCv      = idealGasCv(d.muiConst, d.gamma);
@@ -160,11 +149,13 @@ void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        if (anyFBC) { adjustForFBC = fbcAdjustFactor({d.x[i], d.y[i], d.z[i]}, box, d.h[i], true); }
+        if (anyFBC) { adjustForFBC = min(fbcAdjustFactors({d.x[i], d.y[i], d.z[i]}, box, d.h[i])); }
         auto cv    = haveMui ? idealGasCv(d.mui[i], d.gamma) : constCv;
         auto u_old = cv * d.temp[i];
         // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
-        d.temp[i]  = energyUpdate(u_old, d.minDt * adjustForFBC, d.minDt_m1, d.du[i], d.du_m1[i]) / cv;
+        // we divide out dt_m1 by that factor so it applies only once to each of the updating terms
+        d.temp[i] =
+            energyUpdate(u_old, d.minDt * adjustForFBC, d.minDt_m1 * (1. / adjustForFBC), d.du[i], d.du_m1[i]) / cv;
         d.du_m1[i] = d.du[i];
     }
 }
@@ -172,19 +163,18 @@ void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone
 template<class Dataset, class T>
 void updateIntEnergyHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
 {
-    bool fbcX   = (box.boundaryX() == cstone::BoundaryType::fixed);
-    bool fbcY   = (box.boundaryY() == cstone::BoundaryType::fixed);
-    bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
-    bool anyFBC = fbcX || fbcY || fbcZ;
+    bool anyFBC = box.boundaryX() == cstone::BoundaryType::fixed || box.boundaryY() == cstone::BoundaryType::fixed ||
+                  box.boundaryZ() == cstone::BoundaryType::fixed;
 
     auto adjustForFBC = 1.0;
 
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        if (anyFBC) { adjustForFBC = fbcAdjustFactor({d.x[i], d.y[i], d.z[i]}, box, d.h[i], true); }
+        if (anyFBC) { adjustForFBC = min(fbcAdjustFactors({d.x[i], d.y[i], d.z[i]}, box, d.h[i])); }
         // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
-        d.u[i]     = energyUpdate(d.u[i], d.minDt * adjustForFBC, d.minDt_m1, d.du[i], d.du_m1[i]);
+        // we divide out dt_m1 by that factor so it applies only once to each of the updating terms
+        d.u[i] = energyUpdate(d.u[i], d.minDt * adjustForFBC, d.minDt_m1 * (1. / adjustForFBC), d.du[i], d.du_m1[i]);
         d.du_m1[i] = d.du[i];
     }
 }

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -42,13 +42,15 @@
 
 namespace sph
 {
-//! @brief checks whether a particle is close to a fixed boundary and reduces the acceleration if so
-template<class Tc, class Th>
-HOST_DEVICE_FUN void fbcAdjust(const cstone::Vec3<Tc> X, cstone::Vec3<Tc>& V_nm, cstone::Vec3<Tc>& A,
-                               const cstone::Box<Tc>& box, const Th hi)
+//! @brief checks whether a particle is close to a fixed boundary and reduces a scalar if so
+template<class Tc, class Th, class Ts>
+HOST_DEVICE_FUN void fbcAdjustScalar(const cstone::Vec3<Tc> X, Ts& scalar, const cstone::Box<Tc>& box, const Th hi)
 {
-    constexpr Th       threshold       = 4.;
-    constexpr Th       invTHold        = 1 / threshold;
+    // half the width of the sigmoid, in smoothing lengths
+    constexpr Th width    = 2.;
+    constexpr Th invWidth = 1 / width;
+    // width of particles that are held at zero, in smoothing lengths
+    constexpr Th       offset          = 2.;
     cstone::Vec3<bool> isBoundaryFixed = {
         box.boundaryX() == cstone::BoundaryType::fixed,
         box.boundaryY() == cstone::BoundaryType::fixed,
@@ -66,9 +68,45 @@ HOST_DEVICE_FUN void fbcAdjust(const cstone::Vec3<Tc> X, cstone::Vec3<Tc>& V_nm,
             Th relDistanceMin = std::abs(boxMin[j] - X[j]) / hi;
             Th minDistance    = relDistanceMin < relDistanceMax ? relDistanceMin : relDistanceMax;
 
-            if (minDistance < 2 * threshold)
+            if (minDistance < 2 * width + offset)
             {
-                Tc correction = 0.5 * (std::tanh(4 * minDistance * invTHold - 4) + 1);
+                Tc correction = 0.5 * (std::tanh(4 * (minDistance - offset) * invWidth - 4) + 1);
+                scalar *= correction;
+            }
+        }
+    }
+}
+
+//! @brief checks whether a particle is close to a fixed boundary and reduces the acceleration if so
+template<class Tc, class Th>
+HOST_DEVICE_FUN void fbcAdjustVector(const cstone::Vec3<Tc> X, cstone::Vec3<Tc>& V_nm, cstone::Vec3<Tc>& A,
+                                     const cstone::Box<Tc>& box, const Th hi)
+{
+    // half the width of the sigmoid, in smoothing lengths
+    constexpr Th width    = 2.;
+    constexpr Th invWidth = 1 / width;
+    // width of particles that are held at zero, in smoothing lengths
+    constexpr Th       offset          = 2.;
+    cstone::Vec3<bool> isBoundaryFixed = {
+        box.boundaryX() == cstone::BoundaryType::fixed,
+        box.boundaryY() == cstone::BoundaryType::fixed,
+        box.boundaryZ() == cstone::BoundaryType::fixed,
+    };
+    cstone::Vec3<Tc> boxMax = {box.xmax(), box.ymax(), box.zmax()};
+    cstone::Vec3<Tc> boxMin = {box.xmin(), box.ymin(), box.zmin()};
+
+    for (int j = 0; j < 3; ++j)
+    {
+        if (isBoundaryFixed[j])
+        {
+
+            Th relDistanceMax = std::abs(boxMax[j] - X[j]) / hi;
+            Th relDistanceMin = std::abs(boxMin[j] - X[j]) / hi;
+            Th minDistance    = relDistanceMin < relDistanceMax ? relDistanceMin : relDistanceMax;
+
+            if (minDistance < 2 * width)
+            {
+                Tc correction = 0.5 * (std::tanh(4 * (minDistance - offset) * invWidth - 4) + 1);
                 A[j] *= correction;
                 V_nm[j] *= correction;
             }
@@ -77,12 +115,17 @@ HOST_DEVICE_FUN void fbcAdjust(const cstone::Vec3<Tc> X, cstone::Vec3<Tc>& V_nm,
 }
 
 //! @brief update the energy according to Adams-Bashforth (2nd order)
-template<class TU>
-HOST_DEVICE_FUN TU energyUpdate(TU u_old, double dt, double dt_m1, double du, double du_m1)
+template<class TU, class Th, class Tc>
+HOST_DEVICE_FUN TU energyUpdate(TU u_old, double dt, double dt_m1, double du, double du_m1, const cstone::Vec3<Tc> Xn,
+                                const cstone::Box<Tc>& box, bool anyFBC, const Th hi)
 {
-    TU u_new = u_old + du * dt + 0.5 * (du - du_m1) / dt_m1 * std::abs(dt) * dt;
+    // notice the common factor of dt: if we want to decrease updates for boundary particles with a multiplicative
+    // factor, we might as well do it on dt.
+    auto dt_modified = dt;
+    if (anyFBC) { fbcAdjustScalar(Xn, dt_modified, box, hi); }
+    TU u_new = u_old + du * dt_modified + 0.5 * (du - du_m1) / dt_m1 * std::abs(dt_modified) * dt_modified;
     // To prevent u < 0 (when cooling with GRACKLE is active)
-    if (u_new < 0.) { u_new = u_old * std::exp(u_new * dt / u_old); }
+    if (u_new < 0.) { u_new = u_old * std::exp(u_new * dt_modified / u_old); }
     return u_new;
 }
 
@@ -105,7 +148,7 @@ HOST_DEVICE_FUN auto positionUpdate(double dt, double dt_m1, cstone::Vec3<T> Xn,
                                     cstone::Vec3<T> dXn, const cstone::Box<T>& box, bool anyFbc, const Th hi)
 {
     auto Vnmhalf = dXn * (T(1) / dt_m1);
-    if (anyFbc) { fbcAdjust(Xn, Vnmhalf, An, box, hi); }
+    if (anyFbc) { fbcAdjustVector(Xn, Vnmhalf, An, box, hi); }
 
     auto Vn    = Vnmhalf + T(0.5) * dt_m1 * An;
     auto Vnp1  = Vn + An * dt;
@@ -139,9 +182,14 @@ void updatePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const c
     }
 }
 
-template<class Dataset>
-void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d)
+template<class Dataset, class T>
+void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
 {
+    bool fbcX   = (box.boundaryX() == cstone::BoundaryType::fixed);
+    bool fbcY   = (box.boundaryY() == cstone::BoundaryType::fixed);
+    bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
+    bool anyFBC = fbcX || fbcY || fbcZ;
+
     bool haveMui = !d.mui.empty();
     auto constCv = idealGasCv(d.muiConst, d.gamma);
 
@@ -150,18 +198,26 @@ void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d)
     {
         auto cv    = haveMui ? idealGasCv(d.mui[i], d.gamma) : constCv;
         auto u_old = cv * d.temp[i];
-        d.temp[i]  = energyUpdate(u_old, d.minDt, d.minDt_m1, d.du[i], d.du_m1[i]) / cv;
+        d.temp[i] = energyUpdate(u_old, d.minDt, d.minDt_m1, d.du[i], d.du_m1[i], {d.x[i], d.y[i], d.z[i]}, box, anyFBC,
+                                 d.h[i]) /
+                    cv;
         d.du_m1[i] = d.du[i];
     }
 }
 
-template<class Dataset>
-void updateIntEnergyHost(size_t startIndex, size_t endIndex, Dataset& d)
+template<class Dataset, class T>
+void updateIntEnergyHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
 {
+    bool fbcX   = (box.boundaryX() == cstone::BoundaryType::fixed);
+    bool fbcY   = (box.boundaryY() == cstone::BoundaryType::fixed);
+    bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
+    bool anyFBC = fbcX || fbcY || fbcZ;
+
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        d.u[i]     = energyUpdate(d.u[i], d.minDt, d.minDt_m1, d.du[i], d.du_m1[i]);
+        d.u[i] = energyUpdate(d.u[i], d.minDt, d.minDt_m1, d.du[i], d.du_m1[i], {d.x[i], d.y[i], d.z[i]}, box, anyFBC,
+                              d.h[i]);
         d.du_m1[i] = d.du[i];
     }
 }
@@ -212,8 +268,8 @@ void computePositions(const GroupView& grp, Dataset& d, const cstone::Box<T>& bo
     {
         updatePositionsHost(grp.firstBody, grp.lastBody, d, box);
 
-        if (!d.temp.empty()) { updateTempHost(grp.firstBody, grp.lastBody, d); }
-        else if (!d.u.empty()) { updateIntEnergyHost(grp.firstBody, grp.lastBody, d); }
+        if (!d.temp.empty()) { updateTempHost(grp.firstBody, grp.lastBody, d, box); }
+        else if (!d.u.empty()) { updateIntEnergyHost(grp.firstBody, grp.lastBody, d, box); }
     }
 }
 

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -42,90 +42,45 @@
 
 namespace sph
 {
-//! @brief checks whether a particle is close to a fixed boundary and reduces a scalar if so
-template<class Tc, class Th, class Ts>
-HOST_DEVICE_FUN void fbcAdjustScalar(const cstone::Vec3<Tc> X, Ts& scalar, const cstone::Box<Tc>& box, const Th hi)
-{
-    // half the width of the sigmoid, in smoothing lengths
-    constexpr Th width    = 2.;
-    constexpr Th invWidth = 1 / width;
-    // width of particles that are held at zero, in smoothing lengths
-    constexpr Th       offset          = 2.;
-    cstone::Vec3<bool> isBoundaryFixed = {
-        box.boundaryX() == cstone::BoundaryType::fixed,
-        box.boundaryY() == cstone::BoundaryType::fixed,
-        box.boundaryZ() == cstone::BoundaryType::fixed,
-    };
-    cstone::Vec3<Tc> boxMax = {box.xmax(), box.ymax(), box.zmax()};
-    cstone::Vec3<Tc> boxMin = {box.xmin(), box.ymin(), box.zmin()};
 
-    for (int j = 0; j < 3; ++j)
-    {
-        if (isBoundaryFixed[j])
-        {
-
-            Th relDistanceMax = std::abs(boxMax[j] - X[j]) / hi;
-            Th relDistanceMin = std::abs(boxMin[j] - X[j]) / hi;
-            Th minDistance    = relDistanceMin < relDistanceMax ? relDistanceMin : relDistanceMax;
-
-            if (minDistance < 2 * width + offset)
-            {
-                Tc correction = 0.5 * (std::tanh(4 * (minDistance - offset) * invWidth - 4) + 1);
-                scalar *= correction;
-            }
-        }
-    }
-}
-
-//! @brief checks whether a particle is close to a fixed boundary and reduces the acceleration if so
+//! @brief checks whether a particle is close to a fixed boundary and returns a modification factor if so
 template<class Tc, class Th>
-HOST_DEVICE_FUN void fbcAdjustVector(const cstone::Vec3<Tc> X, cstone::Vec3<Tc>& V_nm, cstone::Vec3<Tc>& A,
-                                     const cstone::Box<Tc>& box, const Th hi)
+HOST_DEVICE_FUN Tc fbcAdjustFactor(const cstone::Vec3<Tc> X, const cstone::Box<Tc>& box, const Th hi, bool doCorrection)
 {
-    // half the width of the sigmoid, in smoothing lengths
-    constexpr Th width    = 2.;
-    constexpr Th invWidth = 1 / width;
-    // width of particles that are held at zero, in smoothing lengths
-    constexpr Th       offset          = 2.;
-    cstone::Vec3<bool> isBoundaryFixed = {
-        box.boundaryX() == cstone::BoundaryType::fixed,
-        box.boundaryY() == cstone::BoundaryType::fixed,
-        box.boundaryZ() == cstone::BoundaryType::fixed,
-    };
-    cstone::Vec3<Tc> boxMax = {box.xmax(), box.ymax(), box.zmax()};
-    cstone::Vec3<Tc> boxMin = {box.xmin(), box.ymin(), box.zmin()};
-
-    for (int j = 0; j < 3; ++j)
+    if (doCorrection)
     {
-        if (isBoundaryFixed[j])
+        // half the width of the sigmoid, in smoothing lengths
+        constexpr Th width    = 2.;
+        constexpr Th invWidth = 1 / width;
+        // width of particles that are held at zero, in smoothing lengths
+        constexpr Th       offset          = 2.;
+        cstone::Vec3<bool> isBoundaryFixed = {
+            box.boundaryX() == cstone::BoundaryType::fixed,
+            box.boundaryY() == cstone::BoundaryType::fixed,
+            box.boundaryZ() == cstone::BoundaryType::fixed,
+        };
+        cstone::Vec3<Tc> boxMax      = {box.xmax(), box.ymax(), box.zmax()};
+        cstone::Vec3<Tc> boxMin      = {box.xmin(), box.ymin(), box.zmin()};
+        cstone::Vec3<Tc> minDistance = min(abs(boxMax - X), abs(boxMin - X)) * (Th(1.0) / hi);
+
+        for (int j = 0; j < 3; ++j)
         {
-
-            Th relDistanceMax = std::abs(boxMax[j] - X[j]) / hi;
-            Th relDistanceMin = std::abs(boxMin[j] - X[j]) / hi;
-            Th minDistance    = relDistanceMin < relDistanceMax ? relDistanceMin : relDistanceMax;
-
-            if (minDistance < 2 * width)
+            if (isBoundaryFixed[j] && minDistance[j] < 2 * width + offset)
             {
-                Tc correction = 0.5 * (std::tanh(4 * (minDistance - offset) * invWidth - 4) + 1);
-                A[j] *= correction;
-                V_nm[j] *= correction;
+                return Tc(0.5 * (std::tanh(4 * (minDistance[j] - offset) * invWidth - 4) + 1));
             }
         }
     }
+    return Tc(1.0);
 }
 
 //! @brief update the energy according to Adams-Bashforth (2nd order)
-template<class TU, class Th, class Tc>
-HOST_DEVICE_FUN TU energyUpdate(TU u_old, double dt, double dt_m1, double du, double du_m1, const cstone::Vec3<Tc> Xn,
-                                const cstone::Box<Tc>& box, bool anyFBC, const Th hi)
+template<class TU>
+HOST_DEVICE_FUN TU energyUpdate(TU u_old, double dt, double dt_m1, double du, double du_m1)
 {
-    // notice the common factor of dt: if we want to decrease updates for boundary particles with a multiplicative
-    // factor, we might as well do it on dt.
-    auto dt_modified = dt;
-    if (anyFBC) { fbcAdjustScalar(Xn, dt_modified, box, hi); }
-    TU u_new = u_old + du * dt_modified + 0.5 * (du - du_m1) / dt_m1 * std::abs(dt_modified) * dt_modified;
+    TU u_new = u_old + du * dt + 0.5 * (du - du_m1) / dt_m1 * std::abs(dt) * dt;
     // To prevent u < 0 (when cooling with GRACKLE is active)
-    if (u_new < 0.) { u_new = u_old * std::exp(u_new * dt_modified / u_old); }
+    if (u_new < 0.) { u_new = u_old * std::exp(u_new * dt / u_old); }
     return u_new;
 }
 
@@ -143,17 +98,15 @@ HOST_DEVICE_FUN TU energyUpdate(TU u_old, double dt, double dt_m1, double du, do
  * time-reversibility:
  * positionUpdate(-dt, dt_m1, X_n+1, An, dXn, box) will back-propagate X_n+1 to X_n
  */
-template<class T, class Th>
+template<class T>
 HOST_DEVICE_FUN auto positionUpdate(double dt, double dt_m1, cstone::Vec3<T> Xn, cstone::Vec3<T> An,
-                                    cstone::Vec3<T> dXn, const cstone::Box<T>& box, bool anyFbc, const Th hi)
+                                    cstone::Vec3<T> dXn, const cstone::Box<T>& box)
 {
     auto Vnmhalf = dXn * (T(1) / dt_m1);
-    if (anyFbc) { fbcAdjustVector(Xn, Vnmhalf, An, box, hi); }
-
-    auto Vn    = Vnmhalf + T(0.5) * dt_m1 * An;
-    auto Vnp1  = Vn + An * dt;
-    auto dXnp1 = (Vn + T(0.5) * An * std::abs(dt)) * dt;
-    auto Xnp1  = cstone::putInBox(Xn + dXnp1, box);
+    auto Vn      = Vnmhalf + T(0.5) * dt_m1 * An;
+    auto Vnp1    = Vn + An * dt;
+    auto dXnp1   = (Vn + T(0.5) * An * std::abs(dt)) * dt;
+    auto Xnp1    = cstone::putInBox(Xn + dXnp1, box);
 
     return util::tuple<cstone::Vec3<T>, cstone::Vec3<T>, cstone::Vec3<T>>{Xnp1, Vnp1, dXnp1};
 }
@@ -161,20 +114,30 @@ HOST_DEVICE_FUN auto positionUpdate(double dt, double dt_m1, cstone::Vec3<T> Xn,
 template<class T, class Dataset>
 void updatePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone::Box<T>& box)
 {
-    bool fbcX = (box.boundaryX() == cstone::BoundaryType::fixed);
-    bool fbcY = (box.boundaryY() == cstone::BoundaryType::fixed);
-    bool fbcZ = (box.boundaryZ() == cstone::BoundaryType::fixed);
+    cstone::Vec3<bool> isAxisFixedBoundary = {box.boundaryX() == cstone::BoundaryType::fixed,
+                                              box.boundaryY() == cstone::BoundaryType::fixed,
+                                              box.boundaryZ() == cstone::BoundaryType::fixed};
 
-    bool anyFBC = fbcX || fbcY || fbcZ;
+    bool anyFBC = isAxisFixedBoundary[0] || isAxisFixedBoundary[1] || isAxisFixedBoundary[2];
+    cstone::Vec3<T> adjustForFBC{T(1.), T(1.), T(1.)};
 
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        cstone::Vec3<T> A{d.ax[i], d.ay[i], d.az[i]};
         cstone::Vec3<T> X{d.x[i], d.y[i], d.z[i]};
-        cstone::Vec3<T> X_m1{d.x_m1[i], d.y_m1[i], d.z_m1[i]};
+
+        if (anyFBC)
+        {
+            for (size_t j = 0; j < 3; ++j)
+            {
+                adjustForFBC[j] = fbcAdjustFactor(X, box, d.h[i], isAxisFixedBoundary[j]);
+            }
+        }
+        // To keep particles belonging to the fixed boundaries from moving, these two quantities need to be adjusted
+        cstone::Vec3<T> A{d.ax[i] * adjustForFBC[0], d.ay[i] * adjustForFBC[1], d.az[i] * adjustForFBC[2]};
+        cstone::Vec3<T> X_m1{d.x_m1[i] * adjustForFBC[0], d.y_m1[i] * adjustForFBC[1], d.z_m1[i] * adjustForFBC[2]};
         cstone::Vec3<T> V;
-        util::tie(X, V, X_m1) = positionUpdate(d.minDt, d.minDt_m1, X, A, X_m1, box, anyFBC, d.h[i]);
+        util::tie(X, V, X_m1) = positionUpdate(d.minDt, d.minDt_m1, X, A, X_m1, box);
 
         util::tie(d.x[i], d.y[i], d.z[i])          = util::tie(X[0], X[1], X[2]);
         util::tie(d.x_m1[i], d.y_m1[i], d.z_m1[i]) = util::tie(X_m1[0], X_m1[1], X_m1[2]);
@@ -190,17 +153,18 @@ void updateTempHost(size_t startIndex, size_t endIndex, Dataset& d, const cstone
     bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
     bool anyFBC = fbcX || fbcY || fbcZ;
 
-    bool haveMui = !d.mui.empty();
-    auto constCv = idealGasCv(d.muiConst, d.gamma);
+    bool haveMui      = !d.mui.empty();
+    auto constCv      = idealGasCv(d.muiConst, d.gamma);
+    auto adjustForFBC = 1.0;
 
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
+        if (anyFBC) { adjustForFBC = fbcAdjustFactor({d.x[i], d.y[i], d.z[i]}, box, d.h[i], true); }
         auto cv    = haveMui ? idealGasCv(d.mui[i], d.gamma) : constCv;
         auto u_old = cv * d.temp[i];
-        d.temp[i] = energyUpdate(u_old, d.minDt, d.minDt_m1, d.du[i], d.du_m1[i], {d.x[i], d.y[i], d.z[i]}, box, anyFBC,
-                                 d.h[i]) /
-                    cv;
+        // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
+        d.temp[i]  = energyUpdate(u_old, d.minDt * adjustForFBC, d.minDt_m1, d.du[i], d.du_m1[i]) / cv;
         d.du_m1[i] = d.du[i];
     }
 }
@@ -213,11 +177,14 @@ void updateIntEnergyHost(size_t startIndex, size_t endIndex, Dataset& d, const c
     bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
     bool anyFBC = fbcX || fbcY || fbcZ;
 
+    auto adjustForFBC = 1.0;
+
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        d.u[i] = energyUpdate(d.u[i], d.minDt, d.minDt_m1, d.du[i], d.du_m1[i], {d.x[i], d.y[i], d.z[i]}, box, anyFBC,
-                              d.h[i]);
+        if (anyFBC) { adjustForFBC = fbcAdjustFactor({d.x[i], d.y[i], d.z[i]}, box, d.h[i], true); }
+        // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
+        d.u[i]     = energyUpdate(d.u[i], d.minDt * adjustForFBC, d.minDt_m1, d.du[i], d.du_m1[i]);
         d.du_m1[i] = d.du[i];
     }
 }

--- a/sph/include/sph/positions.hpp
+++ b/sph/include/sph/positions.hpp
@@ -42,12 +42,38 @@
 
 namespace sph
 {
-
-//! @brief checks whether a particle is in the fixed boundary region in one dimension
+//! @brief checks whether a particle is close to a fixed boundary and reduces the acceleration if so
 template<class Tc, class Th>
-HOST_DEVICE_FUN bool fbcCheck(Tc coord, Th h, Tc top, Tc bottom, bool fbc)
+HOST_DEVICE_FUN void fbcAdjust(const cstone::Vec3<Tc> X, cstone::Vec3<Tc>& V_nm, cstone::Vec3<Tc>& A,
+                               const cstone::Box<Tc>& box, const Th hi)
 {
-    return fbc && (std::abs(top - coord) < Th(2) * h || std::abs(bottom - coord) < Th(2) * h);
+    constexpr Th       threshold       = 4.;
+    constexpr Th       invTHold        = 1 / threshold;
+    cstone::Vec3<bool> isBoundaryFixed = {
+        box.boundaryX() == cstone::BoundaryType::fixed,
+        box.boundaryY() == cstone::BoundaryType::fixed,
+        box.boundaryZ() == cstone::BoundaryType::fixed,
+    };
+    cstone::Vec3<Tc> boxMax = {box.xmax(), box.ymax(), box.zmax()};
+    cstone::Vec3<Tc> boxMin = {box.xmin(), box.ymin(), box.zmin()};
+
+    for (int j = 0; j < 3; ++j)
+    {
+        if (isBoundaryFixed[j])
+        {
+
+            Th relDistanceMax = std::abs(boxMax[j] - X[j]) / hi;
+            Th relDistanceMin = std::abs(boxMin[j] - X[j]) / hi;
+            Th minDistance    = relDistanceMin < relDistanceMax ? relDistanceMin : relDistanceMax;
+
+            if (minDistance < 2 * threshold)
+            {
+                Tc correction = 0.5 * (std::tanh(4 * minDistance * invTHold - 4) + 1);
+                A[j] *= correction;
+                V_nm[j] *= correction;
+            }
+        }
+    }
 }
 
 //! @brief update the energy according to Adams-Bashforth (2nd order)
@@ -74,15 +100,17 @@ HOST_DEVICE_FUN TU energyUpdate(TU u_old, double dt, double dt_m1, double du, do
  * time-reversibility:
  * positionUpdate(-dt, dt_m1, X_n+1, An, dXn, box) will back-propagate X_n+1 to X_n
  */
-template<class T>
+template<class T, class Th>
 HOST_DEVICE_FUN auto positionUpdate(double dt, double dt_m1, cstone::Vec3<T> Xn, cstone::Vec3<T> An,
-                                    cstone::Vec3<T> dXn, const cstone::Box<T>& box)
+                                    cstone::Vec3<T> dXn, const cstone::Box<T>& box, bool anyFbc, const Th hi)
 {
     auto Vnmhalf = dXn * (T(1) / dt_m1);
-    auto Vn      = Vnmhalf + T(0.5) * dt_m1 * An;
-    auto Vnp1    = Vn + An * dt;
-    auto dXnp1   = (Vn + T(0.5) * An * std::abs(dt)) * dt;
-    auto Xnp1    = cstone::putInBox(Xn + dXnp1, box);
+    if (anyFbc) { fbcAdjust(Xn, Vnmhalf, An, box, hi); }
+
+    auto Vn    = Vnmhalf + T(0.5) * dt_m1 * An;
+    auto Vnp1  = Vn + An * dt;
+    auto dXnp1 = (Vn + T(0.5) * An * std::abs(dt)) * dt;
+    auto Xnp1  = cstone::putInBox(Xn + dXnp1, box);
 
     return util::tuple<cstone::Vec3<T>, cstone::Vec3<T>, cstone::Vec3<T>>{Xnp1, Vnp1, dXnp1};
 }
@@ -99,21 +127,11 @@ void updatePositionsHost(size_t startIndex, size_t endIndex, Dataset& d, const c
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        if (anyFBC && d.vx[i] == T(0) && d.vy[i] == T(0) && d.vz[i] == T(0))
-        {
-            if (fbcCheck(d.x[i], d.h[i], box.xmax(), box.xmin(), fbcX) ||
-                fbcCheck(d.y[i], d.h[i], box.ymax(), box.ymin(), fbcY) ||
-                fbcCheck(d.z[i], d.h[i], box.zmax(), box.zmin(), fbcZ))
-            {
-                continue;
-            }
-        }
-
         cstone::Vec3<T> A{d.ax[i], d.ay[i], d.az[i]};
         cstone::Vec3<T> X{d.x[i], d.y[i], d.z[i]};
         cstone::Vec3<T> X_m1{d.x_m1[i], d.y_m1[i], d.z_m1[i]};
         cstone::Vec3<T> V;
-        util::tie(X, V, X_m1) = positionUpdate(d.minDt, d.minDt_m1, X, A, X_m1, box);
+        util::tie(X, V, X_m1) = positionUpdate(d.minDt, d.minDt_m1, X, A, X_m1, box, anyFBC, d.h[i]);
 
         util::tie(d.x[i], d.y[i], d.z[i])          = util::tie(X[0], X[1], X[2]);
         util::tie(d.x_m1[i], d.y_m1[i], d.z_m1[i]) = util::tie(X_m1[0], X_m1[1], X_m1[2]);

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -131,10 +131,9 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
 
     float dt_m1_rung = (rung != nullptr) ? dt_m1[rung[i]] : dt_m1[0];
 
-
-    cstone::Vec3<Tc>   X{x[i], y[i], z[i]};
-    bool               anyFBC = isAxisFixedBoundary[0] || isAxisFixedBoundary[1] || isAxisFixedBoundary[2];
-    cstone::Vec3<Tc>   adjustForFBC{Tc(1.), Tc(1.), Tc(1.)};
+    cstone::Vec3<Tc> X{x[i], y[i], z[i]};
+    bool             anyFBC = isAxisFixedBoundary[0] || isAxisFixedBoundary[1] || isAxisFixedBoundary[2];
+    cstone::Vec3<Tc> adjustForFBC{Tc(1.), Tc(1.), Tc(1.)};
     if (anyFBC)
     {
         for (size_t j = 0; j < 3; ++j)
@@ -186,7 +185,8 @@ void computePositionsGpu(const GroupView& grp, float dt, util::array<float, Time
 
     if (numBlocks == 0) { return; }
     computePositionsKernel<<<numBlocks, numThreads>>>(grp, dt, dt_m1, x, y, z, vx, vy, vz, x_m1, y_m1, z_m1, ax, ay, az,
-                                                      rung, temp, u, du, du_m1, h, mui, gamma, constCv, box, isAxisFixedBoundary);
+                                                      rung, temp, u, du, du_m1, h, mui, gamma, constCv, box,
+                                                      isAxisFixedBoundary);
 }
 
 #define POS_GPU(Tc, Tv, Ta, Tdu, Tm1, Tt, Thydro)                                                                      \

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -64,31 +64,27 @@ __global__ void driftKernel(GroupView grp, float dt, float dt_back, util::array<
     cstone::Vec3<Tc> Xnback{x[i], y[i], z[i]};
     cstone::Vec3<Tc> dXn{x_m1[i], y_m1[i], z_m1[i]};
 
-    bool FBC = false;
-
     // recover Xn, at which point An was calculated
     cstone::Vec3<Tc> Xn_recov, ignore;
-    util::tie(Xn_recov, ignore, ignore) =
-        positionUpdate(-dt_back, dt_m1_rung, Xnback, An, dXn, noPbc, FBC, Thydro(0.0));
+    util::tie(Xn_recov, ignore, ignore) = positionUpdate(-dt_back, dt_m1_rung, Xnback, An, dXn, noPbc);
 
     // drift to new point in time starting from (Xn, An, dXn)
     cstone::Vec3<Tc> Xnp1, Vnp1;
-    util::tie(Xnp1, Vnp1, ignore) = positionUpdate(dt, dt_m1_rung, Xn_recov, An, dXn, noPbc, FBC, Thydro(0.0));
+    util::tie(Xnp1, Vnp1, ignore) = positionUpdate(dt, dt_m1_rung, Xn_recov, An, dXn, noPbc);
 
     util::tie(x[i], y[i], z[i])    = util::tie(Xnp1[0], Xnp1[1], Xnp1[2]);
     util::tie(vx[i], vy[i], vz[i]) = util::tie(Vnp1[0], Vnp1[1], Vnp1[2]);
 
     if (temp != nullptr)
     {
-        Thydro cv = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
-        auto   u_recov =
-            energyUpdate(Tc(temp[i] * cv), -dt_back, dt_m1_rung, du[i], Tdu(du_m1[i]), Xnback, noPbc, FBC, Thydro(0.0));
-        temp[i] = energyUpdate(u_recov, dt, dt_m1_rung, du[i], Tdu(du_m1[i]), Xnback, noPbc, FBC, Thydro(0.0)) / cv;
+        Thydro cv      = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
+        auto   u_recov = energyUpdate(Tc(temp[i] * cv), -dt_back, dt_m1_rung, du[i], Tdu(du_m1[i]));
+        temp[i]        = energyUpdate(u_recov, dt, dt_m1_rung, du[i], Tdu(du_m1[i])) / cv;
     }
     else if (u != nullptr)
     {
-        auto u_recov = energyUpdate(u[i], -dt_back, dt_m1_rung, du[i], Tdu(du_m1[i]), Xnback, noPbc, FBC, Thydro(0.0));
-        u[i]         = energyUpdate(u_recov, dt, dt_m1_rung, du[i], Tdu(du_m1[i]), Xnback, noPbc, FBC, Thydro(0.0));
+        auto u_recov = energyUpdate(u[i], -dt_back, dt_m1_rung, du[i], Tdu(du_m1[i]));
+        u[i]         = energyUpdate(u_recov, dt, dt_m1_rung, du[i], Tdu(du_m1[i]));
     }
 }
 
@@ -124,7 +120,7 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
                                        Tc* y, Tc* z, Tv* vx, Tv* vy, Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax,
                                        Ta* ay, Ta* az, const uint8_t* rung, Tt* temp, Tt* u, Tdu* du, Tm1* du_m1,
                                        Thydro* h, Thydro* mui, Tc gamma, Tc constCv, const cstone::Box<Tc> box,
-                                       const bool anyFBC)
+                                       cstone::Vec3<bool> isAxisFixedBoundary)
 {
     LocalIndex laneIdx = threadIdx.x & (GpuConfig::warpSize - 1);
     LocalIndex warpIdx = (blockDim.x * blockIdx.x + threadIdx.x) >> GpuConfig::warpSizeLog2;
@@ -133,27 +129,43 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
     LocalIndex i = grp.groupStart[warpIdx] + laneIdx;
     if (i >= grp.groupEnd[warpIdx]) { return; }
 
-    float            dt_m1_rung = (rung != nullptr) ? dt_m1[rung[i]] : dt_m1[0];
-    cstone::Vec3<Tc> A{ax[i], ay[i], az[i]};
-    cstone::Vec3<Tc> X{x[i], y[i], z[i]};
-    cstone::Vec3<Tc> X_m1{x_m1[i], y_m1[i], z_m1[i]};
+    float dt_m1_rung = (rung != nullptr) ? dt_m1[rung[i]] : dt_m1[0];
+
+
+    cstone::Vec3<Tc>   X{x[i], y[i], z[i]};
+    bool               anyFBC = isAxisFixedBoundary[0] || isAxisFixedBoundary[1] || isAxisFixedBoundary[2];
+    cstone::Vec3<Tc>   adjustForFBC{Tc(1.), Tc(1.), Tc(1.)};
+    if (anyFBC)
+    {
+        for (size_t j = 0; j < 3; ++j)
+        {
+            adjustForFBC[j] = fbcAdjustFactor(X, box, h[i], isAxisFixedBoundary[j]);
+        }
+    }
+
+    // To keep particles belonging to the fixed boundaries from moving, these two quantities need to be adjusted
+    cstone::Vec3<Tc> A{ax[i] * adjustForFBC[0], ay[i] * adjustForFBC[1], az[i] * adjustForFBC[2]};
+    cstone::Vec3<Tc> X_m1{x_m1[i] * adjustForFBC[0], y_m1[i] * adjustForFBC[1], z_m1[i] * adjustForFBC[2]};
     cstone::Vec3<Tc> V;
-    util::tie(X, V, X_m1) = positionUpdate(dt, dt_m1_rung, X, A, X_m1, box, anyFBC, h[i]);
+    util::tie(X, V, X_m1) = positionUpdate(dt, dt_m1_rung, X, A, X_m1, box);
 
     util::tie(x[i], y[i], z[i])          = util::tie(X[0], X[1], X[2]);
     util::tie(x_m1[i], y_m1[i], z_m1[i]) = util::tie(X_m1[0], X_m1[1], X_m1[2]);
     util::tie(vx[i], vy[i], vz[i])       = util::tie(V[0], V[1], V[2]);
 
+    if (anyFBC) { adjustForFBC[0] = fbcAdjustFactor(X, box, h[i], true); }
     if (temp != nullptr)
     {
         Thydro cv    = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
         auto   u_old = temp[i] * cv;
-        temp[i]      = energyUpdate(u_old, dt, dt_m1_rung, du[i], du_m1[i], X, box, anyFBC, h[i]) / cv;
-        du_m1[i]     = du[i];
+        // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
+        temp[i]  = energyUpdate(u_old, dt * adjustForFBC[0], dt_m1_rung, du[i], du_m1[i]) / cv;
+        du_m1[i] = du[i];
     }
     else if (u != nullptr)
     {
-        u[i]     = energyUpdate(u[i], dt, dt_m1_rung, du[i], du_m1[i], X, box, anyFBC, h[i]);
+        // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
+        u[i]     = energyUpdate(u[i], dt * adjustForFBC[0], dt_m1_rung, du[i], du_m1[i]);
         du_m1[i] = du[i];
     }
 }
@@ -168,14 +180,13 @@ void computePositionsGpu(const GroupView& grp, float dt, util::array<float, Time
     unsigned numWarpsPerBlock = numThreads / GpuConfig::warpSize;
     unsigned numBlocks        = (grp.numGroups + numWarpsPerBlock - 1) / numWarpsPerBlock;
 
-    bool fbcX   = (box.boundaryX() == cstone::BoundaryType::fixed);
-    bool fbcY   = (box.boundaryY() == cstone::BoundaryType::fixed);
-    bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
-    bool anyFBC = fbcX || fbcY || fbcZ;
+    cstone::Vec3<bool> isAxisFixedBoundary = {box.boundaryX() == cstone::BoundaryType::fixed,
+                                              box.boundaryY() == cstone::BoundaryType::fixed,
+                                              box.boundaryZ() == cstone::BoundaryType::fixed};
 
     if (numBlocks == 0) { return; }
     computePositionsKernel<<<numBlocks, numThreads>>>(grp, dt, dt_m1, x, y, z, vx, vy, vz, x_m1, y_m1, z_m1, ax, ay, az,
-                                                      rung, temp, u, du, du_m1, h, mui, gamma, constCv, box, anyFBC);
+                                                      rung, temp, u, du, du_m1, h, mui, gamma, constCv, box, isAxisFixedBoundary);
 }
 
 #define POS_GPU(Tc, Tv, Ta, Tdu, Tm1, Tt, Thydro)                                                                      \

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -80,14 +80,15 @@ __global__ void driftKernel(GroupView grp, float dt, float dt_back, util::array<
 
     if (temp != nullptr)
     {
-        Thydro cv      = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
-        auto   u_recov = energyUpdate(Tc(temp[i] * cv), -dt_back, dt_m1_rung, du[i], Tdu(du_m1[i]));
-        temp[i]        = energyUpdate(u_recov, dt, dt_m1_rung, du[i], Tdu(du_m1[i])) / cv;
+        Thydro cv = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
+        auto   u_recov =
+            energyUpdate(Tc(temp[i] * cv), -dt_back, dt_m1_rung, du[i], Tdu(du_m1[i]), Xnback, noPbc, FBC, Thydro(0.0));
+        temp[i] = energyUpdate(u_recov, dt, dt_m1_rung, du[i], Tdu(du_m1[i]), Xnback, noPbc, FBC, Thydro(0.0)) / cv;
     }
     else if (u != nullptr)
     {
-        auto u_recov = energyUpdate(u[i], -dt_back, dt_m1_rung, du[i], Tdu(du_m1[i]));
-        u[i]         = energyUpdate(u_recov, dt, dt_m1_rung, du[i], Tdu(du_m1[i]));
+        auto u_recov = energyUpdate(u[i], -dt_back, dt_m1_rung, du[i], Tdu(du_m1[i]), Xnback, noPbc, FBC, Thydro(0.0));
+        u[i]         = energyUpdate(u_recov, dt, dt_m1_rung, du[i], Tdu(du_m1[i]), Xnback, noPbc, FBC, Thydro(0.0));
     }
 }
 
@@ -147,12 +148,12 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
     {
         Thydro cv    = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
         auto   u_old = temp[i] * cv;
-        temp[i]      = energyUpdate(u_old, dt, dt_m1_rung, du[i], du_m1[i]) / cv;
+        temp[i]      = energyUpdate(u_old, dt, dt_m1_rung, du[i], du_m1[i], X, box, anyFBC, h[i]) / cv;
         du_m1[i]     = du[i];
     }
     else if (u != nullptr)
     {
-        u[i]     = energyUpdate(u[i], dt, dt_m1_rung, du[i], du_m1[i]);
+        u[i]     = energyUpdate(u[i], dt, dt_m1_rung, du[i], du_m1[i], X, box, anyFBC, h[i]);
         du_m1[i] = du[i];
     }
 }

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -120,7 +120,7 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
                                        Tc* y, Tc* z, Tv* vx, Tv* vy, Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax,
                                        Ta* ay, Ta* az, const uint8_t* rung, Tt* temp, Tt* u, Tdu* du, Tm1* du_m1,
                                        Thydro* h, Thydro* mui, Tc gamma, Tc constCv, const cstone::Box<Tc> box,
-                                       cstone::Vec3<bool> isAxisFixedBoundary)
+                                       bool anyFBC)
 {
     LocalIndex laneIdx = threadIdx.x & (GpuConfig::warpSize - 1);
     LocalIndex warpIdx = (blockDim.x * blockIdx.x + threadIdx.x) >> GpuConfig::warpSizeLog2;
@@ -132,15 +132,8 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
     float dt_m1_rung = (rung != nullptr) ? dt_m1[rung[i]] : dt_m1[0];
 
     cstone::Vec3<Tc> X{x[i], y[i], z[i]};
-    bool             anyFBC = isAxisFixedBoundary[0] || isAxisFixedBoundary[1] || isAxisFixedBoundary[2];
     cstone::Vec3<Tc> adjustForFBC{Tc(1.), Tc(1.), Tc(1.)};
-    if (anyFBC)
-    {
-        for (size_t j = 0; j < 3; ++j)
-        {
-            adjustForFBC[j] = fbcAdjustFactor(X, box, h[i], isAxisFixedBoundary[j]);
-        }
-    }
+    if (anyFBC) { adjustForFBC = fbcAdjustFactors(X, box, h[i]); }
 
     // To keep particles belonging to the fixed boundaries from moving, these two quantities need to be adjusted
     cstone::Vec3<Tc> A{ax[i] * adjustForFBC[0], ay[i] * adjustForFBC[1], az[i] * adjustForFBC[2]};
@@ -152,19 +145,22 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
     util::tie(x_m1[i], y_m1[i], z_m1[i]) = util::tie(X_m1[0], X_m1[1], X_m1[2]);
     util::tie(vx[i], vy[i], vz[i])       = util::tie(V[0], V[1], V[2]);
 
-    if (anyFBC) { adjustForFBC[0] = fbcAdjustFactor(X, box, h[i], true); }
+    Tc minDistanceFactor = min(adjustForFBC);
     if (temp != nullptr)
     {
         Thydro cv    = (constCv < 0) ? idealGasCv(mui[i], gamma) : constCv;
         auto   u_old = temp[i] * cv;
         // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
-        temp[i]  = energyUpdate(u_old, dt * adjustForFBC[0], dt_m1_rung, du[i], du_m1[i]) / cv;
+        // we divide out dt_m1 by that factor so it applies only once to each of the updating terms
+        temp[i] =
+            energyUpdate(u_old, dt * minDistanceFactor, dt_m1_rung * (1. / minDistanceFactor), du[i], du_m1[i]) / cv;
         du_m1[i] = du[i];
     }
     else if (u != nullptr)
     {
         // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
-        u[i]     = energyUpdate(u[i], dt * adjustForFBC[0], dt_m1_rung, du[i], du_m1[i]);
+        // we divide out dt_m1 by that factor so it applies only once to each of the updating terms
+        u[i]     = energyUpdate(u[i], dt * minDistanceFactor, dt_m1_rung * (1. / minDistanceFactor), du[i], du_m1[i]);
         du_m1[i] = du[i];
     }
 }
@@ -179,14 +175,12 @@ void computePositionsGpu(const GroupView& grp, float dt, util::array<float, Time
     unsigned numWarpsPerBlock = numThreads / GpuConfig::warpSize;
     unsigned numBlocks        = (grp.numGroups + numWarpsPerBlock - 1) / numWarpsPerBlock;
 
-    cstone::Vec3<bool> isAxisFixedBoundary = {box.boundaryX() == cstone::BoundaryType::fixed,
-                                              box.boundaryY() == cstone::BoundaryType::fixed,
-                                              box.boundaryZ() == cstone::BoundaryType::fixed};
+    bool anyFBC = box.boundaryX() == cstone::BoundaryType::fixed || box.boundaryY() == cstone::BoundaryType::fixed ||
+                  box.boundaryZ() == cstone::BoundaryType::fixed;
 
     if (numBlocks == 0) { return; }
     computePositionsKernel<<<numBlocks, numThreads>>>(grp, dt, dt_m1, x, y, z, vx, vy, vz, x_m1, y_m1, z_m1, ax, ay, az,
-                                                      rung, temp, u, du, du_m1, h, mui, gamma, constCv, box,
-                                                      isAxisFixedBoundary);
+                                                      rung, temp, u, du, du_m1, h, mui, gamma, constCv, box, anyFBC);
 }
 
 #define POS_GPU(Tc, Tv, Ta, Tdu, Tm1, Tt, Thydro)                                                                      \

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -153,14 +153,14 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
         // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
         // we divide out dt_m1 by that factor so it applies only once to each of the updating terms
         temp[i] =
-            energyUpdate(u_old, dt * minDistanceFactor, dt_m1_rung * (1. / minDistanceFactor), du[i], du_m1[i]) / cv;
+            energyUpdate(u_old, dt * minDistanceFactor, dt_m1_rung * (Tc(1) / minDistanceFactor), du[i], du_m1[i]) / cv;
         du_m1[i] = du[i];
     }
     else if (u != nullptr)
     {
         // notice the common factor of dt in energyUpdate: to apply the Fixed Boundary Correction we can do it on dt.
         // we divide out dt_m1 by that factor so it applies only once to each of the updating terms
-        u[i]     = energyUpdate(u[i], dt * minDistanceFactor, dt_m1_rung * (1. / minDistanceFactor), du[i], du_m1[i]);
+        u[i]     = energyUpdate(u[i], dt * minDistanceFactor, dt_m1_rung * (Tc(1) / minDistanceFactor), du[i], du_m1[i]);
         du_m1[i] = du[i];
     }
 }

--- a/sph/include/sph/positions_gpu.cu
+++ b/sph/include/sph/positions_gpu.cu
@@ -64,13 +64,16 @@ __global__ void driftKernel(GroupView grp, float dt, float dt_back, util::array<
     cstone::Vec3<Tc> Xnback{x[i], y[i], z[i]};
     cstone::Vec3<Tc> dXn{x_m1[i], y_m1[i], z_m1[i]};
 
+    bool FBC = false;
+
     // recover Xn, at which point An was calculated
     cstone::Vec3<Tc> Xn_recov, ignore;
-    util::tie(Xn_recov, ignore, ignore) = positionUpdate(-dt_back, dt_m1_rung, Xnback, An, dXn, noPbc);
+    util::tie(Xn_recov, ignore, ignore) =
+        positionUpdate(-dt_back, dt_m1_rung, Xnback, An, dXn, noPbc, FBC, Thydro(0.0));
 
     // drift to new point in time starting from (Xn, An, dXn)
     cstone::Vec3<Tc> Xnp1, Vnp1;
-    util::tie(Xnp1, Vnp1, ignore) = positionUpdate(dt, dt_m1_rung, Xn_recov, An, dXn, noPbc);
+    util::tie(Xnp1, Vnp1, ignore) = positionUpdate(dt, dt_m1_rung, Xn_recov, An, dXn, noPbc, FBC, Thydro(0.0));
 
     util::tie(x[i], y[i], z[i])    = util::tie(Xnp1[0], Xnp1[1], Xnp1[2]);
     util::tie(vx[i], vy[i], vz[i]) = util::tie(Vnp1[0], Vnp1[1], Vnp1[2]);
@@ -119,7 +122,8 @@ template<class Tc, class Tv, class Ta, class Tdu, class Tm1, class Tt, class Thy
 __global__ void computePositionsKernel(GroupView grp, float dt, util::array<float, Timestep::maxNumRungs> dt_m1, Tc* x,
                                        Tc* y, Tc* z, Tv* vx, Tv* vy, Tv* vz, Tm1* x_m1, Tm1* y_m1, Tm1* z_m1, Ta* ax,
                                        Ta* ay, Ta* az, const uint8_t* rung, Tt* temp, Tt* u, Tdu* du, Tm1* du_m1,
-                                       Thydro* h, Thydro* mui, Tc gamma, Tc constCv, const cstone::Box<Tc> box)
+                                       Thydro* h, Thydro* mui, Tc gamma, Tc constCv, const cstone::Box<Tc> box,
+                                       const bool anyFBC)
 {
     LocalIndex laneIdx = threadIdx.x & (GpuConfig::warpSize - 1);
     LocalIndex warpIdx = (blockDim.x * blockIdx.x + threadIdx.x) >> GpuConfig::warpSizeLog2;
@@ -128,26 +132,12 @@ __global__ void computePositionsKernel(GroupView grp, float dt, util::array<floa
     LocalIndex i = grp.groupStart[warpIdx] + laneIdx;
     if (i >= grp.groupEnd[warpIdx]) { return; }
 
-    bool fbcX   = (box.boundaryX() == cstone::BoundaryType::fixed);
-    bool fbcY   = (box.boundaryY() == cstone::BoundaryType::fixed);
-    bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
-    bool anyFBC = fbcX || fbcY || fbcZ;
-
-    if (anyFBC && vx[i] == Tv(0) && vy[i] == Tv(0) && vz[i] == Tv(0))
-    {
-        if (fbcCheck(x[i], h[i], box.xmax(), box.xmin(), fbcX) || fbcCheck(y[i], h[i], box.ymax(), box.ymin(), fbcY) ||
-            fbcCheck(z[i], h[i], box.zmax(), box.zmin(), fbcZ))
-        {
-            return;
-        }
-    }
-
     float            dt_m1_rung = (rung != nullptr) ? dt_m1[rung[i]] : dt_m1[0];
     cstone::Vec3<Tc> A{ax[i], ay[i], az[i]};
     cstone::Vec3<Tc> X{x[i], y[i], z[i]};
     cstone::Vec3<Tc> X_m1{x_m1[i], y_m1[i], z_m1[i]};
     cstone::Vec3<Tc> V;
-    util::tie(X, V, X_m1) = positionUpdate(dt, dt_m1_rung, X, A, X_m1, box);
+    util::tie(X, V, X_m1) = positionUpdate(dt, dt_m1_rung, X, A, X_m1, box, anyFBC, h[i]);
 
     util::tie(x[i], y[i], z[i])          = util::tie(X[0], X[1], X[2]);
     util::tie(x_m1[i], y_m1[i], z_m1[i]) = util::tie(X_m1[0], X_m1[1], X_m1[2]);
@@ -177,9 +167,14 @@ void computePositionsGpu(const GroupView& grp, float dt, util::array<float, Time
     unsigned numWarpsPerBlock = numThreads / GpuConfig::warpSize;
     unsigned numBlocks        = (grp.numGroups + numWarpsPerBlock - 1) / numWarpsPerBlock;
 
+    bool fbcX   = (box.boundaryX() == cstone::BoundaryType::fixed);
+    bool fbcY   = (box.boundaryY() == cstone::BoundaryType::fixed);
+    bool fbcZ   = (box.boundaryZ() == cstone::BoundaryType::fixed);
+    bool anyFBC = fbcX || fbcY || fbcZ;
+
     if (numBlocks == 0) { return; }
     computePositionsKernel<<<numBlocks, numThreads>>>(grp, dt, dt_m1, x, y, z, vx, vy, vz, x_m1, y_m1, z_m1, ax, ay, az,
-                                                      rung, temp, u, du, du_m1, h, mui, gamma, constCv, box);
+                                                      rung, temp, u, du, du_m1, h, mui, gamma, constCv, box, anyFBC);
 }
 
 #define POS_GPU(Tc, Tv, Ta, Tdu, Tm1, Tt, Thydro)                                                                      \

--- a/sph/test/positions.cpp
+++ b/sph/test/positions.cpp
@@ -28,19 +28,19 @@ TEST(Integrator, timeReversal)
     const Vec3<T> Xn{1, 1, 1}, dXn{0.1, 0.1, 0.1}, An{2, 2, 2};
 
     Vec3<T> Xnp1, Vnp1, dXnp1;
-    std::tie(Xnp1, Vnp1, dXnp1) = positionUpdate(dtn, dtnm1, Xn, An, dXn, box, false, T(0));
+    std::tie(Xnp1, Vnp1, dXnp1) = positionUpdate(dtn, dtnm1, Xn, An, dXn, box);
 
     // advance to an intermediate time
     Vec3<T> Xtmp, Vtmp;
-    std::tie(Xtmp, Vtmp, std::ignore) = positionUpdate(0.5 * dtn, dtnm1, Xn, An, dXn, box, false, T(0));
+    std::tie(Xtmp, Vtmp, std::ignore) = positionUpdate(0.5 * dtn, dtnm1, Xn, An, dXn, box);
 
     // undo last advance to an intermediate time
     Vec3<T> Xn_re;
-    std::tie(Xn_re, std::ignore, std::ignore) = positionUpdate(-0.5 * dtn, dtnm1, Xtmp, An, dXn, box, false, T(0));
+    std::tie(Xn_re, std::ignore, std::ignore) = positionUpdate(-0.5 * dtn, dtnm1, Xtmp, An, dXn, box);
 
     // advance to final time
     Vec3<T> Xnp1_ts, Vnp1_ts, dXnp1_ts;
-    std::tie(Xnp1_ts, Vnp1_ts, dXnp1_ts) = positionUpdate(dtn, dtnm1, Xn_re, An, dXn, box, false, T(0));
+    std::tie(Xnp1_ts, Vnp1_ts, dXnp1_ts) = positionUpdate(dtn, dtnm1, Xn_re, An, dXn, box);
 
     EXPECT_EQ(Xnp1, Xnp1_ts);
     EXPECT_EQ(Vnp1, Vnp1_ts);
@@ -53,13 +53,27 @@ TEST(Integrator, timeEnergyReversal)
 
     T               dtn = 0.1, dtnm1 = 0.2;
     T               dU = 2.0, dUm1 = 3.0;
-    cstone::Vec3<T> X{1, 1, 1};
-    cstone::Box<T>  box(0, 1);
-    bool            anyFBC = false;
 
-    auto Unp1 = energyUpdate(10.0, dtn, dtnm1, dU, dUm1, X, box, anyFBC, T(0));
+    auto Unp1 = energyUpdate(10.0, dtn, dtnm1, dU, dUm1);
     EXPECT_NEAR(Unp1, 10.175, 1e-7);
 
-    auto Un = energyUpdate(10.175, -dtn, dtnm1, dU, dUm1, X, box, anyFBC, T(0));
+    auto Un = energyUpdate(10.175, -dtn, dtnm1, dU, dUm1);
     EXPECT_NEAR(Un, 10.0, 1e-7);
+}
+
+TEST(Integrator, fixedBoundaryCorrection)
+{
+
+    using T = double;
+    Box<T> box(-1.,1., BoundaryType::fixed);
+
+    auto atBoundary = fbcAdjustFactor({1.,0.,0.},box,0.1, true);
+    EXPECT_NEAR(atBoundary, 0.0, 1e-5);
+
+    auto atMidPoint = fbcAdjustFactor({-0.7,0.,0.},box,0.1, true);
+    EXPECT_NEAR(atMidPoint, 0.5, 1e-7);
+
+    auto farAway = fbcAdjustFactor({0.0,0.5,0.},box,0.1, true);
+    EXPECT_NEAR(farAway, 1., 1e-7);
+
 }

--- a/sph/test/positions.cpp
+++ b/sph/test/positions.cpp
@@ -51,12 +51,15 @@ TEST(Integrator, timeEnergyReversal)
 {
     using T = float;
 
-    T dtn = 0.1, dtnm1 = 0.2;
-    T dU = 2.0, dUm1 = 3.0;
+    T               dtn = 0.1, dtnm1 = 0.2;
+    T               dU = 2.0, dUm1 = 3.0;
+    cstone::Vec3<T> X{1, 1, 1};
+    cstone::Box<T>  box(0, 1);
+    bool            anyFBC = false;
 
-    auto Unp1 = energyUpdate(10.0, dtn, dtnm1, dU, dUm1);
+    auto Unp1 = energyUpdate(10.0, dtn, dtnm1, dU, dUm1, X, box, anyFBC, T(0));
     EXPECT_NEAR(Unp1, 10.175, 1e-7);
 
-    auto Un = energyUpdate(10.175, -dtn, dtnm1, dU, dUm1);
+    auto Un = energyUpdate(10.175, -dtn, dtnm1, dU, dUm1, X, box, anyFBC, T(0));
     EXPECT_NEAR(Un, 10.0, 1e-7);
 }

--- a/sph/test/positions.cpp
+++ b/sph/test/positions.cpp
@@ -28,19 +28,19 @@ TEST(Integrator, timeReversal)
     const Vec3<T> Xn{1, 1, 1}, dXn{0.1, 0.1, 0.1}, An{2, 2, 2};
 
     Vec3<T> Xnp1, Vnp1, dXnp1;
-    std::tie(Xnp1, Vnp1, dXnp1) = positionUpdate(dtn, dtnm1, Xn, An, dXn, box);
+    std::tie(Xnp1, Vnp1, dXnp1) = positionUpdate(dtn, dtnm1, Xn, An, dXn, box, false, T(0));
 
     // advance to an intermediate time
     Vec3<T> Xtmp, Vtmp;
-    std::tie(Xtmp, Vtmp, std::ignore) = positionUpdate(0.5 * dtn, dtnm1, Xn, An, dXn, box);
+    std::tie(Xtmp, Vtmp, std::ignore) = positionUpdate(0.5 * dtn, dtnm1, Xn, An, dXn, box, false, T(0));
 
     // undo last advance to an intermediate time
     Vec3<T> Xn_re;
-    std::tie(Xn_re, std::ignore, std::ignore) = positionUpdate(-0.5 * dtn, dtnm1, Xtmp, An, dXn, box);
+    std::tie(Xn_re, std::ignore, std::ignore) = positionUpdate(-0.5 * dtn, dtnm1, Xtmp, An, dXn, box, false, T(0));
 
     // advance to final time
     Vec3<T> Xnp1_ts, Vnp1_ts, dXnp1_ts;
-    std::tie(Xnp1_ts, Vnp1_ts, dXnp1_ts) = positionUpdate(dtn, dtnm1, Xn_re, An, dXn, box);
+    std::tie(Xnp1_ts, Vnp1_ts, dXnp1_ts) = positionUpdate(dtn, dtnm1, Xn_re, An, dXn, box, false, T(0));
 
     EXPECT_EQ(Xnp1, Xnp1_ts);
     EXPECT_EQ(Vnp1, Vnp1_ts);

--- a/sph/test/positions.cpp
+++ b/sph/test/positions.cpp
@@ -67,12 +67,18 @@ TEST(Integrator, fixedBoundaryCorrection)
     using T = double;
     Box<T> box(-1., 1., BoundaryType::fixed);
 
-    auto atBoundary = fbcAdjustFactor({1., 0., 0.}, box, 0.1, true);
-    EXPECT_NEAR(atBoundary, 0.0, 1e-5);
+    auto atBoundary = fbcAdjustFactors({1., 0., 0.}, box, 0.1);
+    EXPECT_NEAR(atBoundary[0], 0.0, 1e-5);
+    EXPECT_NEAR(atBoundary[1], 1.0, 1e-7);
 
-    auto atMidPoint = fbcAdjustFactor({-0.7, 0., 0.}, box, 0.1, true);
-    EXPECT_NEAR(atMidPoint, 0.5, 1e-7);
+    auto atMidPoint = fbcAdjustFactors({-0.7, 0., 0.}, box, 0.1);
+    EXPECT_NEAR(atMidPoint[0], 0.5, 1e-7);
 
-    auto farAway = fbcAdjustFactor({0.0, 0.5, 0.}, box, 0.1, true);
-    EXPECT_NEAR(farAway, 1., 1e-7);
+    auto farAway = fbcAdjustFactors({0.0, 0.5, 0.}, box, 0.1);
+    EXPECT_NEAR(farAway[1], 1., 1e-7);
+
+    // Should not correct even though close to boundary, boundary is not fixed
+    Box<T> box2(-1., 1., BoundaryType::open);
+    auto   atBoundary2 = fbcAdjustFactors({1, 0., 0.}, box2, 0.1);
+    EXPECT_NEAR(atBoundary2[0], 1.0, 1e-7);
 }

--- a/sph/test/positions.cpp
+++ b/sph/test/positions.cpp
@@ -51,8 +51,8 @@ TEST(Integrator, timeEnergyReversal)
 {
     using T = float;
 
-    T               dtn = 0.1, dtnm1 = 0.2;
-    T               dU = 2.0, dUm1 = 3.0;
+    T dtn = 0.1, dtnm1 = 0.2;
+    T dU = 2.0, dUm1 = 3.0;
 
     auto Unp1 = energyUpdate(10.0, dtn, dtnm1, dU, dUm1);
     EXPECT_NEAR(Unp1, 10.175, 1e-7);
@@ -65,15 +65,14 @@ TEST(Integrator, fixedBoundaryCorrection)
 {
 
     using T = double;
-    Box<T> box(-1.,1., BoundaryType::fixed);
+    Box<T> box(-1., 1., BoundaryType::fixed);
 
-    auto atBoundary = fbcAdjustFactor({1.,0.,0.},box,0.1, true);
+    auto atBoundary = fbcAdjustFactor({1., 0., 0.}, box, 0.1, true);
     EXPECT_NEAR(atBoundary, 0.0, 1e-5);
 
-    auto atMidPoint = fbcAdjustFactor({-0.7,0.,0.},box,0.1, true);
+    auto atMidPoint = fbcAdjustFactor({-0.7, 0., 0.}, box, 0.1, true);
     EXPECT_NEAR(atMidPoint, 0.5, 1e-7);
 
-    auto farAway = fbcAdjustFactor({0.0,0.5,0.},box,0.1, true);
+    auto farAway = fbcAdjustFactor({0.0, 0.5, 0.}, box, 0.1, true);
     EXPECT_NEAR(farAway, 1., 1e-7);
-
 }


### PR DESCRIPTION
Adds fixed boundary conditions for the rim of cuboid boxes. A sigmoid function is used to remove acceleration of particles within `8*h` of the boundary.

Is a prerequisite of the Rayleigh-Taylor, Sod shock and Triple-Point shock test cases. 