### PR TITLE
Id tagging and finding basic functionalities 

### DIFF
--- a/main/src/io/CMakeLists.txt
+++ b/main/src/io/CMakeLists.txt
@@ -14,7 +14,14 @@ function(enableH5hut exename)
     endif()
 endfunction()
 
-add_library(io ifile_io_ascii.cpp ifile_io_hdf5.cpp arg_parser.cpp)
-target_include_directories(io PRIVATE ${CSTONE_DIR} ${MPI_CXX_INCLUDE_PATH})
+add_library(io id_tag_utils.cpp ifile_io_ascii.cpp ifile_io_hdf5.cpp arg_parser.cpp)
+target_include_directories(io PRIVATE ${CSTONE_DIR} ${SPH_EXA_INCLUDE_DIRS} ${MPI_CXX_INCLUDE_PATH})
 target_link_libraries(io PRIVATE ${MPI_CXX_LIBRARIES})
+
+if (CMAKE_CUDA_COMPILER OR CMAKE_HIP_COMPILER)
+    add_library(io_gpu OBJECT id_tag_utils.cu)
+    target_include_directories(io_gpu PRIVATE ${SPH_EXA_INCLUDE_DIRS})
+    target_link_libraries(io_gpu PRIVATE CUDA::cudart)
+endif()
+
 enableH5hut(io)

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -40,24 +40,19 @@
 namespace sphexa
 {
 
-void applyTaggingMask(IdType groupId, IdType& id)
+void applyTaggingMask(uint64_t groupId, uint64_t& id)
 {
-    if (groupId >= supGroupId)
-        throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(supGroupId) + ")\n");
+    if (groupId >= maxNumGroupIds)
+        throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(maxNumGroupIds) + ")\n");
 
-    // Clear previous tagging if present
-    if(IsMasked{}(id)) {
-        id &= ~taggingCheckMask;
-        std::cout << "Warning: applying tagging mask to already tagged id " << id << "\n";
-    }
+    // Clear previous tagging bits if any
+    id &= ~taggingCheckMask;
 
-    // Apply new tagging information
     id |= ((groupId+1) << taggingMaskStartingBit);
 }
 
-template<class IdTypeP>
-void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<const IdTypeP> selectedIds,
-    const LocalIndex groupId)
+void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<const uint64_t> selectedIds,
+    const uint32_t groupId)
 {
     const auto idListBeginIt = ids.begin()+first;
     const auto idListEndIt = ids.begin()+last;
@@ -70,14 +65,10 @@ void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<c
         }
     });
 }
-template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, size_t last, std::span<const IdType> selectedIds,
-    const LocalIndex groupId);
 
-
-template<class IdTypeP>
-void tagIdsInSphere(std::span<IdTypeP> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
+void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
     std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
-    const LocalIndex groupId)
+    const uint32_t groupId)
 {
     const auto squareRadius = selSphereData[3]*selSphereData[3];
     const auto sphereCenter = util::makeVec3(selSphereData);
@@ -90,13 +81,9 @@ void tagIdsInSphere(std::span<IdTypeP> ids, std::span<const CoordinateType> x, s
         }
     }
 }
-template void tagIdsInSphere<IdType>(std::span<IdType> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
-    const LocalIndex groupId);
 
-
-template<class IdTypeP, class LocalIndexP>
-void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
+template<class LocalIndexP>
+void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
 {
     const auto numIds = last - first;
     std::vector<uint8_t> flags(numIds, 0);
@@ -108,7 +95,7 @@ void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std:
         flags[index] = IsMasked{}(ids[index + first]);
     }
 
-    std::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), LocalIndex(0));
+    std::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), uint32_t(0));
     taggedIdsIndexes.resize(flagsScan.back() + flags.back());
 
 #pragma omp parallel for
@@ -118,6 +105,6 @@ void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std:
     }
 }
 
-template void findTaggedIds<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
+template void findTaggedIds<uint32_t>(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<uint32_t>& taggedIdsIndexes);
 
 }

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -54,14 +54,14 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id)
     return taggedId;
 }
 
-void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
+void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                   std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups)
 {
     if (selectedIds.size() != selectedIdsGroups.size())
         throw std::runtime_error("Number of selected ids and number of group ids must be the same\n");
 
 #pragma omp parallel for schedule(static)
-    for (auto i = first; i < last; i++)
+    for (auto i = firstIndex; i < lastIndex; i++)
     {
         // Since ids may be already tagged we need to unmask them in the search
         // Warning: race conditions can be generated here if selectedIds contains duplicates
@@ -75,7 +75,7 @@ void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
 }
 
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-                    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex,
+                    std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
                     std::span<const IdSelectionSphere> selSphereData, std::span<const unsigned> sphereGroupIds)
 {
 
@@ -101,17 +101,17 @@ void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, 
 }
 
 template<class LocalIndexP>
-void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
+void findTaggedIds(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                    std::vector<LocalIndexP>& taggedIdsIndexes)
 {
-    const auto               numIds = last - first;
+    const auto               numIds = lastIndex - firstIndex;
     std::vector<uint8_t>     flags(numIds, 0);
     std::vector<LocalIndexP> flagsScan(numIds);
 
 #pragma omp parallel for schedule(static)
     for (LocalIndexP index = 0; index < numIds; ++index)
     {
-        flags[index] = IsMasked{}(ids[index + first]);
+        flags[index] = IsMasked{}(ids[index + firstIndex]);
     }
 
     std::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), uint32_t(0));
@@ -120,13 +120,13 @@ void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
 #pragma omp parallel for
     for (LocalIndexP i = 0; i < numIds; i++)
     {
-        if (flags[i]) { taggedIdsIndexes[flagsScan[i]] = i + first; }
+        if (flags[i]) { taggedIdsIndexes[flagsScan[i]] = i + firstIndex; }
     }
 }
 
-template void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
+template void findTaggedIds(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                             std::vector<uint32_t>& taggedIdsIndexes);
-template void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
+template void findTaggedIds(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                             std::vector<uint64_t>& taggedIdsIndexes);
 
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -40,15 +40,17 @@
 namespace sphexa
 {
 
-void applyTaggingMask(uint64_t groupId, uint64_t& id)
+uint64_t applyTaggingMask(uint64_t groupId, uint64_t id)
 {
     if (groupId >= maxNumGroupIds)
         throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(maxNumGroupIds) + ")\n");
 
     // Clear previous tagging bits if any
-    id &= ~taggingCheckMask;
+    uint64_t taggedId = id & ~taggingCheckMask;
 
-    id |= ((groupId+1) << taggingMaskStartingBit);
+    taggedId |= ((groupId+1) << taggingMaskStartingBit);
+
+    return taggedId;
 }
 
 void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<const IdSelectionList> selectedIdsLists)
@@ -64,7 +66,7 @@ void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<
             auto lower = std::lower_bound(idListBeginIt+lastFound, idListEndIt, selectedIds);
             if(lower != idListEndIt && *lower == selectedIds) {
                 lastFound = lower - idListBeginIt + 1;
-                applyTaggingMask(groupId, *lower);
+                *lower = applyTaggingMask(groupId, *lower);
             }
         });
         groupId++;
@@ -83,7 +85,7 @@ void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, 
             cstone::Vec3<CoordinateType> currentPosition{x[particleIndex], y[particleIndex], z[particleIndex]};
             auto squaredDistance = util::norm2(currentPosition - sphereCenter);
             if(squaredDistance < squareRadius) {
-                applyTaggingMask(groupId, ids[particleIndex]);
+                ids[particleIndex] = applyTaggingMask(groupId, ids[particleIndex]);
             }
         }
         groupId++;

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -64,7 +64,6 @@ void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t l
     for (auto i = firstIndex; i < lastIndex; i++)
     {
         // Since ids may be already tagged we need to unmask them in the search
-        // Warning: race conditions can be generated here if selectedIds contains duplicates
         auto it = std::find(selectedIds.begin(), selectedIds.end(), ids[i] & ~taggingCheckMask);
         if (it != selectedIds.end())
         {

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -33,7 +33,6 @@
 #include <omp.h>
 
 #include <algorithm>
-//#include <execution>
 #include <iostream>
 
 #include "id_tag_utils.hpp"
@@ -95,7 +94,6 @@ template void tagIdsInSphere<IdType>(std::span<IdType> ids, std::span<const Coor
     std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
     const LocalIndex groupId);
 
-#if 1
 
 template<class IdTypeP, class LocalIndexP>
 void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
@@ -119,32 +117,6 @@ void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std:
         if (flags[i]) { taggedIdsIndexes[flagsScan[i]] = i + first; }
     }
 }
-
-#else
-
-template<class IdTypeP, class LocalIndexP>
-void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
-{
-    const auto hostIdSize = last - first;
-    taggedIdsIndexes.clear();
-    taggedIdsIndexes.reserve(hostIdSize);
-
-    #pragma omp parallel
-    {
-        std::vector<LocalIndexP> tmpTaggedIdsIndexes;
-//        tmpTaggedIdsIndexes.reserve(hostIdSize); // TODO: without a better estimate of the size, this is not efficient
-        #pragma omp for nowait
-        for (LocalIndexP index = first; index<last; ++index)
-        {
-            if (IsMasked{}(ids[index]))
-                tmpTaggedIdsIndexes.push_back(index);
-        }
-        #pragma omp critical
-        taggedIdsIndexes.insert(taggedIdsIndexes.end(), tmpTaggedIdsIndexes.begin(), tmpTaggedIdsIndexes.end());
-    }
-    std::sort(taggedIdsIndexes.begin(), taggedIdsIndexes.end());
-}
-#endif
 
 template void findTaggedIds<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
 

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -69,7 +69,7 @@ void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t l
         if (it != selectedIds.end())
         {
             auto index = it - selectedIds.begin();
-            ids[i]    = applyTaggingMask(selectedIdsGroups[index], ids[i]);
+            ids[i]     = applyTaggingMask(selectedIdsGroups[index], ids[i]);
         }
     }
 }
@@ -80,14 +80,14 @@ void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, 
 {
 
     if (selSphereData.size() != sphereGroupIds.size())
-        throw std::runtime_error("Number of spherical volumes and number of group ids must be the same\n");\
+        throw std::runtime_error("Number of spherical volumes and number of group ids must be the same\n");
 
     uint64_t groupIndex = 0;
     for (const auto& sphere : selSphereData)
     {
-        const auto squareRadius = sphere[3] * sphere[3];
-        const auto sphereCenter = util::makeVec3(sphere);
-        const unsigned groupId = sphereGroupIds[groupIndex];
+        const auto     squareRadius = sphere[3] * sphere[3];
+        const auto     sphereCenter = util::makeVec3(sphere);
+        const unsigned groupId      = sphereGroupIds[groupIndex];
 #pragma omp parallel for schedule(static)
         for (auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++)
         {
@@ -97,7 +97,6 @@ void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, 
         }
         groupIndex++;
     }
-
 }
 
 template<class LocalIndexP>

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -54,7 +54,8 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id)
     return taggedId;
 }
 
-void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<const IdSelectionList> selectedIdsLists)
+void tagIdsInList(std::span<uint64_t> ids, std::size_t first, std::size_t last,
+                  std::span<const IdSelectionList> selectedIdsLists)
 {
     const auto idListBeginIt = ids.begin() + first;
     const auto idListEndIt   = ids.begin() + last;
@@ -80,7 +81,7 @@ void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<
 }
 
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-                    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex,
+                    std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
                     std::span<const IdSelectionSphere> selSphereData)
 {
     uint64_t groupId = 0; // TODO: how do we decide the starting groupId?
@@ -100,7 +101,8 @@ void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, 
 }
 
 template<class LocalIndexP>
-void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
+void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+                   std::vector<LocalIndexP>& taggedIdsIndexes)
 {
     const auto               numIds = last - first;
     std::vector<uint8_t>     flags(numIds, 0);
@@ -122,7 +124,9 @@ void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last, std
     }
 }
 
-template void findTaggedIds<uint32_t>(std::span<const uint64_t> ids, size_t first, size_t last,
-                                      std::vector<uint32_t>& taggedIdsIndexes);
+template void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+                            std::vector<uint32_t>& taggedIdsIndexes);
+template void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+                            std::vector<uint64_t>& taggedIdsIndexes);
 
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -33,74 +33,70 @@
 #include <omp.h>
 
 #include <algorithm>
-#include <execution>
+//#include <execution>
+#include <iostream>
 
 #include "id_tag_utils.hpp"
 
 namespace sphexa
 {
 
-/*! @brief Id tagging (in first:last range) from list, CPU version
- *
- * @param[out] ids          ordered id list
- * @param[in]  first        first id index // TODO number of elements and pass iterator?
- * @param[in]  last         last (excluded) id index
- * @param[in]  selectedIds  indexes to be tagged
- */
+void applyTaggingMask(IdType groupId, IdType& id)
+{
+    if (groupId >= supGroupId)
+        throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(supGroupId) + ")\n");
+
+    // Clear previous tagging if present
+    if(IsMasked{}(id)) {
+        id &= ~taggingCheckMask;
+        std::cout << "Warning: applying tagging mask to already tagged id " << id << "\n";
+    }
+
+    // Apply new tagging information
+    id |= ((groupId+1) << taggingMaskStartingBit);
+}
+
 template<class IdTypeP>
-void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<const IdTypeP> selectedIds)
+void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<const IdTypeP> selectedIds,
+    const LocalIndex groupId)
 {
     const auto idListBeginIt = ids.begin()+first;
     const auto idListEndIt = ids.begin()+last;
     auto lastFound = 0;
-    std::for_each(selectedIds.begin(), selectedIds.end(), [idListBeginIt, idListEndIt, &lastFound](auto selectedIds){
+    std::for_each(selectedIds.begin(), selectedIds.end(), [idListBeginIt, idListEndIt, &lastFound, groupId](auto selectedIds){
         auto lower = std::lower_bound(idListBeginIt+lastFound, idListEndIt, selectedIds);
         if(lower != idListEndIt && *lower == selectedIds) {
             lastFound = lower - idListBeginIt + 1;
-            *lower = *lower | msbMask;
+            applyTaggingMask(groupId, *lower);
         }
     });
 }
-template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, size_t last, std::span<const IdType> selectedIds);
+template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, size_t last, std::span<const IdType> selectedIds,
+    const LocalIndex groupId);
 
 
-// TODO: should we save here the list of tagged ids without tag?
-/*! @brief Id tagging (in first:last range) in spherical volume, CPU version
- *
- * @param[out] ids                ordered id list
- * @param[in]  x                  x coordinates
- * @param[in]  y                  y coordinates
- * @param[in]  z                  z coordinates
- * @param[in]  first              first id index // TODO number of elements and pass iterator?
- * @param[in]  last               last (excluded) id index
- * @param[in]  selSphereData      spherical volume definition
- */
 template<class IdTypeP>
 void tagIdsInSphere(std::span<IdTypeP> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, const IdSelectionSphere& selSphereData)
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
+    const LocalIndex groupId)
 {
-    const auto squareRadius = selSphereData.radius*selSphereData.radius;
+    const auto squareRadius = selSphereData[3]*selSphereData[3];
+    const auto sphereCenter = util::makeVec3(selSphereData);
 #pragma omp parallel for schedule(static)
     for(auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++){
         cstone::Vec3<CoordinateType> currentPosition{x[particleIndex], y[particleIndex], z[particleIndex]};
-        auto squaredDistance = util::norm2(currentPosition - selSphereData.center);
+        auto squaredDistance = util::norm2(currentPosition - sphereCenter);
         if(squaredDistance < squareRadius) {
-            ids[particleIndex] = ids[particleIndex] | msbMask;
+            applyTaggingMask(groupId, ids[particleIndex]);
         }
     }
 }
 template void tagIdsInSphere<IdType>(std::span<IdType> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, const IdSelectionSphere& selSphereData);
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
+    const LocalIndex groupId);
 
 #if 1
 
-/*! @brief Tagged id identification
- *
- * @param[in]  ids              ordered id list
- * @param[in]  first            first id index // TODO number of elements and pass iterator?
- * @param[in]  last             last (excluded) id index
- * @param[out] taggedIdsIndexes vector of indexes (positions wrt of provided ids list)
- */
 template<class IdTypeP, class LocalIndexP>
 void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
 {
@@ -125,13 +121,7 @@ void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std:
 }
 
 #else
-/*! @brief Tagged id identification
- *
- * @param[in]  ids              ordered id list
- * @param[in]  first            first id index // TODO number of elements and pass iterator?
- * @param[in]  last             last (excluded) id index
- * @param[out] taggedIdsIndexes vector of indexes (positions wrt of provided ids list)
- */
+
 template<class IdTypeP, class LocalIndexP>
 void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
 {

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
- /*! @file
+/*! @file
  * @brief  CPU/GPU Particle ID tag utilities, CPU implementations
  *
  * @author Christopher Bignamini <christopher.bignamini@gmail.com>
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <numeric>
 
 #include "id_tag_utils.hpp"
 
@@ -48,45 +49,51 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id)
     // Clear previous tagging bits if any
     uint64_t taggedId = id & ~taggingCheckMask;
 
-    taggedId |= ((groupId+1) << taggingMaskStartingBit);
+    taggedId |= ((groupId + 1) << taggingMaskStartingBit);
 
     return taggedId;
 }
 
 void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<const IdSelectionList> selectedIdsLists)
 {
-    const auto idListBeginIt = ids.begin()+first;
-    const auto idListEndIt = ids.begin()+last;
-    uint64_t groupId = 0; // TODO: how do we decide the starting groupId?
-    for(const auto& idsList : selectedIdsLists) {
+    const auto idListBeginIt = ids.begin() + first;
+    const auto idListEndIt   = ids.begin() + last;
+    uint64_t   groupId       = 0; // TODO: how do we decide the starting groupId?
+    for (const auto& idsList : selectedIdsLists)
+    {
         if (groupId >= maxNumGroupIds)
-            throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(maxNumGroupIds) + ")\n");
+            throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(maxNumGroupIds) +
+                                     ")\n");
         auto lastFound = 0;
-        std::for_each(idsList.begin(), idsList.end(), [idListBeginIt, idListEndIt, &lastFound, groupId](auto selectedIds){
-            auto lower = std::lower_bound(idListBeginIt+lastFound, idListEndIt, selectedIds);
-            if(lower != idListEndIt && *lower == selectedIds) {
-                lastFound = lower - idListBeginIt + 1;
-                *lower = applyTaggingMask(groupId, *lower);
-            }
-        });
+        std::for_each(idsList.begin(), idsList.end(),
+                      [idListBeginIt, idListEndIt, &lastFound, groupId](auto selectedIds)
+                      {
+                          auto lower = std::lower_bound(idListBeginIt + lastFound, idListEndIt, selectedIds);
+                          if (lower != idListEndIt && *lower == selectedIds)
+                          {
+                              lastFound = lower - idListBeginIt + 1;
+                              *lower    = applyTaggingMask(groupId, *lower);
+                          }
+                      });
         groupId++;
     }
 }
 
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, std::span<const IdSelectionSphere> selSphereData)
+                    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex,
+                    std::span<const IdSelectionSphere> selSphereData)
 {
     uint64_t groupId = 0; // TODO: how do we decide the starting groupId?
-    for(const auto& sphere : selSphereData) {
-        const auto squareRadius = sphere[3]*sphere[3];
+    for (const auto& sphere : selSphereData)
+    {
+        const auto squareRadius = sphere[3] * sphere[3];
         const auto sphereCenter = util::makeVec3(sphere);
 #pragma omp parallel for schedule(static)
-        for(auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++){
+        for (auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++)
+        {
             cstone::Vec3<CoordinateType> currentPosition{x[particleIndex], y[particleIndex], z[particleIndex]};
-            auto squaredDistance = util::norm2(currentPosition - sphereCenter);
-            if(squaredDistance < squareRadius) {
-                ids[particleIndex] = applyTaggingMask(groupId, ids[particleIndex]);
-            }
+            auto                         squaredDistance = util::norm2(currentPosition - sphereCenter);
+            if (squaredDistance < squareRadius) { ids[particleIndex] = applyTaggingMask(groupId, ids[particleIndex]); }
         }
         groupId++;
     }
@@ -95,8 +102,8 @@ void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, 
 template<class LocalIndexP>
 void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
 {
-    const auto numIds = last - first;
-    std::vector<uint8_t> flags(numIds, 0);
+    const auto               numIds = last - first;
+    std::vector<uint8_t>     flags(numIds, 0);
     std::vector<LocalIndexP> flagsScan(numIds);
 
 #pragma omp parallel for schedule(static)
@@ -115,6 +122,7 @@ void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last, std
     }
 }
 
-template void findTaggedIds<uint32_t>(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<uint32_t>& taggedIdsIndexes);
+template void findTaggedIds<uint32_t>(std::span<const uint64_t> ids, size_t first, size_t last,
+                                      std::vector<uint32_t>& taggedIdsIndexes);
 
-}
+} // namespace sphexa

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -1,0 +1,161 @@
+/*
+ * MIT License
+ *
+ * SPH-EXA
+ * Copyright (c) 2024 CSCS, ETH Zurich, University of Basel, University of Zurich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+ /*! @file
+ * @brief  CPU/GPU Particle ID tag utilities, CPU implementations
+ *
+ * @author Christopher Bignamini <christopher.bignamini@gmail.com>
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#include <omp.h>
+
+#include <algorithm>
+#include <execution>
+
+#include "id_tag_utils.hpp"
+
+namespace sphexa
+{
+
+/*! @brief Id tagging (in first:last range) from list, CPU version
+ *
+ * @param[out] ids          ordered id list
+ * @param[in]  first        first id index // TODO number of elements and pass iterator?
+ * @param[in]  last         last (excluded) id index
+ * @param[in]  selectedIds  indexes to be tagged
+ */
+template<class IdTypeP>
+void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<const IdTypeP> selectedIds)
+{
+    const auto idListBeginIt = ids.begin()+first;
+    const auto idListEndIt = ids.begin()+last;
+    auto lastFound = 0;
+    std::for_each(selectedIds.begin(), selectedIds.end(), [idListBeginIt, idListEndIt, &lastFound](auto selectedIds){
+        auto lower = std::lower_bound(idListBeginIt+lastFound, idListEndIt, selectedIds);
+        if(lower != idListEndIt && *lower == selectedIds) {
+            lastFound = lower - idListBeginIt + 1;
+            *lower = *lower | msbMask;
+        }
+    });
+}
+template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, size_t last, std::span<const IdType> selectedIds);
+
+
+// TODO: should we save here the list of tagged ids without tag?
+/*! @brief Id tagging (in first:last range) in spherical volume, CPU version
+ *
+ * @param[out] ids                ordered id list
+ * @param[in]  x                  x coordinates
+ * @param[in]  y                  y coordinates
+ * @param[in]  z                  z coordinates
+ * @param[in]  first              first id index // TODO number of elements and pass iterator?
+ * @param[in]  last               last (excluded) id index
+ * @param[in]  selSphereData      spherical volume definition
+ */
+template<class IdTypeP>
+void tagIdsInSphere(std::span<IdTypeP> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, const IdSelectionSphere& selSphereData)
+{
+    const auto squareRadius = selSphereData.radius*selSphereData.radius;
+#pragma omp parallel for schedule(static)
+    for(auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++){
+        cstone::Vec3<CoordinateType> currentPosition{x[particleIndex], y[particleIndex], z[particleIndex]};
+        auto squaredDistance = util::norm2(currentPosition - selSphereData.center);
+        if(squaredDistance < squareRadius) {
+            ids[particleIndex] = ids[particleIndex] | msbMask;
+        }
+    }
+}
+template void tagIdsInSphere<IdType>(std::span<IdType> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, const IdSelectionSphere& selSphereData);
+
+#if 1
+
+/*! @brief Tagged id identification
+ *
+ * @param[in]  ids              ordered id list
+ * @param[in]  first            first id index // TODO number of elements and pass iterator?
+ * @param[in]  last             last (excluded) id index
+ * @param[out] taggedIdsIndexes vector of indexes (positions wrt of provided ids list)
+ */
+template<class IdTypeP, class LocalIndexP>
+void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
+{
+    const auto numIds = last - first;
+    std::vector<uint8_t> flags(numIds, 0);
+    std::vector<LocalIndexP> flagsScan(numIds);
+
+#pragma omp parallel for schedule(static)
+    for (LocalIndexP index = 0; index < numIds; ++index)
+    {
+        flags[index] = IsMasked{}(ids[index + first]);
+    }
+
+    std::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), LocalIndex(0));
+    taggedIdsIndexes.resize(flagsScan.back() + flags.back());
+
+#pragma omp parallel for
+    for (LocalIndexP i = 0; i < numIds; i++)
+    {
+        if (flags[i]) { taggedIdsIndexes[flagsScan[i]] = i + first; }
+    }
+}
+
+#else
+/*! @brief Tagged id identification
+ *
+ * @param[in]  ids              ordered id list
+ * @param[in]  first            first id index // TODO number of elements and pass iterator?
+ * @param[in]  last             last (excluded) id index
+ * @param[out] taggedIdsIndexes vector of indexes (positions wrt of provided ids list)
+ */
+template<class IdTypeP, class LocalIndexP>
+void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
+{
+    const auto hostIdSize = last - first;
+    taggedIdsIndexes.clear();
+    taggedIdsIndexes.reserve(hostIdSize);
+
+    #pragma omp parallel
+    {
+        std::vector<LocalIndexP> tmpTaggedIdsIndexes;
+//        tmpTaggedIdsIndexes.reserve(hostIdSize); // TODO: without a better estimate of the size, this is not efficient
+        #pragma omp for nowait
+        for (LocalIndexP index = first; index<last; ++index)
+        {
+            if (IsMasked{}(ids[index]))
+                tmpTaggedIdsIndexes.push_back(index);
+        }
+        #pragma omp critical
+        taggedIdsIndexes.insert(taggedIdsIndexes.end(), tmpTaggedIdsIndexes.begin(), tmpTaggedIdsIndexes.end());
+    }
+    std::sort(taggedIdsIndexes.begin(), taggedIdsIndexes.end());
+}
+#endif
+
+template void findTaggedIds<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
+
+}

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -51,34 +51,42 @@ void applyTaggingMask(uint64_t groupId, uint64_t& id)
     id |= ((groupId+1) << taggingMaskStartingBit);
 }
 
-void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<const uint64_t> selectedIds,
-    const uint32_t groupId)
+void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<const IdSelectionList> selectedIdsLists)
 {
     const auto idListBeginIt = ids.begin()+first;
     const auto idListEndIt = ids.begin()+last;
-    auto lastFound = 0;
-    std::for_each(selectedIds.begin(), selectedIds.end(), [idListBeginIt, idListEndIt, &lastFound, groupId](auto selectedIds){
-        auto lower = std::lower_bound(idListBeginIt+lastFound, idListEndIt, selectedIds);
-        if(lower != idListEndIt && *lower == selectedIds) {
-            lastFound = lower - idListBeginIt + 1;
-            applyTaggingMask(groupId, *lower);
-        }
-    });
+    uint64_t groupId = 0; // TODO: how do we decide the starting groupId?
+    for(const auto& idsList : selectedIdsLists) {
+        if (groupId >= maxNumGroupIds)
+            throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(maxNumGroupIds) + ")\n");
+        auto lastFound = 0;
+        std::for_each(idsList.begin(), idsList.end(), [idListBeginIt, idListEndIt, &lastFound, groupId](auto selectedIds){
+            auto lower = std::lower_bound(idListBeginIt+lastFound, idListEndIt, selectedIds);
+            if(lower != idListEndIt && *lower == selectedIds) {
+                lastFound = lower - idListBeginIt + 1;
+                applyTaggingMask(groupId, *lower);
+            }
+        });
+        groupId++;
+    }
 }
 
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
-    const uint32_t groupId)
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, std::span<const IdSelectionSphere> selSphereData)
 {
-    const auto squareRadius = selSphereData[3]*selSphereData[3];
-    const auto sphereCenter = util::makeVec3(selSphereData);
+    uint64_t groupId = 0; // TODO: how do we decide the starting groupId?
+    for(const auto& sphere : selSphereData) {
+        const auto squareRadius = sphere[3]*sphere[3];
+        const auto sphereCenter = util::makeVec3(sphere);
 #pragma omp parallel for schedule(static)
-    for(auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++){
-        cstone::Vec3<CoordinateType> currentPosition{x[particleIndex], y[particleIndex], z[particleIndex]};
-        auto squaredDistance = util::norm2(currentPosition - sphereCenter);
-        if(squaredDistance < squareRadius) {
-            applyTaggingMask(groupId, ids[particleIndex]);
+        for(auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++){
+            cstone::Vec3<CoordinateType> currentPosition{x[particleIndex], y[particleIndex], z[particleIndex]};
+            auto squaredDistance = util::norm2(currentPosition - sphereCenter);
+            if(squaredDistance < squareRadius) {
+                applyTaggingMask(groupId, ids[particleIndex]);
+            }
         }
+        groupId++;
     }
 }
 

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -75,26 +75,25 @@ void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t l
 
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
                     std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
-                    std::span<const IdSelectionSphere> selSphereData, std::span<const unsigned> sphereGroupIds)
+                    std::span<const IdSelectionSphere> selSpheres, std::span<const unsigned> sphereGroupIds)
 {
 
-    if (selSphereData.size() != sphereGroupIds.size())
+    if (selSpheres.size() != sphereGroupIds.size())
         throw std::runtime_error("Number of spherical volumes and number of group ids must be the same\n");
 
-    uint64_t groupIndex = 0;
-    for (const auto& sphere : selSphereData)
-    {
-        const auto     squareRadius = sphere[3] * sphere[3];
-        const auto     sphereCenter = util::makeVec3(sphere);
-        const unsigned groupId      = sphereGroupIds[groupIndex];
 #pragma omp parallel for schedule(static)
-        for (auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++)
+    for (auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++)
+    {
+        cstone::Vec3<CoordinateType> currentPosition{x[particleIndex], y[particleIndex], z[particleIndex]};
+        for (unsigned groupIndex = 0; groupIndex < selSpheres.size(); ++groupIndex)
         {
-            cstone::Vec3<CoordinateType> currentPosition{x[particleIndex], y[particleIndex], z[particleIndex]};
-            auto                         squaredDistance = util::norm2(currentPosition - sphereCenter);
+            const auto     sphere          = selSpheres[groupIndex];
+            const auto     squareRadius    = sphere[3] * sphere[3];
+            const auto     sphereCenter    = util::makeVec3(sphere);
+            const unsigned groupId         = sphereGroupIds[groupIndex];
+            auto           squaredDistance = util::norm2(currentPosition - sphereCenter);
             if (squaredDistance < squareRadius) { ids[particleIndex] = applyTaggingMask(groupId, ids[particleIndex]); }
         }
-        groupIndex++;
     }
 }
 

--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -54,41 +54,40 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id)
     return taggedId;
 }
 
-void tagIdsInList(std::span<uint64_t> ids, std::size_t first, std::size_t last,
-                  std::span<const IdSelectionList> selectedIdsLists)
+void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
+                  std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups)
 {
-    const auto idListBeginIt = ids.begin() + first;
-    const auto idListEndIt   = ids.begin() + last;
-    uint64_t   groupId       = 0; // TODO: how do we decide the starting groupId?
-    for (const auto& idsList : selectedIdsLists)
+    if (selectedIds.size() != selectedIdsGroups.size())
+        throw std::runtime_error("Number of selected ids and number of group ids must be the same\n");
+
+#pragma omp parallel for schedule(static)
+    for (auto i = first; i < last; i++)
     {
-        if (groupId >= maxNumGroupIds)
-            throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(maxNumGroupIds) +
-                                     ")\n");
-        auto lastFound = 0;
-        std::for_each(idsList.begin(), idsList.end(),
-                      [idListBeginIt, idListEndIt, &lastFound, groupId](auto selectedIds)
-                      {
-                          auto lower = std::lower_bound(idListBeginIt + lastFound, idListEndIt, selectedIds);
-                          if (lower != idListEndIt && *lower == selectedIds)
-                          {
-                              lastFound = lower - idListBeginIt + 1;
-                              *lower    = applyTaggingMask(groupId, *lower);
-                          }
-                      });
-        groupId++;
+        // Since ids may be already tagged we need to unmask them in the search
+        // Warning: race conditions can be generated here if selectedIds contains duplicates
+        auto it = std::find(selectedIds.begin(), selectedIds.end(), ids[i] & ~taggingCheckMask);
+        if (it != selectedIds.end())
+        {
+            auto index = it - selectedIds.begin();
+            ids[i]    = applyTaggingMask(selectedIdsGroups[index], ids[i]);
+        }
     }
 }
 
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-                    std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
-                    std::span<const IdSelectionSphere> selSphereData)
+                    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex,
+                    std::span<const IdSelectionSphere> selSphereData, std::span<const unsigned> sphereGroupIds)
 {
-    uint64_t groupId = 0; // TODO: how do we decide the starting groupId?
+
+    if (selSphereData.size() != sphereGroupIds.size())
+        throw std::runtime_error("Number of spherical volumes and number of group ids must be the same\n");\
+
+    uint64_t groupIndex = 0;
     for (const auto& sphere : selSphereData)
     {
         const auto squareRadius = sphere[3] * sphere[3];
         const auto sphereCenter = util::makeVec3(sphere);
+        const unsigned groupId = sphereGroupIds[groupIndex];
 #pragma omp parallel for schedule(static)
         for (auto particleIndex = firstIndex; particleIndex < lastIndex; particleIndex++)
         {
@@ -96,12 +95,13 @@ void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, 
             auto                         squaredDistance = util::norm2(currentPosition - sphereCenter);
             if (squaredDistance < squareRadius) { ids[particleIndex] = applyTaggingMask(groupId, ids[particleIndex]); }
         }
-        groupId++;
+        groupIndex++;
     }
+
 }
 
 template<class LocalIndexP>
-void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
                    std::vector<LocalIndexP>& taggedIdsIndexes)
 {
     const auto               numIds = last - first;
@@ -124,9 +124,9 @@ void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t
     }
 }
 
-template void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+template void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
                             std::vector<uint32_t>& taggedIdsIndexes);
-template void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+template void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
                             std::vector<uint64_t>& taggedIdsIndexes);
 
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -46,7 +46,7 @@ namespace sphexa
 {
 
 template<class LocalIndexP>
-void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
                       std::vector<LocalIndexP>& taggedIdsIndexes)
 {
 
@@ -57,7 +57,7 @@ void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
     thrust::transform(thrust::device, ids.data() + first, ids.data() + last, flags.begin(), isMasked);
 
     thrust::device_vector<LocalIndexP> flagsScan(numIds);
-    thrust::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), 0, thrust::plus<LocalIndexP>());
+    thrust::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), LocalIndexP(0), thrust::plus<LocalIndexP>());
     taggedIdsIndexes.resize(flagsScan.back() + flags.back());
 
     thrust::device_vector<LocalIndexP> taggedIdsIndexesDev(taggedIdsIndexes.size());
@@ -67,7 +67,9 @@ void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
     thrust::copy(taggedIdsIndexesDev.begin(), taggedIdsIndexesDev.end(), taggedIdsIndexes.begin());
 }
 
-template void findTaggedIdsGPU<uint32_t>(std::span<const uint64_t> ids, size_t first, size_t last,
-                                         std::vector<uint32_t>& taggedIdsIndexes);
+template void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+                               std::vector<uint32_t>& taggedIdsIndexes);
+template void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+                               std::vector<uint64_t>& taggedIdsIndexes);
 
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -40,14 +40,15 @@
 #include <thrust/scatter.h>
 #include <thrust/transform.h>
 
+#include "cstone/cuda/device_vector.h"
 #include "id_tag_utils.hpp"
 
 namespace sphexa
 {
 
-template<class LocalIndexP>
-void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
-                      cstone::DeviceVector<LocalIndexP>& taggedIdsIndexes)
+template<class LocalIndexP, template<class> class DeviceVector>
+extern void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
+                             DeviceVector<LocalIndexP>& taggedIdsIndexes)
 {
 
     const auto                     numIds = lastIndex - firstIndex;

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -46,28 +46,28 @@ namespace sphexa
 {
 
 template<class LocalIndexP>
-void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                       cstone::DeviceVector<LocalIndexP>& taggedIdsIndexes)
 {
 
-    const auto                     numIds = last - first;
+    const auto                     numIds = lastIndex - firstIndex;
     thrust::device_vector<uint8_t> flags(numIds, 0);
 
     IsMasked isMasked;
-    thrust::transform(thrust::device, ids.data() + first, ids.data() + last, flags.begin(), isMasked);
+    thrust::transform(thrust::device, ids.data() + firstIndex, ids.data() + lastIndex, flags.begin(), isMasked);
 
     thrust::device_vector<LocalIndexP> flagsScan(numIds);
     thrust::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), LocalIndexP(0), thrust::plus<LocalIndexP>());
     taggedIdsIndexes.resize(flagsScan.back() + flags.back());
 
-    thrust::scatter_if(thrust::device, thrust::make_counting_iterator(first),
-                       thrust::make_counting_iterator(first + numIds), flagsScan.begin(), flags.begin(),
+    thrust::scatter_if(thrust::device, thrust::make_counting_iterator(firstIndex),
+                       thrust::make_counting_iterator(firstIndex + numIds), flagsScan.begin(), flags.begin(),
                        taggedIdsIndexes.data());
 }
 
-template void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+template void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                                cstone::DeviceVector<uint32_t>& taggedIdsIndexes);
-template void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+template void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                                cstone::DeviceVector<uint64_t>& taggedIdsIndexes);
 
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -45,47 +45,6 @@
 namespace sphexa
 {
 
-// TODO: to be removed, used to select between two implementations
-#if 0
-
-struct IsMaskedGPU
-{
-    const IdType* ids_ptr;
-
-    IsMaskedGPU(const IdType* ids_ptr_) : ids_ptr(ids_ptr_) {}
-
-    HOST_DEVICE_FUN
-    uint8_t operator()(LocalIndex idx) const
-    {
-       return IsMasked{}(ids_ptr[idx]);
-    }
-};
-
-// TODO: this implementation is 3x faster than the one below
-template<class IdTypeP, class LocalIndexP>
-void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
-{
-
-    // Count number of tagged ids
-    IsMaskedGPU isMasked(ids.data());
-    auto begin = thrust::make_counting_iterator<IdType>(first);
-    auto end   = thrust::make_counting_iterator<IdType>(last);
-    const size_t nTaggedIds = thrust::count_if(thrust::device, begin, end, isMasked);
-
-    // Save indexes of tagged ids
-    thrust::device_vector<IdType> deviceTaggedIdsIndexes(nTaggedIds);
-    thrust::copy_if(thrust::device, begin, end, deviceTaggedIdsIndexes.begin(), isMasked);
-
-    // Copy indices of tagged ids to host vector
-    taggedIdsIndexes.resize(nTaggedIds);
-    thrust::copy(deviceTaggedIdsIndexes.begin(), deviceTaggedIdsIndexes.end(), taggedIdsIndexes.begin());
-
-    return;
-
-}
-
-#else
-
 template<class IdTypeP, class LocalIndexP>
 void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
 {
@@ -106,8 +65,6 @@ void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, s
     thrust::copy(taggedIdsIndexesDev.begin(), taggedIdsIndexesDev.end(), taggedIdsIndexes.begin());
 
 }
-
-#endif
 
 template void findTaggedIdsGPU<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
 

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -1,0 +1,128 @@
+/*
+ * MIT License
+ *
+ * SPH-EXA
+ * Copyright (c) 2024 CSCS, ETH Zurich, University of Basel, University of Zurich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+ /*! @file
+ * @brief  CPU/GPU Particle ID tag utilities, GPU implementation
+ *
+ * @author Christopher Bignamini <christopher.bignamini@gmail.com>
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/scan.h>
+#include <thrust/scatter.h>
+#include <thrust/transform.h>
+
+#include "id_tag_utils.hpp"
+
+namespace sphexa
+{
+
+// TODO: to be removed, used to select between two implementations
+#if 0
+
+struct IsMaskedGPU
+{
+    const IdType* ids_ptr;
+
+    IsMaskedGPU(const IdType* ids_ptr_) : ids_ptr(ids_ptr_) {}
+
+    HOST_DEVICE_FUN
+    uint8_t operator()(LocalIndex idx) const
+    {
+       return IsMasked{}(ids_ptr[idx]);
+    }
+};
+
+// TODO: this implementation is 3x faster than the one below
+/*! @brief Tagged id identification
+ *
+ * @param[in]  ids              ordered id list
+ * @param[in]  first            first id index // TODO number of elements and pass iterator?
+ * @param[in]  last             last (excluded) id index
+ * @param[out] taggedIdsIndexes vector of indexes (positions wrt of provided ids list)
+ */
+template<class IdTypeP, class LocalIndexP>
+void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
+{
+
+    // Count number of tagged ids
+    IsMaskedGPU isMasked(ids.data());
+    auto begin = thrust::make_counting_iterator<IdType>(first);
+    auto end   = thrust::make_counting_iterator<IdType>(last);
+    const size_t nTaggedIds = thrust::count_if(thrust::device, begin, end, isMasked);
+
+    // Save indexes of tagged ids
+    thrust::device_vector<IdType> deviceTaggedIdsIndexes(nTaggedIds);
+    thrust::copy_if(thrust::device, begin, end, deviceTaggedIdsIndexes.begin(), isMasked);
+
+    // Copy indices of tagged ids to host vector
+    taggedIdsIndexes.resize(nTaggedIds);
+    thrust::copy(deviceTaggedIdsIndexes.begin(), deviceTaggedIdsIndexes.end(), taggedIdsIndexes.begin());
+
+    return;
+
+}
+
+#else
+
+/*! @brief Tagged id identification
+ *
+ * @param[in]  ids              ordered id list
+ * @param[in]  first            first id index // TODO number of elements and pass iterator?
+ * @param[in]  last             last (excluded) id index
+ * @param[out] taggedIdsIndexes vector of indexes (positions wrt of provided ids list)
+ */
+template<class IdTypeP, class LocalIndexP>
+void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
+{
+
+    const auto numIds = last - first;
+    thrust::device_vector<uint8_t> flags(numIds, 0);
+
+    IsMasked isMasked;
+    thrust::transform(thrust::device, ids.data() + first, ids.data() + last, flags.begin(), isMasked);
+
+    thrust::device_vector<LocalIndexP> flagsScan(numIds);
+    thrust::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), 0, thrust::plus<LocalIndexP>());
+    taggedIdsIndexes.resize(flagsScan.back() + flags.back());
+
+    thrust::device_vector<LocalIndexP> taggedIdsIndexesDev(taggedIdsIndexes.size());
+    thrust::scatter_if(thrust::device, thrust::make_counting_iterator(first), thrust::make_counting_iterator(first + numIds),
+            flagsScan.begin(), flags.begin(), taggedIdsIndexesDev.begin());
+    thrust::copy(taggedIdsIndexesDev.begin(), taggedIdsIndexesDev.end(), taggedIdsIndexes.begin());
+
+}
+
+#endif
+
+template void findTaggedIdsGPU<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
+
+}

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -46,8 +46,8 @@ namespace sphexa
 {
 
 template<class LocalIndexP>
-void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
-                      std::vector<LocalIndexP>& taggedIdsIndexes)
+void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+                      cstone::DeviceVector<LocalIndexP>& taggedIdsIndexes)
 {
 
     const auto                     numIds = last - first;
@@ -60,16 +60,14 @@ void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::siz
     thrust::exclusive_scan(flags.begin(), flags.end(), flagsScan.begin(), LocalIndexP(0), thrust::plus<LocalIndexP>());
     taggedIdsIndexes.resize(flagsScan.back() + flags.back());
 
-    thrust::device_vector<LocalIndexP> taggedIdsIndexesDev(taggedIdsIndexes.size());
     thrust::scatter_if(thrust::device, thrust::make_counting_iterator(first),
                        thrust::make_counting_iterator(first + numIds), flagsScan.begin(), flags.begin(),
-                       taggedIdsIndexesDev.begin());
-    thrust::copy(taggedIdsIndexesDev.begin(), taggedIdsIndexesDev.end(), taggedIdsIndexes.begin());
+                       taggedIdsIndexes.data());
 }
 
-template void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
-                               std::vector<uint32_t>& taggedIdsIndexes);
-template void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
-                               std::vector<uint64_t>& taggedIdsIndexes);
+template void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+                               cstone::DeviceVector<uint32_t>& taggedIdsIndexes);
+template void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+                               cstone::DeviceVector<uint64_t>& taggedIdsIndexes);
 
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
- /*! @file
+/*! @file
  * @brief  CPU/GPU Particle ID tag utilities, GPU implementation
  *
  * @author Christopher Bignamini <christopher.bignamini@gmail.com>
@@ -46,10 +46,11 @@ namespace sphexa
 {
 
 template<class LocalIndexP>
-void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
+void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+                      std::vector<LocalIndexP>& taggedIdsIndexes)
 {
 
-    const auto numIds = last - first;
+    const auto                     numIds = last - first;
     thrust::device_vector<uint8_t> flags(numIds, 0);
 
     IsMasked isMasked;
@@ -60,12 +61,13 @@ void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last, 
     taggedIdsIndexes.resize(flagsScan.back() + flags.back());
 
     thrust::device_vector<LocalIndexP> taggedIdsIndexesDev(taggedIdsIndexes.size());
-    thrust::scatter_if(thrust::device, thrust::make_counting_iterator(first), thrust::make_counting_iterator(first + numIds),
-            flagsScan.begin(), flags.begin(), taggedIdsIndexesDev.begin());
+    thrust::scatter_if(thrust::device, thrust::make_counting_iterator(first),
+                       thrust::make_counting_iterator(first + numIds), flagsScan.begin(), flags.begin(),
+                       taggedIdsIndexesDev.begin());
     thrust::copy(taggedIdsIndexesDev.begin(), taggedIdsIndexesDev.end(), taggedIdsIndexes.begin());
-
 }
 
-template void findTaggedIdsGPU<uint32_t>(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<uint32_t>& taggedIdsIndexes);
+template void findTaggedIdsGPU<uint32_t>(std::span<const uint64_t> ids, size_t first, size_t last,
+                                         std::vector<uint32_t>& taggedIdsIndexes);
 
-}
+} // namespace sphexa

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -45,8 +45,8 @@
 namespace sphexa
 {
 
-template<class IdTypeP, class LocalIndexP>
-void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
+template<class LocalIndexP>
+void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
 {
 
     const auto numIds = last - first;
@@ -66,6 +66,6 @@ void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, s
 
 }
 
-template void findTaggedIdsGPU<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
+template void findTaggedIdsGPU<uint32_t>(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<uint32_t>& taggedIdsIndexes);
 
 }

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -62,13 +62,6 @@ struct IsMaskedGPU
 };
 
 // TODO: this implementation is 3x faster than the one below
-/*! @brief Tagged id identification
- *
- * @param[in]  ids              ordered id list
- * @param[in]  first            first id index // TODO number of elements and pass iterator?
- * @param[in]  last             last (excluded) id index
- * @param[out] taggedIdsIndexes vector of indexes (positions wrt of provided ids list)
- */
 template<class IdTypeP, class LocalIndexP>
 void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
 {
@@ -93,13 +86,6 @@ void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, s
 
 #else
 
-/*! @brief Tagged id identification
- *
- * @param[in]  ids              ordered id list
- * @param[in]  first            first id index // TODO number of elements and pass iterator?
- * @param[in]  last             last (excluded) id index
- * @param[out] taggedIdsIndexes vector of indexes (positions wrt of provided ids list)
- */
 template<class IdTypeP, class LocalIndexP>
 void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes)
 {

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -32,7 +32,6 @@
 
 #pragma once
 
-#include <numeric>
 #include <span>
 #include <vector>
 
@@ -48,26 +47,22 @@ using CoordinateType = sph::SphTypes::CoordinateType;
  */
 constexpr uint64_t tagNumBits = 10;
 
-/*! @brief Given tagNumBits, the maximum number of groups we can address is 2^tagNumBits - 1. 
+/*! @brief Given tagNumBits, the maximum number of groups we can address is 2^tagNumBits - 1.
  * We subtract one, because groupId=0 corresponds to an unmasked particle ID
  */
 constexpr uint64_t maxNumGroupIds = (1 << tagNumBits) - 1;
 
 /*! @brief First tagging bit position
  */
-constexpr uint64_t taggingMaskStartingBit = sizeof(uint64_t)*8 - tagNumBits;
+constexpr uint64_t taggingMaskStartingBit = sizeof(uint64_t) * 8 - tagNumBits;
 
 constexpr uint64_t taggingCheckMask = maxNumGroupIds << taggingMaskStartingBit;
-
 
 /*! @brief Tagged id identification condition functor
  */
 struct IsMasked
 {
-    HOST_DEVICE_FUN uint8_t operator()(uint64_t id) const
-    {
-        return (id & taggingCheckMask) != 0;
-    }
+    HOST_DEVICE_FUN uint8_t operator()(uint64_t id) const { return (id & taggingCheckMask) != 0; }
 };
 
 /*! @brief Application of tagging mask to a given id
@@ -86,7 +81,8 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id);
  * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
  */
 template<class LocalIndexP>
-extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
+extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
+                          std::vector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Tagged id (in first:last range) identification, GPU version
  *
@@ -96,7 +92,8 @@ extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t la
  * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
  */
 template<class LocalIndexP>
-extern void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
+extern void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+                             std::vector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Id tagging spherical volume definition
  * (center[0:2], radius)
@@ -112,7 +109,8 @@ using IdSelectionList = std::vector<uint64_t>;
  * @param[in]  last              last (excluded) id index
  * @param[in]  selectedIdsLists  lists of indexes to be tagged
  */
-void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<const IdSelectionList> selectedIdsLists);
+void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
+                  std::span<const IdSelectionList> selectedIdsLists);
 
 /*! @brief Id tagging (in first:last range) in spherical volume, CPU version
  *
@@ -125,5 +123,6 @@ void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<
  * @param[in]  selSphereData     set of spherical volume definitions
  */
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, std::span<const IdSelectionSphere> selSphereData);
-}
+                    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex,
+                    std::span<const IdSelectionSphere> selSphereData);
+} // namespace sphexa

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -102,11 +102,11 @@ using IdSelectionSphere = cstone::Vec4<CoordinateType>;
 
 /*! @brief Id tagging (in first:last range) from list
  *
- * @param[out] ids               id list
- * @param[in]  firstIndex        first id index
- * @param[in]  lastIndex         last (excluded) id index
- * @param[in]  selectedIdsList   ids to be tagged (no duplications allowed)
- * @param[in]  selectedIdsGroups group id for each selected id
+ * @param[inout] ids               id list
+ * @param[in]    firstIndex        first id index
+ * @param[in]    lastIndex         last (excluded) id index
+ * @param[in]    selectedIds       ids to be tagged (no duplications allowed)
+ * @param[in]    selectedIdsGroups group id for each selected id
  */
 void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                   std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups);

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -1,0 +1,125 @@
+/*
+ * MIT License
+ *
+ * SPH-EXA
+ * Copyright (c) 2024 CSCS, ETH Zurich, University of Basel, University of Zurich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief  CPU/GPU Particle ID tag utilities
+ *
+ * @author Christopher Bignamini <christopher.bignamini@gmail.com>
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#pragma once
+
+#include <numeric>
+#include <span>
+#include <vector>
+
+#include "cstone/tree/definitions.h"
+#include "sph/types.hpp"
+
+namespace sphexa
+{
+
+using IdType = uint64_t;
+using LocalIndex = uint32_t;
+using CoordinateType = sph::SphTypes::CoordinateType;
+
+/*! @brief Tagging mask definition (most significant bit flip)
+ */
+constexpr IdType msbMask = static_cast<IdType>(1) << (sizeof(IdType)*8 - 1);
+
+/*! @brief Tagged id identification condition functor
+ */
+struct IsMasked
+{
+    HOST_DEVICE_FUN uint8_t operator()(IdType id) const
+    {
+        return ((id & msbMask) != 0) ? 1 : 0;
+    }
+};
+
+/*! @brief Tagged id (in first:last range) identification, CPU version
+ *
+ * @param[in]  ids          ordered id list
+ * @param[in]  first        first id index // TODO number of elements and pass iterator?
+ * @param[in]  last         last (excluded) id index
+ * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
+ */
+template<class IdTypeP, class LocalIndexP>
+void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
+extern template void findTaggedIds<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
+
+/*! @brief Tagged id (in first:last range) identification, GPU version
+ *
+ * @param[in]  ids          ordered id list
+ * @param[in]  first        first id index // TODO number of elements and pass iterator?
+ * @param[in]  last         last (excluded) id index
+ * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
+ */
+template<class IdTypeP, class LocalIndexP>
+void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
+extern template void findTaggedIdsGPU<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
+
+/*! @brief Id tagging (in first:last range) from list, CPU version
+ *
+ * @param[out] ids               id list
+ * @param[in]  first             first id index // TODO number of elements and pass iterator?
+ * @param[in]  last              last (excluded) id index
+ * @param[in]  selectedIds       indexes to be tagged
+ */
+template<class IdTypeP>
+void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<const IdTypeP> selectedIds);
+extern template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, size_t last, std::span<const IdType> selectedIds);
+
+// Id tagging types selection
+/*! @brief Id tagging spherical volume definition
+ */
+// TODO: selection spheres can be stored as cstone::Vec4<Tc>
+struct IdSelectionSphere
+{
+    cstone::Vec3<CoordinateType> center;
+    CoordinateType radius;
+};
+/*! @brief Id tagging list definition
+ */
+using IdSelectionList = std::vector<IdType>;
+
+
+/*! @brief Id tagging (in first:last range) in spherical volume, CPU version
+ *
+ * @param[out] ids               id list
+ * @param[in]  x                 x coordinates
+ * @param[in]  y                 y coordinates
+ * @param[in]  z                 z coordinates
+ * @param[in]  first             first id index // TODO number of elements and pass iterator?
+ * @param[in]  last              last (excluded) id index
+ * @param[in]  selSphereData     spherical volume definition
+ */
+template<class IdTypeP>
+void tagIdsInSphere(std::span<IdTypeP> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, const IdSelectionSphere& selSphereData);
+extern template void tagIdsInSphere<IdType>(std::span<IdType> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, const IdSelectionSphere& selSphereData);
+}

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -42,30 +42,29 @@
 namespace sphexa
 {
 
-using IdType = uint64_t;
-using LocalIndex = uint32_t;
 using CoordinateType = sph::SphTypes::CoordinateType;
 
 /*! @brief Number of bits used for tagging information storage
  */
-constexpr IdType taggingMaskSize = 10;
+constexpr uint64_t tagNumBits = 10;
 
-/*! @brief Given the taggingMaskSize, this is the maximum selection group id value plus one
+/*! @brief Given tagNumBits, the maximum number of groups we can address is 2^tagNumBits - 1. 
+ * We subtract one, because groupId=0 corresponds to an unmasked particle ID
  */
-constexpr IdType supGroupId = (1 << taggingMaskSize) - 1;
+constexpr uint64_t maxNumGroupIds = (1 << tagNumBits) - 1;
 
 /*! @brief First tagging bit position
  */
-constexpr IdType taggingMaskStartingBit = sizeof(IdType)*8 - taggingMaskSize;
+constexpr uint64_t taggingMaskStartingBit = sizeof(uint64_t)*8 - tagNumBits;
 
-constexpr IdType taggingCheckMask = supGroupId << taggingMaskStartingBit;
+constexpr uint64_t taggingCheckMask = maxNumGroupIds << taggingMaskStartingBit;
 
 
 /*! @brief Tagged id identification condition functor
  */
 struct IsMasked
 {
-    HOST_DEVICE_FUN uint8_t operator()(IdType id) const
+    HOST_DEVICE_FUN uint8_t operator()(uint64_t id) const
     {
         return (id & taggingCheckMask) != 0;
     }
@@ -73,10 +72,10 @@ struct IsMasked
 
 /*! @brief Application of tagging mask to a given id
  *
- * @param[in]  groupId      selection group id (must be < supGroupId)
+ * @param[in]  groupId      selection group id (must be < maxNumGroupIds)
  * @param[out] id           input id with tagging mask applied
  */
-void applyTaggingMask(IdType groupId, IdType& id);
+void applyTaggingMask(uint64_t groupId, uint64_t& id);
 
 /*! @brief Tagged id (in first:last range) identification, CPU version
  *
@@ -85,9 +84,8 @@ void applyTaggingMask(IdType groupId, IdType& id);
  * @param[in]  last         last (excluded) id index
  * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
  */
-template<class IdTypeP, class LocalIndexP>
-void findTaggedIds(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
-extern template void findTaggedIds<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
+template<class LocalIndexP>
+extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Tagged id (in first:last range) identification, GPU version
  *
@@ -96,32 +94,24 @@ extern template void findTaggedIds<IdType, LocalIndex>(std::span<const IdType> i
  * @param[in]  last         last (excluded) id index
  * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
  */
-template<class IdTypeP, class LocalIndexP>
-void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
-extern template void findTaggedIdsGPU<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
-
+template<class LocalIndexP>
+extern void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Id tagging spherical volume definition
  * (center[0:2], radius)
  */
 using IdSelectionSphere = cstone::Vec4<CoordinateType>;
 
-/*! @brief Id tagging list definition
- */
-using IdSelectionList = std::vector<IdType>;
+using IdSelectionList = std::vector<uint64_t>;
 
 /*! @brief Id tagging (in first:last range) from list, CPU version
  *
  * @param[out] ids               id list
  * @param[in]  first             first id index // TODO number of elements and pass iterator?
  * @param[in]  last              last (excluded) id index
- * @param[in]  selectedIds       indexes to be tagged
- * @param[in]  groupId           selection group id
+ * @param[in]  selectedIdsLists  lists of indexes to be tagged
  */
-template<class IdTypeP>
-void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<const IdTypeP> selectedIds, const LocalIndex groupId = 0);
-extern template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, size_t last, std::span<const IdType> selectedIds,
-    const LocalIndex groupId);
+void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last, std::span<const IdSelectionList> selectedIdsLists);
 
 /*! @brief Id tagging (in first:last range) in spherical volume, CPU version
  *
@@ -131,14 +121,8 @@ extern template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, s
  * @param[in]  z                 z coordinates
  * @param[in]  first             first id index // TODO number of elements and pass iterator?
  * @param[in]  last              last (excluded) id index
- * @param[in]  selSphereData     spherical volume definition
- * @param[in]  groupId           selection group id
+ * @param[in]  selSphereData     set of spherical volume definitions
  */
-template<class IdTypeP>
-void tagIdsInSphere(std::span<IdTypeP> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
-    const LocalIndex groupId = 0);
-extern template void tagIdsInSphere<IdType>(std::span<IdType> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
-    const LocalIndex groupId);
+void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, std::span<const IdSelectionSphere> selSphereData);
 }

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -46,9 +46,20 @@ using IdType = uint64_t;
 using LocalIndex = uint32_t;
 using CoordinateType = sph::SphTypes::CoordinateType;
 
-/*! @brief Tagging mask definition (most significant bit flip)
+/*! @brief Number of bits used for tagging information storage
  */
-constexpr IdType msbMask = static_cast<IdType>(1) << (sizeof(IdType)*8 - 1);
+constexpr IdType taggingMaskSize = 10;
+
+/*! @brief Given the taggingMaskSize, this is the maximum selection group id value plus one
+ */
+constexpr IdType supGroupId = (1 << taggingMaskSize) - 1;
+
+/*! @brief First tagging bit position
+ */
+constexpr IdType taggingMaskStartingBit = sizeof(IdType)*8 - taggingMaskSize;
+
+constexpr IdType taggingCheckMask = supGroupId << taggingMaskStartingBit;
+
 
 /*! @brief Tagged id identification condition functor
  */
@@ -56,9 +67,16 @@ struct IsMasked
 {
     HOST_DEVICE_FUN uint8_t operator()(IdType id) const
     {
-        return ((id & msbMask) != 0) ? 1 : 0;
+        return (id & taggingCheckMask) != 0;
     }
 };
+
+/*! @brief Application of tagging mask to a given id
+ *
+ * @param[in]  groupId      selection group id (must be < supGroupId)
+ * @param[out] id           input id with tagging mask applied
+ */
+void applyTaggingMask(IdType groupId, IdType& id);
 
 /*! @brief Tagged id (in first:last range) identification, CPU version
  *
@@ -82,30 +100,28 @@ template<class IdTypeP, class LocalIndexP>
 void findTaggedIdsGPU(std::span<const IdTypeP> ids, size_t first, size_t last, std::vector<LocalIndexP>& taggedIdsIndexes);
 extern template void findTaggedIdsGPU<IdType, LocalIndex>(std::span<const IdType> ids, size_t first, size_t last, std::vector<LocalIndex>& taggedIdsIndexes);
 
+
+/*! @brief Id tagging spherical volume definition
+ * (center[0:2], radius)
+ */
+using IdSelectionSphere = cstone::Vec4<CoordinateType>;
+
+/*! @brief Id tagging list definition
+ */
+using IdSelectionList = std::vector<IdType>;
+
 /*! @brief Id tagging (in first:last range) from list, CPU version
  *
  * @param[out] ids               id list
  * @param[in]  first             first id index // TODO number of elements and pass iterator?
  * @param[in]  last              last (excluded) id index
  * @param[in]  selectedIds       indexes to be tagged
+ * @param[in]  groupId           selection group id
  */
 template<class IdTypeP>
-void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<const IdTypeP> selectedIds);
-extern template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, size_t last, std::span<const IdType> selectedIds);
-
-// Id tagging types selection
-/*! @brief Id tagging spherical volume definition
- */
-// TODO: selection spheres can be stored as cstone::Vec4<Tc>
-struct IdSelectionSphere
-{
-    cstone::Vec3<CoordinateType> center;
-    CoordinateType radius;
-};
-/*! @brief Id tagging list definition
- */
-using IdSelectionList = std::vector<IdType>;
-
+void tagIdsInList(std::span<IdTypeP> ids, size_t first, size_t last, std::span<const IdTypeP> selectedIds, const LocalIndex groupId = 0);
+extern template void tagIdsInList<IdType>(std::span<IdType> ids, size_t first, size_t last, std::span<const IdType> selectedIds,
+    const LocalIndex groupId);
 
 /*! @brief Id tagging (in first:last range) in spherical volume, CPU version
  *
@@ -116,10 +132,13 @@ using IdSelectionList = std::vector<IdType>;
  * @param[in]  first             first id index // TODO number of elements and pass iterator?
  * @param[in]  last              last (excluded) id index
  * @param[in]  selSphereData     spherical volume definition
+ * @param[in]  groupId           selection group id
  */
 template<class IdTypeP>
 void tagIdsInSphere(std::span<IdTypeP> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, const IdSelectionSphere& selSphereData);
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
+    const LocalIndex groupId = 0);
 extern template void tagIdsInSphere<IdType>(std::span<IdType> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, const IdSelectionSphere& selSphereData);
+    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex, IdSelectionSphere selSphereData,
+    const LocalIndex groupId);
 }

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -112,7 +112,6 @@ using IdSelectionSphere = cstone::Vec4<CoordinateType>;
 void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                   std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups);
 
-
 /*! @brief Id tagging (in first:last range) in spherical volume
  *
  * @param[out] ids               id list

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -81,7 +81,7 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id);
  * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
  */
 template<class LocalIndexP>
-extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
+extern void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
                           std::vector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Tagged id (in first:last range) identification, GPU version
@@ -89,10 +89,10 @@ extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t la
  * @param[in]  ids          ordered id list
  * @param[in]  first        first id index // TODO number of elements and pass iterator?
  * @param[in]  last         last (excluded) id index
- * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
+ * @param[out] taggedIdsIndexes  vector with indices of tagged ids
  */
 template<class LocalIndexP>
-extern void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+extern void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
                              std::vector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Id tagging spherical volume definition
@@ -109,7 +109,7 @@ using IdSelectionList = std::vector<uint64_t>;
  * @param[in]  last              last (excluded) id index
  * @param[in]  selectedIdsLists  lists of indexes to be tagged
  */
-void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
+void tagIdsInList(std::span<uint64_t> ids, std::size_t first, std::size_t last,
                   std::span<const IdSelectionList> selectedIdsLists);
 
 /*! @brief Id tagging (in first:last range) in spherical volume, CPU version
@@ -118,11 +118,11 @@ void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
  * @param[in]  x                 x coordinates
  * @param[in]  y                 y coordinates
  * @param[in]  z                 z coordinates
- * @param[in]  first             first id index // TODO number of elements and pass iterator?
- * @param[in]  last              last (excluded) id index
+ * @param[in]  firstIndex        first id index // TODO number of elements and pass iterator?
+ * @param[in]  lastIndex         last (excluded) id index
  * @param[in]  selSphereData     set of spherical volume definitions
  */
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-                    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex,
+                    std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
                     std::span<const IdSelectionSphere> selSphereData);
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -35,6 +35,7 @@
 #include <span>
 #include <vector>
 
+#include "cstone/cuda/device_vector.h"
 #include "cstone/tree/definitions.h"
 #include "sph/types.hpp"
 
@@ -81,7 +82,7 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id);
  * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
  */
 template<class LocalIndexP>
-extern void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
+extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
                           std::vector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Tagged id (in first:last range) identification, GPU version
@@ -92,27 +93,27 @@ extern void findTaggedIds(std::span<const uint64_t> ids, std::size_t first, std:
  * @param[out] taggedIdsIndexes  vector with indices of tagged ids
  */
 template<class LocalIndexP>
-extern void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t first, std::size_t last,
-                             std::vector<LocalIndexP>& taggedIdsIndexes);
+extern void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+                             cstone::DeviceVector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Id tagging spherical volume definition
  * (center[0:2], radius)
  */
 using IdSelectionSphere = cstone::Vec4<CoordinateType>;
 
-using IdSelectionList = std::vector<uint64_t>;
-
-/*! @brief Id tagging (in first:last range) from list, CPU version
+/*! @brief Id tagging (in first:last range) from list
  *
  * @param[out] ids               id list
  * @param[in]  first             first id index // TODO number of elements and pass iterator?
  * @param[in]  last              last (excluded) id index
- * @param[in]  selectedIdsLists  lists of indexes to be tagged
+ * @param[in]  selectedIdsList   ids to be tagged (no duplications allowed)
+ * @param[in]  selectedIdsGroups group id for each selected id
  */
-void tagIdsInList(std::span<uint64_t> ids, std::size_t first, std::size_t last,
-                  std::span<const IdSelectionList> selectedIdsLists);
+void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
+                  std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups);
 
-/*! @brief Id tagging (in first:last range) in spherical volume, CPU version
+
+/*! @brief Id tagging (in first:last range) in spherical volume
  *
  * @param[out] ids               id list
  * @param[in]  x                 x coordinates
@@ -121,8 +122,9 @@ void tagIdsInList(std::span<uint64_t> ids, std::size_t first, std::size_t last,
  * @param[in]  firstIndex        first id index // TODO number of elements and pass iterator?
  * @param[in]  lastIndex         last (excluded) id index
  * @param[in]  selSphereData     set of spherical volume definitions
+ * @param[in]  sphereGroupIds    group id for each spherical volume definition
  */
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-                    std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
-                    std::span<const IdSelectionSphere> selSphereData);
+                    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex,
+                    std::span<const IdSelectionSphere> selSphereData, std::span<const unsigned> sphereGroupIds);
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -77,7 +77,7 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id);
 /*! @brief Tagged id (in first:last range) identification, CPU version
  *
  * @param[in]  ids          ordered id list
- * @param[in]  first        first id index // TODO number of elements and pass iterator?
+ * @param[in]  first        first id index
  * @param[in]  last         last (excluded) id index
  * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
  */
@@ -88,7 +88,7 @@ extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t la
 /*! @brief Tagged id (in first:last range) identification, GPU version
  *
  * @param[in]  ids          ordered id list
- * @param[in]  first        first id index // TODO number of elements and pass iterator?
+ * @param[in]  first        first id index
  * @param[in]  last         last (excluded) id index
  * @param[out] taggedIdsIndexes  vector with indices of tagged ids
  */
@@ -104,7 +104,7 @@ using IdSelectionSphere = cstone::Vec4<CoordinateType>;
 /*! @brief Id tagging (in first:last range) from list
  *
  * @param[out] ids               id list
- * @param[in]  first             first id index // TODO number of elements and pass iterator?
+ * @param[in]  first             first id index
  * @param[in]  last              last (excluded) id index
  * @param[in]  selectedIdsList   ids to be tagged (no duplications allowed)
  * @param[in]  selectedIdsGroups group id for each selected id
@@ -119,7 +119,7 @@ void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
  * @param[in]  x                 x coordinates
  * @param[in]  y                 y coordinates
  * @param[in]  z                 z coordinates
- * @param[in]  firstIndex        first id index // TODO number of elements and pass iterator?
+ * @param[in]  firstIndex        first id index
  * @param[in]  lastIndex         last (excluded) id index
  * @param[in]  selSphereData     set of spherical volume definitions
  * @param[in]  sphereGroupIds    group id for each spherical volume definition

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -76,24 +76,24 @@ uint64_t applyTaggingMask(uint64_t groupId, uint64_t id);
 
 /*! @brief Tagged id (in first:last range) identification, CPU version
  *
- * @param[in]  ids          ordered id list
- * @param[in]  first        first id index
- * @param[in]  last         last (excluded) id index
+ * @param[in]  ids               ordered id list
+ * @param[in]  firstIndex        first id index
+ * @param[in]  lastIndex         last (excluded) id index
  * @param[out] taggedIdsIndexes  vector of indexes of tagged ids
  */
 template<class LocalIndexP>
-extern void findTaggedIds(std::span<const uint64_t> ids, size_t first, size_t last,
+extern void findTaggedIds(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                           std::vector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Tagged id (in first:last range) identification, GPU version
  *
- * @param[in]  ids          ordered id list
- * @param[in]  first        first id index
- * @param[in]  last         last (excluded) id index
+ * @param[in]  ids               ordered id list
+ * @param[in]  firstIndex        first id index
+ * @param[in]  lastIndex         last (excluded) id index
  * @param[out] taggedIdsIndexes  vector with indices of tagged ids
  */
 template<class LocalIndexP>
-extern void findTaggedIdsGPU(std::span<const uint64_t> ids, size_t first, size_t last,
+extern void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                              cstone::DeviceVector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Id tagging spherical volume definition
@@ -104,12 +104,12 @@ using IdSelectionSphere = cstone::Vec4<CoordinateType>;
 /*! @brief Id tagging (in first:last range) from list
  *
  * @param[out] ids               id list
- * @param[in]  first             first id index
- * @param[in]  last              last (excluded) id index
+ * @param[in]  firstIndex        first id index
+ * @param[in]  lastIndex         last (excluded) id index
  * @param[in]  selectedIdsList   ids to be tagged (no duplications allowed)
  * @param[in]  selectedIdsGroups group id for each selected id
  */
-void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
+void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                   std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups);
 
 
@@ -125,6 +125,6 @@ void tagIdsInList(std::span<uint64_t> ids, size_t first, size_t last,
  * @param[in]  sphereGroupIds    group id for each spherical volume definition
  */
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
-                    std::span<const CoordinateType> z, size_t firstIndex, size_t lastIndex,
+                    std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
                     std::span<const IdSelectionSphere> selSphereData, std::span<const unsigned> sphereGroupIds);
 } // namespace sphexa

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -73,9 +73,10 @@ struct IsMasked
 /*! @brief Application of tagging mask to a given id
  *
  * @param[in]  groupId      selection group id (must be < maxNumGroupIds)
- * @param[out] id           input id with tagging mask applied
+ * @param[in] id            input id
+ * @return                  tagged id
  */
-void applyTaggingMask(uint64_t groupId, uint64_t& id);
+uint64_t applyTaggingMask(uint64_t groupId, uint64_t id);
 
 /*! @brief Tagged id (in first:last range) identification, CPU version
  *

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -35,7 +35,6 @@
 #include <span>
 #include <vector>
 
-#include "cstone/cuda/device_vector.h"
 #include "cstone/tree/definitions.h"
 #include "sph/types.hpp"
 
@@ -92,9 +91,9 @@ extern void findTaggedIds(std::span<const uint64_t> ids, std::size_t firstIndex,
  * @param[in]  lastIndex         last (excluded) id index
  * @param[out] taggedIdsIndexes  vector with indices of tagged ids
  */
-template<class LocalIndexP>
+template<class LocalIndexP, template<class> class DeviceVector>
 extern void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
-                             cstone::DeviceVector<LocalIndexP>& taggedIdsIndexes);
+                             DeviceVector<LocalIndexP>& taggedIdsIndexes);
 
 /*! @brief Id tagging spherical volume definition
  * (center[0:2], radius)

--- a/main/test/CMakeLists.txt
+++ b/main/test/CMakeLists.txt
@@ -30,7 +30,7 @@ if (CMAKE_CUDA_COMPILER AND SPH_EXA_WITH_H5HUT)
                                ${SPH_DIR}
                                ${CSTONE_DIR}
                                ${PROJECT_SOURCE_DIR}/main/src)
-    target_link_libraries(${testname} PUBLIC cstone_gpu io_gpu sph_gpu OpenMP::OpenMP_CXX CUDA::cudart GTest::gtest_main)
+    target_link_libraries(${testname} PUBLIC cstone_gpu io io_gpu sph_gpu OpenMP::OpenMP_CXX CUDA::cudart GTest::gtest_main)
     add_test(NAME FrontendUnitsCuda COMMAND ${exename})
     unset(testname)
 endif ()

--- a/main/test/CMakeLists.txt
+++ b/main/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UNIT_TESTS
         init/grid.cpp
         io/arg_parser.cpp
         io/h5part_wrapper.cpp
+        io/id_tag_utils.cpp
         observables/gravitational_waves.cpp
         sphexa/particles_data.cpp
         test_main.cpp)
@@ -22,13 +23,14 @@ if (CMAKE_CUDA_COMPILER AND SPH_EXA_WITH_H5HUT)
     set(testname frontend_units_cuda)
     add_executable(${testname}
             cuda/gpu_particles_data.cpp
+            io/id_tag_utils_gpu.cu
             test_main.cpp)
     target_include_directories(${testname} PRIVATE
                                ${COOLING_DIR}
                                ${SPH_DIR}
                                ${CSTONE_DIR}
                                ${PROJECT_SOURCE_DIR}/main/src)
-    target_link_libraries(${testname} PUBLIC cstone_gpu sph_gpu OpenMP::OpenMP_CXX CUDA::cudart GTest::gtest_main)
+    target_link_libraries(${testname} PUBLIC cstone_gpu io_gpu sph_gpu OpenMP::OpenMP_CXX CUDA::cudart GTest::gtest_main)
     add_test(NAME FrontendUnitsCuda COMMAND ${exename})
     unset(testname)
 endif ()

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -114,7 +114,8 @@ TEST(IO, tagIdInList)
 {
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    sphexa::IdSelectionList selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint64_t>   selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<unsigned>   selectedIdsGroups(selectedIds.size(), 0);
     std::vector<uint64_t>   tagIdsRef = ids;
     tagIdsRef[0]                      = 18014398509481984ULL;
     tagIdsRef[1]                      = 18014398509481985ULL;
@@ -130,10 +131,38 @@ TEST(IO, tagIdInList)
     tagIdsRef[95]                     = 18014398509482079ULL;
     tagIdsRef[99]                     = 18014398509482083ULL;
 
-    std::vector<sphexa::IdSelectionList> selectedIdsLists{selectedIds};
+    sphexa::tagIdsInList(std::span<uint64_t>(ids), 0, ids.size(),
+                         std::span<const uint64_t>(selectedIds),
+                         std::span<const unsigned>(selectedIdsGroups));
+
+    EXPECT_EQ(ids, tagIdsRef);
+}
+
+TEST(IO, tagIdInListMultipleGroups)
+{
+    std::vector<uint64_t> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t>   selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<unsigned>   selectedIdsGroups{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2};
+    std::vector<uint64_t>   tagIdsRef = ids;
+    tagIdsRef[0]                      = 18014398509481984ULL;
+    tagIdsRef[1]                      = 18014398509481985ULL;
+    tagIdsRef[2]                      = 18014398509481986ULL;
+    tagIdsRef[3]                      = 18014398509481987ULL;
+    tagIdsRef[6]                      = 36028797018963974ULL;
+    tagIdsRef[11]                     = 36028797018963979ULL;
+    tagIdsRef[13]                     = 36028797018963981ULL;
+    tagIdsRef[23]                     = 36028797018963991ULL;
+    tagIdsRef[71]                     = 54043195528446023ULL;
+    tagIdsRef[83]                     = 54043195528446035ULL;
+    tagIdsRef[91]                     = 54043195528446043ULL;
+    tagIdsRef[95]                     = 54043195528446047ULL;
+    tagIdsRef[99]                     = 54043195528446051ULL;
 
     sphexa::tagIdsInList(std::span<uint64_t>(ids), 0, ids.size(),
-                         std::span<const sphexa::IdSelectionList>(selectedIdsLists));
+                         std::span<const uint64_t>(selectedIds),
+                         std::span<const unsigned>(selectedIdsGroups));
+
     EXPECT_EQ(ids, tagIdsRef);
 }
 
@@ -143,17 +172,44 @@ TEST(IO, tagIdInListWithRange)
     uint32_t              last  = 10;
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    sphexa::IdSelectionList selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint64_t> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<unsigned> selectedIdsGroups(selectedIds.size(), 0);
     std::vector<uint64_t>   tagIdsRef = ids;
     tagIdsRef[3]                      = 18014398509481987ULL;
     tagIdsRef[6]                      = 18014398509481990ULL;
 
-    std::vector<sphexa::IdSelectionList> selectedIdsLists{selectedIds};
 
     sphexa::tagIdsInList(std::span<uint64_t>(ids), first, last,
-                         std::span<const sphexa::IdSelectionList>(selectedIdsLists));
+                         std::span<const uint64_t>(selectedIds),
+                         std::span<const unsigned>(selectedIdsGroups));
     EXPECT_EQ(ids, tagIdsRef);
 }
+
+TEST(IO, tagIdInListWithRangeMultipleGroups)
+{
+    uint32_t              first = 3;
+    uint32_t              last  = 94;
+    std::vector<uint64_t> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<unsigned> selectedIdsGroups{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2};
+    std::vector<uint64_t>   tagIdsRef = ids;
+    tagIdsRef[3]                      = 18014398509481987ULL;
+    tagIdsRef[6]                      = 36028797018963974ULL;
+    tagIdsRef[11]                     = 36028797018963979ULL;
+    tagIdsRef[13]                     = 36028797018963981ULL;
+    tagIdsRef[23]                     = 36028797018963991ULL;
+    tagIdsRef[71]                     = 54043195528446023ULL;
+    tagIdsRef[83]                     = 54043195528446035ULL;
+    tagIdsRef[91]                     = 54043195528446043ULL;
+
+    sphexa::tagIdsInList(std::span<uint64_t>(ids), first, last,
+                         std::span<const uint64_t>(selectedIds),
+                         std::span<const unsigned>(selectedIdsGroups));
+
+    EXPECT_EQ(ids, tagIdsRef);
+}
+
 
 TEST(IO, tagIdInSphere)
 {
@@ -178,7 +234,8 @@ TEST(IO, tagIdInSphere)
     tagIdsRef[554] = 18014398509482538ULL;
     tagIdsRef[555] = 18014398509482539ULL;
     sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, 0, ids.size(),
-                           std::span<const sphexa::IdSelectionSphere>(selSphereDataVec));
+                           std::span<const sphexa::IdSelectionSphere>(selSphereDataVec),
+                           std::span<const unsigned>(std::vector<unsigned>{0}));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
@@ -203,7 +260,40 @@ TEST(IO, tagIdInSphereWithRange)
     tagIdsRef[454] = 18014398509482438ULL;
     tagIdsRef[455] = 18014398509482439ULL;
     sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, first, last,
-                           std::span<const sphexa::IdSelectionSphere>(selSphereDataVec));
+                           std::span<const sphexa::IdSelectionSphere>(selSphereDataVec),
+                           std::span<const unsigned>(std::vector<unsigned>{0}));
+    EXPECT_EQ(ids, tagIdsRef);
+}
+
+TEST(IO, tagIdInMultipleSpheres)
+{
+    std::vector<uint64_t> ids(1000);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t> tagIdsRef = ids;
+
+    // Particle distribution creation
+    std::vector<sphexa::CoordinateType> x, y, z;
+    makeParticleDistribution(x, y, z, 1000);
+
+    // Selection spheres definition: second sphere overlaps with first one
+    std::vector<sphexa::IdSelectionSphere> selSphereDataVec{sphexa::IdSelectionSphere{0.0, 0.0, 0.0, 0.25},
+                                                            sphexa::IdSelectionSphere{0.1, 0.1, 0.1, 0.25}};
+
+    tagIdsRef[444] = 18014398509482428ULL;
+    tagIdsRef[445] = 18014398509482429ULL;
+    tagIdsRef[454] = 18014398509482438ULL;
+    tagIdsRef[455] = 36028797018964423ULL;
+    tagIdsRef[544] = 18014398509482528ULL;
+    tagIdsRef[545] = 36028797018964513ULL;
+    tagIdsRef[554] = 36028797018964522ULL;
+    tagIdsRef[555] = 36028797018964523ULL;
+    tagIdsRef[556] = 36028797018964524ULL;
+    tagIdsRef[565] = 36028797018964533ULL;
+    tagIdsRef[655] = 36028797018964623ULL;
+
+    sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, 0, ids.size(),
+                           std::span<const sphexa::IdSelectionSphere>(selSphereDataVec),
+                           std::span<const unsigned>(std::vector<unsigned>{0, 1}));
     EXPECT_EQ(ids, tagIdsRef);
 }
 

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -38,7 +38,7 @@
 #include "io/id_tag_utils.hpp"
 
 void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x, std::vector<sphexa::CoordinateType>& y,
-                              std::vector<sphexa::CoordinateType>& z, size_t numParticles)
+                              std::vector<sphexa::CoordinateType>& z, std::size_t numParticles)
 {
     x.resize(numParticles);
     y.resize(numParticles);

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
- /*! @file
+/*! @file
  * @brief Unit tests for id tagging related functionality
  *
  * @author Christopher Bignamini <christopher.bignamini@gmail.com>
@@ -37,21 +37,22 @@
 #include "gtest/gtest.h"
 #include "io/id_tag_utils.hpp"
 
-void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x,
-                              std::vector<sphexa::CoordinateType>& y,
-                              std::vector<sphexa::CoordinateType>& z,
-                              size_t numParticles)
+void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x, std::vector<sphexa::CoordinateType>& y,
+                              std::vector<sphexa::CoordinateType>& z, size_t numParticles)
 {
     x.resize(numParticles);
     y.resize(numParticles);
     z.resize(numParticles);
 
     unsigned int gridSize = std::cbrt(numParticles);
-    double step = 2.0 / (gridSize - 1);
-    unsigned int index = 0;
-    for (unsigned int i = 0; i < gridSize; ++i) {
-        for (unsigned int j = 0; j < gridSize; ++j) {
-            for (unsigned int k = 0; k < gridSize; ++k) {
+    double       step     = 2.0 / (gridSize - 1);
+    unsigned int index    = 0;
+    for (unsigned int i = 0; i < gridSize; ++i)
+    {
+        for (unsigned int j = 0; j < gridSize; ++j)
+        {
+            for (unsigned int k = 0; k < gridSize; ++k)
+            {
                 if (index >= numParticles) break;
                 x[index] = -1.0 + i * step;
                 y[index] = -1.0 + j * step;
@@ -64,48 +65,48 @@ void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x,
 
 TEST(IO, applyTaggingMaskZero)
 {
-    uint64_t id = 0;
+    uint64_t id      = 0;
     uint64_t groupId = 0;
-    uint64_t idRef = 18014398509481984ULL;
-    id = sphexa::applyTaggingMask(groupId, id);
+    uint64_t idRef   = 18014398509481984ULL;
+    id               = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
 TEST(IO, applyTaggingMaskMaxGroup)
 {
-    uint64_t id = 1;
+    uint64_t id      = 1;
     uint64_t groupId = sphexa::maxNumGroupIds - 1;
-    uint64_t idRef = 18428729675200069633ULL;
-    id = sphexa::applyTaggingMask(groupId, id);
+    uint64_t idRef   = 18428729675200069633ULL;
+    id               = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
 TEST(IO, applyTaggingMaskMaxId)
 {
-    uint64_t id = (uint64_t(1) << (sizeof(uint64_t)*8 - sphexa::tagNumBits)) - 1;
+    uint64_t id      = (uint64_t(1) << (sizeof(uint64_t) * 8 - sphexa::tagNumBits)) - 1;
     uint64_t groupId = 0;
-    uint64_t idRef = 36028797018963967;
-    id = sphexa::applyTaggingMask(groupId, id);
+    uint64_t idRef   = 36028797018963967;
+    id               = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
 TEST(IO, applyTaggingMaskMaxIdMaxGroup)
 {
-    uint64_t id = (uint64_t(1) << (sizeof(uint64_t)*8 - sphexa::tagNumBits)) - 1;
+    uint64_t id      = (uint64_t(1) << (sizeof(uint64_t) * 8 - sphexa::tagNumBits)) - 1;
     uint64_t groupId = sphexa::maxNumGroupIds - 1;
-    uint64_t idRef = 18446744073709551615ULL;
-    id = sphexa::applyTaggingMask(groupId, id);
+    uint64_t idRef   = 18446744073709551615ULL;
+    id               = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
 TEST(IO, applyTaggingMaskTwice)
 {
-    uint64_t id = 0;
+    uint64_t id      = 0;
     uint64_t groupId = 0;
-    uint64_t idRef = 36028797018963968ULL;
-    id = sphexa::applyTaggingMask(groupId, id);
-    groupId = 1;
-    id = sphexa::applyTaggingMask(groupId, id);
+    uint64_t idRef   = 36028797018963968ULL;
+    id               = sphexa::applyTaggingMask(groupId, id);
+    groupId          = 1;
+    id               = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
@@ -114,41 +115,43 @@ TEST(IO, tagIdInList)
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     sphexa::IdSelectionList selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::vector<uint64_t> tagIdsRef = ids;
-    tagIdsRef[0] = 18014398509481984ULL;
-    tagIdsRef[1] = 18014398509481985ULL;
-    tagIdsRef[2] = 18014398509481986ULL;
-    tagIdsRef[3] = 18014398509481987ULL;
-    tagIdsRef[6] = 18014398509481990ULL;
-    tagIdsRef[11] = 18014398509481995ULL;
-    tagIdsRef[13] = 18014398509481997ULL;
-    tagIdsRef[23] = 18014398509482007ULL;
-    tagIdsRef[71] = 18014398509482055ULL;
-    tagIdsRef[83] = 18014398509482067ULL;
-    tagIdsRef[91] = 18014398509482075ULL;
-    tagIdsRef[95] = 18014398509482079ULL;
-    tagIdsRef[99] = 18014398509482083ULL;
+    std::vector<uint64_t>   tagIdsRef = ids;
+    tagIdsRef[0]                      = 18014398509481984ULL;
+    tagIdsRef[1]                      = 18014398509481985ULL;
+    tagIdsRef[2]                      = 18014398509481986ULL;
+    tagIdsRef[3]                      = 18014398509481987ULL;
+    tagIdsRef[6]                      = 18014398509481990ULL;
+    tagIdsRef[11]                     = 18014398509481995ULL;
+    tagIdsRef[13]                     = 18014398509481997ULL;
+    tagIdsRef[23]                     = 18014398509482007ULL;
+    tagIdsRef[71]                     = 18014398509482055ULL;
+    tagIdsRef[83]                     = 18014398509482067ULL;
+    tagIdsRef[91]                     = 18014398509482075ULL;
+    tagIdsRef[95]                     = 18014398509482079ULL;
+    tagIdsRef[99]                     = 18014398509482083ULL;
 
     std::vector<sphexa::IdSelectionList> selectedIdsLists{selectedIds};
 
-    sphexa::tagIdsInList(std::span<uint64_t>(ids), 0, ids.size(), std::span<const sphexa::IdSelectionList>(selectedIdsLists));
+    sphexa::tagIdsInList(std::span<uint64_t>(ids), 0, ids.size(),
+                         std::span<const sphexa::IdSelectionList>(selectedIdsLists));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
 TEST(IO, tagIdInListWithRange)
 {
-    uint32_t first = 3;
-    uint32_t last = 10;
+    uint32_t              first = 3;
+    uint32_t              last  = 10;
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     sphexa::IdSelectionList selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::vector<uint64_t> tagIdsRef = ids;
-    tagIdsRef[3] = 18014398509481987ULL;
-    tagIdsRef[6] = 18014398509481990ULL;
+    std::vector<uint64_t>   tagIdsRef = ids;
+    tagIdsRef[3]                      = 18014398509481987ULL;
+    tagIdsRef[6]                      = 18014398509481990ULL;
 
     std::vector<sphexa::IdSelectionList> selectedIdsLists{selectedIds};
 
-    sphexa::tagIdsInList(std::span<uint64_t>(ids), first, last, std::span<const sphexa::IdSelectionList>(selectedIdsLists));
+    sphexa::tagIdsInList(std::span<uint64_t>(ids), first, last,
+                         std::span<const sphexa::IdSelectionList>(selectedIdsLists));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
@@ -163,18 +166,19 @@ TEST(IO, tagIdInSphere)
     makeParticleDistribution(x, y, z, 1000);
 
     // Selection sphere definition
-    sphexa::IdSelectionSphere selSphereData{0.0, 0.0, 0.0, 0.25};
+    sphexa::IdSelectionSphere              selSphereData{0.0, 0.0, 0.0, 0.25};
     std::vector<sphexa::IdSelectionSphere> selSphereDataVec{selSphereData};
 
-    tagIdsRef[444]=18014398509482428ULL;
-    tagIdsRef[445]=18014398509482429ULL;
-    tagIdsRef[454]=18014398509482438ULL;
-    tagIdsRef[455]=18014398509482439ULL;
-    tagIdsRef[544]=18014398509482528ULL;
-    tagIdsRef[545]=18014398509482529ULL;
-    tagIdsRef[554]=18014398509482538ULL;
-    tagIdsRef[555]=18014398509482539ULL;
-    sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, 0, ids.size(), std::span<const sphexa::IdSelectionSphere>(selSphereDataVec));
+    tagIdsRef[444] = 18014398509482428ULL;
+    tagIdsRef[445] = 18014398509482429ULL;
+    tagIdsRef[454] = 18014398509482438ULL;
+    tagIdsRef[455] = 18014398509482439ULL;
+    tagIdsRef[544] = 18014398509482528ULL;
+    tagIdsRef[545] = 18014398509482529ULL;
+    tagIdsRef[554] = 18014398509482538ULL;
+    tagIdsRef[555] = 18014398509482539ULL;
+    sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, 0, ids.size(),
+                           std::span<const sphexa::IdSelectionSphere>(selSphereDataVec));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
@@ -183,22 +187,23 @@ TEST(IO, tagIdInSphereWithRange)
     std::vector<uint64_t> ids(1000);
     std::iota(ids.begin(), ids.end(), 0);
     std::vector<uint64_t> tagIdsRef = ids;
-    uint32_t first = 400;
-    uint32_t last = 500;
+    uint32_t              first     = 400;
+    uint32_t              last      = 500;
 
     // Particle distribution creation
     std::vector<sphexa::CoordinateType> x, y, z;
     makeParticleDistribution(x, y, z, 1000);
 
     // Selection sphere definition
-    sphexa::IdSelectionSphere selSphereData{0.0, 0.0, 0.0, 0.25};
+    sphexa::IdSelectionSphere              selSphereData{0.0, 0.0, 0.0, 0.25};
     std::vector<sphexa::IdSelectionSphere> selSphereDataVec{selSphereData};
 
-    tagIdsRef[444]=18014398509482428ULL;
-    tagIdsRef[445]=18014398509482429ULL;
-    tagIdsRef[454]=18014398509482438ULL;
-    tagIdsRef[455]=18014398509482439ULL;
-    sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, first, last, std::span<const sphexa::IdSelectionSphere>(selSphereDataVec));
+    tagIdsRef[444] = 18014398509482428ULL;
+    tagIdsRef[445] = 18014398509482429ULL;
+    tagIdsRef[454] = 18014398509482438ULL;
+    tagIdsRef[455] = 18014398509482439ULL;
+    sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, first, last,
+                           std::span<const sphexa::IdSelectionSphere>(selSphereDataVec));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
@@ -209,9 +214,8 @@ TEST(IO, taggedIdIdentification)
     std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = sphexa::applyTaggingMask(0, ids[idPos]);
-    });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
+                  [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(0, ids[idPos]); });
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
@@ -222,17 +226,15 @@ TEST(IO, taggedIdIdentificationWithRange)
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     std::vector<uint32_t> taggedIdPos;
-    uint32_t first = 3;
-    uint32_t last = 10;
+    uint32_t              first = 3;
+    uint32_t              last  = 10;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = sphexa::applyTaggingMask(1, ids[idPos]);
-    });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
+                  [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(1, ids[idPos]); });
     std::vector<uint32_t> taggedIdPosRefRange;
-    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
-        return idPos >= first && idPos < last;
-    });
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange),
+                 [first, last](auto idPos) { return idPos >= first && idPos < last; });
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
@@ -243,17 +245,15 @@ TEST(IO, taggedIdIdentificationWithRangeStart)
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     std::vector<uint32_t> taggedIdPos;
-    uint32_t first = 0;
-    uint32_t last = 3;
+    uint32_t              first = 0;
+    uint32_t              last  = 3;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = sphexa::applyTaggingMask(2, ids[idPos]);
-    });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
+                  [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(2, ids[idPos]); });
     std::vector<uint32_t> taggedIdPosRefRange;
-    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
-        return idPos >= first && idPos < last;
-    });
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange),
+                 [first, last](auto idPos) { return idPos >= first && idPos < last; });
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
@@ -264,17 +264,15 @@ TEST(IO, taggedIdIdentificationWithRangeEnd)
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     std::vector<uint32_t> taggedIdPos;
-    uint32_t first = 97;
-    uint32_t last = 100;
+    uint32_t              first = 97;
+    uint32_t              last  = 100;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = sphexa::applyTaggingMask(3, ids[idPos]);
-    });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
+                  [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(3, ids[idPos]); });
     std::vector<uint32_t> taggedIdPosRefRange;
-    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
-        return idPos >= first && idPos < last;
-    });
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange),
+                 [first, last](auto idPos) { return idPos >= first && idPos < last; });
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
@@ -287,7 +285,7 @@ TEST(IO, taggedIdIdentificationSingleStart)
     std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef = {0};
-    ids[0] = sphexa::applyTaggingMask(4, ids[0]);
+    ids[0]                               = sphexa::applyTaggingMask(4, ids[0]);
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
@@ -300,7 +298,7 @@ TEST(IO, taggedIdIdentificationSingleEnd)
     std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef = {99};
-    ids[99] = sphexa::applyTaggingMask(5, ids[99]);
+    ids[99]                              = sphexa::applyTaggingMask(5, ids[99]);
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -66,7 +66,7 @@ TEST(IO, applyTaggingMaskZero)
     uint64_t id = 0;
     uint64_t groupId = 0;
     uint64_t idRef = 18014398509481984ULL;
-    sphexa::applyTaggingMask(groupId, id);
+    id = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
@@ -75,7 +75,7 @@ TEST(IO, applyTaggingMaskMaxGroup)
     uint64_t id = 1;
     uint64_t groupId = sphexa::maxNumGroupIds - 1;
     uint64_t idRef = 18428729675200069633ULL;
-    sphexa::applyTaggingMask(groupId, id);
+    id = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
@@ -84,7 +84,7 @@ TEST(IO, applyTaggingMaskMaxId)
     uint64_t id = (uint64_t(1) << (sizeof(uint64_t)*8 - sphexa::tagNumBits)) - 1;
     uint64_t groupId = 0;
     uint64_t idRef = 36028797018963967;
-    sphexa::applyTaggingMask(groupId, id);
+    id = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
@@ -93,7 +93,7 @@ TEST(IO, applyTaggingMaskMaxIdMaxGroup)
     uint64_t id = (uint64_t(1) << (sizeof(uint64_t)*8 - sphexa::tagNumBits)) - 1;
     uint64_t groupId = sphexa::maxNumGroupIds - 1;
     uint64_t idRef = 18446744073709551615ULL;
-    sphexa::applyTaggingMask(groupId, id);
+    id = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
@@ -102,9 +102,9 @@ TEST(IO, applyTaggingMaskTwice)
     uint64_t id = 0;
     uint64_t groupId = 0;
     uint64_t idRef = 36028797018963968ULL;
-    sphexa::applyTaggingMask(groupId, id);
+    id = sphexa::applyTaggingMask(groupId, id);
     groupId = 1;
-    sphexa::applyTaggingMask(groupId, id);
+    id = sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
@@ -209,7 +209,7 @@ TEST(IO, taggedIdIdentification)
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        sphexa::applyTaggingMask(0, ids[idPos]);
+        ids[idPos] = sphexa::applyTaggingMask(0, ids[idPos]);
     });
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
@@ -226,7 +226,7 @@ TEST(IO, taggedIdIdentificationWithRange)
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        sphexa::applyTaggingMask(1, ids[idPos]);
+        ids[idPos] = sphexa::applyTaggingMask(1, ids[idPos]);
     });
     std::vector<uint32_t> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
@@ -247,7 +247,7 @@ TEST(IO, taggedIdIdentificationWithRangeStart)
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        sphexa::applyTaggingMask(2, ids[idPos]);
+        ids[idPos] = sphexa::applyTaggingMask(2, ids[idPos]);
     });
     std::vector<uint32_t> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
@@ -268,7 +268,7 @@ TEST(IO, taggedIdIdentificationWithRangeEnd)
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        sphexa::applyTaggingMask(3, ids[idPos]);
+        ids[idPos] = sphexa::applyTaggingMask(3, ids[idPos]);
     });
     std::vector<uint32_t> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
@@ -286,7 +286,7 @@ TEST(IO, taggedIdIdentificationSingleStart)
     std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef = {0};
-    sphexa::applyTaggingMask(4, ids[0]);
+    ids[0] = sphexa::applyTaggingMask(4, ids[0]);
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
@@ -299,7 +299,7 @@ TEST(IO, taggedIdIdentificationSingleEnd)
     std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef = {99};
-    sphexa::applyTaggingMask(5, ids[99]);
+    ids[99] = sphexa::applyTaggingMask(5, ids[99]);
 
     sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -61,25 +61,73 @@ void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x,
     }
 }
 
+TEST(IO, applyTaggingMaskZero)
+{
+    sphexa::IdType id = 0;
+    sphexa::IdType groupId = 0;
+    sphexa::IdType idRef = 18014398509481984ULL;
+    sphexa::applyTaggingMask(groupId, id);
+    EXPECT_EQ(id, idRef);
+}
+
+TEST(IO, applyTaggingMaskMaxGroup)
+{
+    sphexa::IdType id = 1;
+    sphexa::IdType groupId = sphexa::supGroupId - 1;
+    sphexa::IdType idRef = 18428729675200069633ULL;
+    sphexa::applyTaggingMask(groupId, id);
+    EXPECT_EQ(id, idRef);
+}
+
+TEST(IO, applyTaggingMaskMaxId)
+{
+    sphexa::IdType id = (sphexa::IdType(1) << (sizeof(sphexa::IdType)*8 - sphexa::taggingMaskSize)) - 1;
+    sphexa::IdType groupId = 0;
+    sphexa::IdType idRef = 36028797018963967;
+    sphexa::applyTaggingMask(groupId, id);
+    EXPECT_EQ(id, idRef);
+}
+
+TEST(IO, applyTaggingMaskMaxIdMaxGroup)
+{
+    sphexa::IdType id = (sphexa::IdType(1) << (sizeof(sphexa::IdType)*8 - sphexa::taggingMaskSize)) - 1;
+    sphexa::IdType groupId = sphexa::supGroupId - 1;
+    sphexa::IdType idRef = 18446744073709551615ULL;
+    sphexa::applyTaggingMask(groupId, id);
+    EXPECT_EQ(id, idRef);
+}
+
+TEST(IO, applyTaggingMaskTwice)
+{
+    sphexa::IdType id = 0;
+    sphexa::IdType groupId = 0;
+    sphexa::IdType idRef = 36028797018963968ULL;
+    sphexa::applyTaggingMask(groupId, id);
+    groupId = 1;
+    sphexa::applyTaggingMask(groupId, id);
+    EXPECT_EQ(id, idRef);
+}
+
+
 TEST(IO, tagIdInList)
 {
     std::vector<sphexa::IdType> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     std::vector<sphexa::IdType> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::vector<sphexa::IdType> tagIdsRef = ids;
-    tagIdsRef[0] = 9223372036854775808ULL;
-    tagIdsRef[1] = 9223372036854775809ULL;
-    tagIdsRef[2] = 9223372036854775810ULL;
-    tagIdsRef[3] = 9223372036854775811ULL;
-    tagIdsRef[6] = 9223372036854775814ULL;
-    tagIdsRef[11] = 9223372036854775819ULL;
-    tagIdsRef[13] = 9223372036854775821ULL;
-    tagIdsRef[23] = 9223372036854775831ULL;
-    tagIdsRef[71] = 9223372036854775879ULL;
-    tagIdsRef[83] = 9223372036854775891ULL;
-    tagIdsRef[91] = 9223372036854775899ULL;
-    tagIdsRef[95] = 9223372036854775903ULL;
-    tagIdsRef[99] = 9223372036854775907ULL;
+    tagIdsRef[0] = 18014398509481984ULL;
+    tagIdsRef[1] = 18014398509481985ULL;
+    tagIdsRef[2] = 18014398509481986ULL;
+    tagIdsRef[3] = 18014398509481987ULL;
+    tagIdsRef[6] = 18014398509481990ULL;
+    tagIdsRef[11] = 18014398509481995ULL;
+    tagIdsRef[13] = 18014398509481997ULL;
+    tagIdsRef[23] = 18014398509482007ULL;
+    tagIdsRef[71] = 18014398509482055ULL;
+    tagIdsRef[83] = 18014398509482067ULL;
+    tagIdsRef[91] = 18014398509482075ULL;
+    tagIdsRef[95] = 18014398509482079ULL;
+    tagIdsRef[99] = 18014398509482083ULL;
 
     sphexa::tagIdsInList(std::span<sphexa::IdType>(ids), 0, ids.size(), std::span<const sphexa::IdType>(selectedIds));
     EXPECT_EQ(ids, tagIdsRef);
@@ -91,12 +139,13 @@ TEST(IO, tagIdInListWithRange)
     sphexa::LocalIndex last = 10;
     std::vector<sphexa::IdType> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
+    sphexa::IdType groupId = 1;
     std::vector<sphexa::IdType> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::vector<sphexa::IdType> tagIdsRef = ids;
-    tagIdsRef[3] = 9223372036854775811ULL;
-    tagIdsRef[6] = 9223372036854775814ULL;
+    tagIdsRef[3] = 36028797018963971ULL;
+    tagIdsRef[6] = 36028797018963974ULL;
 
-    sphexa::tagIdsInList(std::span<sphexa::IdType>(ids), first, last, std::span<const sphexa::IdType>(selectedIds));
+    sphexa::tagIdsInList(std::span<sphexa::IdType>(ids), first, last, std::span<const sphexa::IdType>(selectedIds), groupId);
     EXPECT_EQ(ids, tagIdsRef);
 }
 
@@ -104,30 +153,32 @@ TEST(IO, tagIdInSphere)
 {
     std::vector<sphexa::IdType> ids(1000);
     std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::IdType> tagIdsRef = ids;
 
     // Particle distribution creation
     std::vector<sphexa::CoordinateType> x, y, z;
     makeParticleDistribution(x, y, z, 1000);
 
     // Selection sphere definition
-    sphexa::IdSelectionSphere selSphereData;
-    selSphereData.radius = 0.25;
-    selSphereData.center[0] = 0.0;
-    selSphereData.center[1] = 0.0;
-    selSphereData.center[2] = 0.0;
+    sphexa::IdSelectionSphere selSphereData{0.0, 0.0, 0.0, 0.25};
 
-    std::vector<sphexa::LocalIndex> taggedIdxRef{444, 445, 454, 455, 544, 545, 554, 555};
-    std::vector<sphexa::LocalIndex> taggedIdx;
+    tagIdsRef[444]=18014398509482428ULL;
+    tagIdsRef[445]=18014398509482429ULL;
+    tagIdsRef[454]=18014398509482438ULL;
+    tagIdsRef[455]=18014398509482439ULL;
+    tagIdsRef[544]=18014398509482528ULL;
+    tagIdsRef[545]=18014398509482529ULL;
+    tagIdsRef[554]=18014398509482538ULL;
+    tagIdsRef[555]=18014398509482539ULL;
     sphexa::tagIdsInSphere(std::span<sphexa::IdType>(ids), x, y, z, 0, ids.size(), selSphereData);
-    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdx);
-    EXPECT_EQ(taggedIdx, taggedIdxRef);
-
+    EXPECT_EQ(ids, tagIdsRef);
 }
 
 TEST(IO, tagIdInSphereWithRange)
 {
     std::vector<sphexa::IdType> ids(1000);
     std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::IdType> tagIdsRef = ids;
     sphexa::LocalIndex first = 400;
     sphexa::LocalIndex last = 500;
 
@@ -136,19 +187,14 @@ TEST(IO, tagIdInSphereWithRange)
     makeParticleDistribution(x, y, z, 1000);
 
     // Selection sphere definition
-    sphexa::IdSelectionSphere selSphereData;
-    selSphereData.radius = 0.25;
-    selSphereData.center[0] = 0.0;
-    selSphereData.center[1] = 0.0;
-    selSphereData.center[2] = 0.0;
+    sphexa::IdSelectionSphere selSphereData{0.0, 0.0, 0.0, 0.25};
 
-
-    std::vector<sphexa::LocalIndex> taggedIdxRef = {444, 445, 454, 455};
-    std::vector<sphexa::LocalIndex> taggedIdx;
+    tagIdsRef[444]=18014398509482428ULL;
+    tagIdsRef[445]=18014398509482429ULL;
+    tagIdsRef[454]=18014398509482438ULL;
+    tagIdsRef[455]=18014398509482439ULL;
     sphexa::tagIdsInSphere(std::span<sphexa::IdType>(ids), x, y, z, first, last, selSphereData);
-    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdx);
-    EXPECT_EQ(taggedIdx, taggedIdxRef);
-
+    EXPECT_EQ(ids, tagIdsRef);
 }
 
 TEST(IO, taggedIdIdentification)
@@ -159,7 +205,7 @@ TEST(IO, taggedIdIdentification)
 
     std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = ids[idPos] | sphexa::msbMask;
+        sphexa::applyTaggingMask(0, ids[idPos]);
     });
 
     sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
@@ -176,7 +222,7 @@ TEST(IO, taggedIdIdentificationWithRange)
 
     std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = ids[idPos] | sphexa::msbMask;
+        sphexa::applyTaggingMask(1, ids[idPos]);
     });
     std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
@@ -197,7 +243,7 @@ TEST(IO, taggedIdIdentificationWithRangeStart)
 
     std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = ids[idPos] | sphexa::msbMask;
+        sphexa::applyTaggingMask(2, ids[idPos]);
     });
     std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
@@ -218,7 +264,7 @@ TEST(IO, taggedIdIdentificationWithRangeEnd)
 
     std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = ids[idPos] | sphexa::msbMask;
+        sphexa::applyTaggingMask(3, ids[idPos]);
     });
     std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
@@ -236,7 +282,7 @@ TEST(IO, taggedIdIdentificationSingleStart)
     std::vector<sphexa::LocalIndex> taggedIdPos;
 
     std::vector<sphexa::LocalIndex> taggedIdPosRef = {0};
-    ids[0] = ids[0] | sphexa::msbMask;
+    sphexa::applyTaggingMask(4, ids[0]);
 
     sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
@@ -249,7 +295,7 @@ TEST(IO, taggedIdIdentificationSingleEnd)
     std::vector<sphexa::LocalIndex> taggedIdPos;
 
     std::vector<sphexa::LocalIndex> taggedIdPosRef = {99};
-    ids[99] = ids[99] | sphexa::msbMask;
+    sphexa::applyTaggingMask(5, ids[99]);
 
     sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -30,6 +30,7 @@
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */
 
+#include <algorithm>
 #include <numeric>
 #include <vector>
 

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -1,0 +1,256 @@
+/*
+ * MIT License
+ *
+ * SPH-EXA
+ * Copyright (c) 2024 CSCS, ETH Zurich, University of Basel, University of Zurich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+ /*! @file
+ * @brief Unit tests for id tagging related functionality
+ *
+ * @author Christopher Bignamini <christopher.bignamini@gmail.com>
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#include <numeric>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "io/id_tag_utils.hpp"
+
+void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x,
+                              std::vector<sphexa::CoordinateType>& y,
+                              std::vector<sphexa::CoordinateType>& z,
+                              size_t numParticles)
+{
+    x.resize(numParticles);
+    y.resize(numParticles);
+    z.resize(numParticles);
+
+    unsigned int gridSize = std::cbrt(numParticles);
+    double step = 2.0 / (gridSize - 1);
+    unsigned int index = 0;
+    for (unsigned int i = 0; i < gridSize; ++i) {
+        for (unsigned int j = 0; j < gridSize; ++j) {
+            for (unsigned int k = 0; k < gridSize; ++k) {
+                if (index >= numParticles) break;
+                x[index] = -1.0 + i * step;
+                y[index] = -1.0 + j * step;
+                z[index] = -1.0 + k * step;
+                ++index;
+            }
+        }
+    }
+}
+
+TEST(IO, tagIdInList)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::IdType> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<sphexa::IdType> tagIdsRef = ids;
+    tagIdsRef[0] = 9223372036854775808ULL;
+    tagIdsRef[1] = 9223372036854775809ULL;
+    tagIdsRef[2] = 9223372036854775810ULL;
+    tagIdsRef[3] = 9223372036854775811ULL;
+    tagIdsRef[6] = 9223372036854775814ULL;
+    tagIdsRef[11] = 9223372036854775819ULL;
+    tagIdsRef[13] = 9223372036854775821ULL;
+    tagIdsRef[23] = 9223372036854775831ULL;
+    tagIdsRef[71] = 9223372036854775879ULL;
+    tagIdsRef[83] = 9223372036854775891ULL;
+    tagIdsRef[91] = 9223372036854775899ULL;
+    tagIdsRef[95] = 9223372036854775903ULL;
+    tagIdsRef[99] = 9223372036854775907ULL;
+
+    sphexa::tagIdsInList(std::span<sphexa::IdType>(ids), 0, ids.size(), std::span<const sphexa::IdType>(selectedIds));
+    EXPECT_EQ(ids, tagIdsRef);
+}
+
+TEST(IO, tagIdInListWithRange)
+{
+    sphexa::LocalIndex first = 3;
+    sphexa::LocalIndex last = 10;
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::IdType> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<sphexa::IdType> tagIdsRef = ids;
+    tagIdsRef[3] = 9223372036854775811ULL;
+    tagIdsRef[6] = 9223372036854775814ULL;
+
+    sphexa::tagIdsInList(std::span<sphexa::IdType>(ids), first, last, std::span<const sphexa::IdType>(selectedIds));
+    EXPECT_EQ(ids, tagIdsRef);
+}
+
+TEST(IO, tagIdInSphere)
+{
+    std::vector<sphexa::IdType> ids(1000);
+    std::iota(ids.begin(), ids.end(), 0);
+
+    // Particle distribution creation
+    std::vector<sphexa::CoordinateType> x, y, z;
+    makeParticleDistribution(x, y, z, 1000);
+
+    // Selection sphere definition
+    sphexa::IdSelectionSphere selSphereData;
+    selSphereData.radius = 0.25;
+    selSphereData.center[0] = 0.0;
+    selSphereData.center[1] = 0.0;
+    selSphereData.center[2] = 0.0;
+
+    std::vector<sphexa::LocalIndex> taggedIdxRef{444, 445, 454, 455, 544, 545, 554, 555};
+    std::vector<sphexa::LocalIndex> taggedIdx;
+    sphexa::tagIdsInSphere(std::span<sphexa::IdType>(ids), x, y, z, 0, ids.size(), selSphereData);
+    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdx);
+    EXPECT_EQ(taggedIdx, taggedIdxRef);
+
+}
+
+TEST(IO, tagIdInSphereWithRange)
+{
+    std::vector<sphexa::IdType> ids(1000);
+    std::iota(ids.begin(), ids.end(), 0);
+    sphexa::LocalIndex first = 400;
+    sphexa::LocalIndex last = 500;
+
+    // Particle distribution creation
+    std::vector<sphexa::CoordinateType> x, y, z;
+    makeParticleDistribution(x, y, z, 1000);
+
+    // Selection sphere definition
+    sphexa::IdSelectionSphere selSphereData;
+    selSphereData.radius = 0.25;
+    selSphereData.center[0] = 0.0;
+    selSphereData.center[1] = 0.0;
+    selSphereData.center[2] = 0.0;
+
+
+    std::vector<sphexa::LocalIndex> taggedIdxRef = {444, 445, 454, 455};
+    std::vector<sphexa::LocalIndex> taggedIdx;
+    sphexa::tagIdsInSphere(std::span<sphexa::IdType>(ids), x, y, z, first, last, selSphereData);
+    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdx);
+    EXPECT_EQ(taggedIdx, taggedIdxRef);
+
+}
+
+TEST(IO, taggedIdIdentification)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+
+    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
+        ids[idPos] = ids[idPos] | sphexa::msbMask;
+    });
+
+    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+}
+
+TEST(IO, taggedIdIdentificationWithRange)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+    sphexa::LocalIndex first = 3;
+    sphexa::LocalIndex last = 10;
+
+    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
+        ids[idPos] = ids[idPos] | sphexa::msbMask;
+    });
+    std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
+        return idPos >= first && idPos < last;
+    });
+
+    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), first, last, taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+}
+
+TEST(IO, taggedIdIdentificationWithRangeStart)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+    sphexa::LocalIndex first = 0;
+    sphexa::LocalIndex last = 3;
+
+    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
+        ids[idPos] = ids[idPos] | sphexa::msbMask;
+    });
+    std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
+        return idPos >= first && idPos < last;
+    });
+
+    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), first, last, taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+}
+
+TEST(IO, taggedIdIdentificationWithRangeEnd)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+    sphexa::LocalIndex first = 97;
+    sphexa::LocalIndex last = 100;
+
+    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
+        ids[idPos] = ids[idPos] | sphexa::msbMask;
+    });
+    std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
+        return idPos >= first && idPos < last;
+    });
+
+    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), first, last, taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+}
+
+TEST(IO, taggedIdIdentificationSingleStart)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+
+    std::vector<sphexa::LocalIndex> taggedIdPosRef = {0};
+    ids[0] = ids[0] | sphexa::msbMask;
+
+    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+}
+
+TEST(IO, taggedIdIdentificationSingleEnd)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+
+    std::vector<sphexa::LocalIndex> taggedIdPosRef = {99};
+    ids[99] = ids[99] | sphexa::msbMask;
+
+    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+}

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -63,58 +63,57 @@ void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x,
 
 TEST(IO, applyTaggingMaskZero)
 {
-    sphexa::IdType id = 0;
-    sphexa::IdType groupId = 0;
-    sphexa::IdType idRef = 18014398509481984ULL;
+    uint64_t id = 0;
+    uint64_t groupId = 0;
+    uint64_t idRef = 18014398509481984ULL;
     sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
 TEST(IO, applyTaggingMaskMaxGroup)
 {
-    sphexa::IdType id = 1;
-    sphexa::IdType groupId = sphexa::supGroupId - 1;
-    sphexa::IdType idRef = 18428729675200069633ULL;
+    uint64_t id = 1;
+    uint64_t groupId = sphexa::maxNumGroupIds - 1;
+    uint64_t idRef = 18428729675200069633ULL;
     sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
 TEST(IO, applyTaggingMaskMaxId)
 {
-    sphexa::IdType id = (sphexa::IdType(1) << (sizeof(sphexa::IdType)*8 - sphexa::taggingMaskSize)) - 1;
-    sphexa::IdType groupId = 0;
-    sphexa::IdType idRef = 36028797018963967;
+    uint64_t id = (uint64_t(1) << (sizeof(uint64_t)*8 - sphexa::tagNumBits)) - 1;
+    uint64_t groupId = 0;
+    uint64_t idRef = 36028797018963967;
     sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
 TEST(IO, applyTaggingMaskMaxIdMaxGroup)
 {
-    sphexa::IdType id = (sphexa::IdType(1) << (sizeof(sphexa::IdType)*8 - sphexa::taggingMaskSize)) - 1;
-    sphexa::IdType groupId = sphexa::supGroupId - 1;
-    sphexa::IdType idRef = 18446744073709551615ULL;
+    uint64_t id = (uint64_t(1) << (sizeof(uint64_t)*8 - sphexa::tagNumBits)) - 1;
+    uint64_t groupId = sphexa::maxNumGroupIds - 1;
+    uint64_t idRef = 18446744073709551615ULL;
     sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
 TEST(IO, applyTaggingMaskTwice)
 {
-    sphexa::IdType id = 0;
-    sphexa::IdType groupId = 0;
-    sphexa::IdType idRef = 36028797018963968ULL;
+    uint64_t id = 0;
+    uint64_t groupId = 0;
+    uint64_t idRef = 36028797018963968ULL;
     sphexa::applyTaggingMask(groupId, id);
     groupId = 1;
     sphexa::applyTaggingMask(groupId, id);
     EXPECT_EQ(id, idRef);
 }
 
-
 TEST(IO, tagIdInList)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::IdType> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::vector<sphexa::IdType> tagIdsRef = ids;
+    sphexa::IdSelectionList selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint64_t> tagIdsRef = ids;
     tagIdsRef[0] = 18014398509481984ULL;
     tagIdsRef[1] = 18014398509481985ULL;
     tagIdsRef[2] = 18014398509481986ULL;
@@ -129,31 +128,34 @@ TEST(IO, tagIdInList)
     tagIdsRef[95] = 18014398509482079ULL;
     tagIdsRef[99] = 18014398509482083ULL;
 
-    sphexa::tagIdsInList(std::span<sphexa::IdType>(ids), 0, ids.size(), std::span<const sphexa::IdType>(selectedIds));
+    std::vector<sphexa::IdSelectionList> selectedIdsLists{selectedIds};
+
+    sphexa::tagIdsInList(std::span<uint64_t>(ids), 0, ids.size(), std::span<const sphexa::IdSelectionList>(selectedIdsLists));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
 TEST(IO, tagIdInListWithRange)
 {
-    sphexa::LocalIndex first = 3;
-    sphexa::LocalIndex last = 10;
-    std::vector<sphexa::IdType> ids(100);
+    uint32_t first = 3;
+    uint32_t last = 10;
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    sphexa::IdType groupId = 1;
-    std::vector<sphexa::IdType> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::vector<sphexa::IdType> tagIdsRef = ids;
-    tagIdsRef[3] = 36028797018963971ULL;
-    tagIdsRef[6] = 36028797018963974ULL;
+    sphexa::IdSelectionList selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint64_t> tagIdsRef = ids;
+    tagIdsRef[3] = 18014398509481987ULL;
+    tagIdsRef[6] = 18014398509481990ULL;
 
-    sphexa::tagIdsInList(std::span<sphexa::IdType>(ids), first, last, std::span<const sphexa::IdType>(selectedIds), groupId);
+    std::vector<sphexa::IdSelectionList> selectedIdsLists{selectedIds};
+
+    sphexa::tagIdsInList(std::span<uint64_t>(ids), first, last, std::span<const sphexa::IdSelectionList>(selectedIdsLists));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
 TEST(IO, tagIdInSphere)
 {
-    std::vector<sphexa::IdType> ids(1000);
+    std::vector<uint64_t> ids(1000);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::IdType> tagIdsRef = ids;
+    std::vector<uint64_t> tagIdsRef = ids;
 
     // Particle distribution creation
     std::vector<sphexa::CoordinateType> x, y, z;
@@ -161,6 +163,7 @@ TEST(IO, tagIdInSphere)
 
     // Selection sphere definition
     sphexa::IdSelectionSphere selSphereData{0.0, 0.0, 0.0, 0.25};
+    std::vector<sphexa::IdSelectionSphere> selSphereDataVec{selSphereData};
 
     tagIdsRef[444]=18014398509482428ULL;
     tagIdsRef[445]=18014398509482429ULL;
@@ -170,17 +173,17 @@ TEST(IO, tagIdInSphere)
     tagIdsRef[545]=18014398509482529ULL;
     tagIdsRef[554]=18014398509482538ULL;
     tagIdsRef[555]=18014398509482539ULL;
-    sphexa::tagIdsInSphere(std::span<sphexa::IdType>(ids), x, y, z, 0, ids.size(), selSphereData);
+    sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, 0, ids.size(), std::span<const sphexa::IdSelectionSphere>(selSphereDataVec));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
 TEST(IO, tagIdInSphereWithRange)
 {
-    std::vector<sphexa::IdType> ids(1000);
+    std::vector<uint64_t> ids(1000);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::IdType> tagIdsRef = ids;
-    sphexa::LocalIndex first = 400;
-    sphexa::LocalIndex last = 500;
+    std::vector<uint64_t> tagIdsRef = ids;
+    uint32_t first = 400;
+    uint32_t last = 500;
 
     // Particle distribution creation
     std::vector<sphexa::CoordinateType> x, y, z;
@@ -188,115 +191,116 @@ TEST(IO, tagIdInSphereWithRange)
 
     // Selection sphere definition
     sphexa::IdSelectionSphere selSphereData{0.0, 0.0, 0.0, 0.25};
+    std::vector<sphexa::IdSelectionSphere> selSphereDataVec{selSphereData};
 
     tagIdsRef[444]=18014398509482428ULL;
     tagIdsRef[445]=18014398509482429ULL;
     tagIdsRef[454]=18014398509482438ULL;
     tagIdsRef[455]=18014398509482439ULL;
-    sphexa::tagIdsInSphere(std::span<sphexa::IdType>(ids), x, y, z, first, last, selSphereData);
+    sphexa::tagIdsInSphere(std::span<uint64_t>(ids), x, y, z, first, last, std::span<const sphexa::IdSelectionSphere>(selSphereDataVec));
     EXPECT_EQ(ids, tagIdsRef);
 }
 
 TEST(IO, taggedIdIdentification)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
+    std::vector<uint32_t> taggedIdPos;
 
-    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
         sphexa::applyTaggingMask(0, ids[idPos]);
     });
 
-    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
+    sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }
 
 TEST(IO, taggedIdIdentificationWithRange)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
-    sphexa::LocalIndex first = 3;
-    sphexa::LocalIndex last = 10;
+    std::vector<uint32_t> taggedIdPos;
+    uint32_t first = 3;
+    uint32_t last = 10;
 
-    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
         sphexa::applyTaggingMask(1, ids[idPos]);
     });
-    std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
+    std::vector<uint32_t> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
         return idPos >= first && idPos < last;
     });
 
-    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), first, last, taggedIdPos);
+    sphexa::findTaggedIds(std::span<const uint64_t>(ids), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationWithRangeStart)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
-    sphexa::LocalIndex first = 0;
-    sphexa::LocalIndex last = 3;
+    std::vector<uint32_t> taggedIdPos;
+    uint32_t first = 0;
+    uint32_t last = 3;
 
-    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
         sphexa::applyTaggingMask(2, ids[idPos]);
     });
-    std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
+    std::vector<uint32_t> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
         return idPos >= first && idPos < last;
     });
 
-    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), first, last, taggedIdPos);
+    sphexa::findTaggedIds(std::span<const uint64_t>(ids), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationWithRangeEnd)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
-    sphexa::LocalIndex first = 97;
-    sphexa::LocalIndex last = 100;
+    std::vector<uint32_t> taggedIdPos;
+    uint32_t first = 97;
+    uint32_t last = 100;
 
-    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
         sphexa::applyTaggingMask(3, ids[idPos]);
     });
-    std::vector<sphexa::LocalIndex> taggedIdPosRefRange;
+    std::vector<uint32_t> taggedIdPosRefRange;
     std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
         return idPos >= first && idPos < last;
     });
 
-    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), first, last, taggedIdPos);
+    sphexa::findTaggedIds(std::span<const uint64_t>(ids), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationSingleStart)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
+    std::vector<uint32_t> taggedIdPos;
 
-    std::vector<sphexa::LocalIndex> taggedIdPosRef = {0};
+    std::vector<uint32_t> taggedIdPosRef = {0};
     sphexa::applyTaggingMask(4, ids[0]);
 
-    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
+    sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }
 
 TEST(IO, taggedIdIdentificationSingleEnd)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
+    std::vector<uint32_t> taggedIdPos;
 
-    std::vector<sphexa::LocalIndex> taggedIdPosRef = {99};
+    std::vector<uint32_t> taggedIdPosRef = {99};
     sphexa::applyTaggingMask(5, ids[99]);
 
-    sphexa::findTaggedIds(std::span<const sphexa::IdType>(ids), 0, ids.size(), taggedIdPos);
+    sphexa::findTaggedIds(std::span<const uint64_t>(ids), 0, ids.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }

--- a/main/test/io/id_tag_utils_gpu.cu
+++ b/main/test/io/id_tag_utils_gpu.cu
@@ -38,27 +38,27 @@
 
 TEST(IO, taggedIdIdentificationGPU)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
+    std::vector<uint32_t> taggedIdPos;
 
-    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
         sphexa::applyTaggingMask(0, ids[idPos]);
     });
-    thrust::device_vector<sphexa::IdType> idsDev(ids);
+    thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }
 
 TEST(IO, taggedIdIdentificationWithRangeGPU)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
-    sphexa::LocalIndex first = 3;
-    sphexa::LocalIndex last = 10;
+    std::vector<uint32_t> taggedIdPos;
+    uint32_t first = 3;
+    uint32_t last = 10;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::vector<uint32_t> taggedIdPosRefRange;
@@ -68,19 +68,19 @@ TEST(IO, taggedIdIdentificationWithRangeGPU)
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
         sphexa::applyTaggingMask(1, ids[idPos]);
     });
-    thrust::device_vector<sphexa::IdType> idsDev(ids);
+    thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationWithRangeStartGPU)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
-    sphexa::LocalIndex first = 0;
-    sphexa::LocalIndex last = 3;
+    std::vector<uint32_t> taggedIdPos;
+    uint32_t first = 0;
+    uint32_t last = 3;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::vector<uint32_t> taggedIdPosRefRange;
@@ -90,19 +90,19 @@ TEST(IO, taggedIdIdentificationWithRangeStartGPU)
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
         sphexa::applyTaggingMask(2, ids[idPos]);
     });
-    thrust::device_vector<sphexa::IdType> idsDev(ids);
+    thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationWithRangeEndGPU)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
-    sphexa::LocalIndex first = 97;
-    sphexa::LocalIndex last = 100;
+    std::vector<uint32_t> taggedIdPos;
+    uint32_t first = 97;
+    uint32_t last = 100;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::vector<uint32_t> taggedIdPosRefRange;
@@ -112,36 +112,36 @@ TEST(IO, taggedIdIdentificationWithRangeEndGPU)
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
         sphexa::applyTaggingMask(3, ids[idPos]);
     });
-    thrust::device_vector<sphexa::IdType> idsDev(ids);
+    thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationSingleStartGPU)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
+    std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef{0};
     sphexa::applyTaggingMask(4, ids[0]);
-    thrust::device_vector<sphexa::IdType> idsDev(ids);
+    thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }
 
 TEST(IO, taggedIdIdentificationSingleEndGPU)
 {
-    std::vector<sphexa::IdType> ids(100);
+    std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<sphexa::LocalIndex> taggedIdPos;
+    std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef{99};
     sphexa::applyTaggingMask(5, ids[99]);
-    thrust::device_vector<sphexa::IdType> idsDev(ids);
+    thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }

--- a/main/test/io/id_tag_utils_gpu.cu
+++ b/main/test/io/id_tag_utils_gpu.cu
@@ -44,7 +44,7 @@ TEST(IO, taggedIdIdentificationGPU)
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        sphexa::applyTaggingMask(0, ids[idPos]);
+        ids[idPos] = sphexa::applyTaggingMask(0, ids[idPos]);
     });
     thrust::device_vector<uint64_t> idsDev(ids);
 
@@ -66,7 +66,7 @@ TEST(IO, taggedIdIdentificationWithRangeGPU)
         return idPos >= first && idPos < last;
     });
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        sphexa::applyTaggingMask(1, ids[idPos]);
+        ids[idPos] = sphexa::applyTaggingMask(1, ids[idPos]);
     });
     thrust::device_vector<uint64_t> idsDev(ids);
 
@@ -88,7 +88,7 @@ TEST(IO, taggedIdIdentificationWithRangeStartGPU)
         return idPos >= first && idPos < last;
     });
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        sphexa::applyTaggingMask(2, ids[idPos]);
+        ids[idPos] = sphexa::applyTaggingMask(2, ids[idPos]);
     });
     thrust::device_vector<uint64_t> idsDev(ids);
 
@@ -110,7 +110,7 @@ TEST(IO, taggedIdIdentificationWithRangeEndGPU)
         return idPos >= first && idPos < last;
     });
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        sphexa::applyTaggingMask(3, ids[idPos]);
+        ids[idPos] = sphexa::applyTaggingMask(3, ids[idPos]);
     });
     thrust::device_vector<uint64_t> idsDev(ids);
 
@@ -125,7 +125,7 @@ TEST(IO, taggedIdIdentificationSingleStartGPU)
     std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef{0};
-    sphexa::applyTaggingMask(4, ids[0]);
+    ids[0] = sphexa::applyTaggingMask(4, ids[0]);
     thrust::device_vector<uint64_t> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
@@ -139,7 +139,7 @@ TEST(IO, taggedIdIdentificationSingleEndGPU)
     std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef{99};
-    sphexa::applyTaggingMask(5, ids[99]);
+    ids[99] = sphexa::applyTaggingMask(5, ids[99]);
     thrust::device_vector<uint64_t> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);

--- a/main/test/io/id_tag_utils_gpu.cu
+++ b/main/test/io/id_tag_utils_gpu.cu
@@ -1,0 +1,147 @@
+/*
+ * MIT License
+ *
+ * SPH-EXA
+ * Copyright (c) 2024 CSCS, ETH Zurich, University of Basel, University of Zurich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief Unit tests for id tagging related functionality, GPU version
+ *
+ * @author Christopher Bignamini <christopher.bignamini@gmail.com>
+ */
+
+#include <vector>
+
+#include <thrust/device_vector.h>
+
+#include "gtest/gtest.h"
+#include "io/id_tag_utils.hpp"
+
+TEST(IO, taggedIdIdentificationGPU)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+
+    std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
+        ids[idPos] = ids[idPos] | sphexa::msbMask;
+    });
+    thrust::device_vector<sphexa::IdType> idsDev(ids);
+
+    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+}
+
+TEST(IO, taggedIdIdentificationWithRangeGPU)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+    sphexa::LocalIndex first = 3;
+    sphexa::LocalIndex last = 10;
+
+    std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint32_t> taggedIdPosRefRange;
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
+        return idPos >= first && idPos < last;
+    });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
+        ids[idPos] = ids[idPos] | sphexa::msbMask;
+    });
+    thrust::device_vector<sphexa::IdType> idsDev(ids);
+
+    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+}
+
+TEST(IO, taggedIdIdentificationWithRangeStartGPU)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+    sphexa::LocalIndex first = 0;
+    sphexa::LocalIndex last = 3;
+
+    std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint32_t> taggedIdPosRefRange;
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
+        return idPos >= first && idPos < last;
+    });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
+        ids[idPos] = ids[idPos] | sphexa::msbMask;
+    });
+    thrust::device_vector<sphexa::IdType> idsDev(ids);
+
+    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+}
+
+TEST(IO, taggedIdIdentificationWithRangeEndGPU)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+    sphexa::LocalIndex first = 97;
+    sphexa::LocalIndex last = 100;
+
+    std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<uint32_t> taggedIdPosRefRange;
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
+        return idPos >= first && idPos < last;
+    });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
+        ids[idPos] = ids[idPos] | sphexa::msbMask;
+    });
+    thrust::device_vector<sphexa::IdType> idsDev(ids);
+
+    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+}
+
+TEST(IO, taggedIdIdentificationSingleStartGPU)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+
+    std::vector<uint32_t> taggedIdPosRef{0};
+    ids[0] = ids[0] | sphexa::msbMask;
+    thrust::device_vector<sphexa::IdType> idsDev(ids);
+
+    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+}
+
+TEST(IO, taggedIdIdentificationSingleEndGPU)
+{
+    std::vector<sphexa::IdType> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<sphexa::LocalIndex> taggedIdPos;
+
+    std::vector<uint32_t> taggedIdPosRef{99};
+    ids[99] = ids[99] | sphexa::msbMask;
+    thrust::device_vector<sphexa::IdType> idsDev(ids);
+
+    sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+}

--- a/main/test/io/id_tag_utils_gpu.cu
+++ b/main/test/io/id_tag_utils_gpu.cu
@@ -44,7 +44,7 @@ TEST(IO, taggedIdIdentificationGPU)
 
     std::vector<sphexa::LocalIndex> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = ids[idPos] | sphexa::msbMask;
+        sphexa::applyTaggingMask(0, ids[idPos]);
     });
     thrust::device_vector<sphexa::IdType> idsDev(ids);
 
@@ -66,7 +66,7 @@ TEST(IO, taggedIdIdentificationWithRangeGPU)
         return idPos >= first && idPos < last;
     });
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = ids[idPos] | sphexa::msbMask;
+        sphexa::applyTaggingMask(1, ids[idPos]);
     });
     thrust::device_vector<sphexa::IdType> idsDev(ids);
 
@@ -88,7 +88,7 @@ TEST(IO, taggedIdIdentificationWithRangeStartGPU)
         return idPos >= first && idPos < last;
     });
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = ids[idPos] | sphexa::msbMask;
+        sphexa::applyTaggingMask(2, ids[idPos]);
     });
     thrust::device_vector<sphexa::IdType> idsDev(ids);
 
@@ -110,7 +110,7 @@ TEST(IO, taggedIdIdentificationWithRangeEndGPU)
         return idPos >= first && idPos < last;
     });
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = ids[idPos] | sphexa::msbMask;
+        sphexa::applyTaggingMask(3, ids[idPos]);
     });
     thrust::device_vector<sphexa::IdType> idsDev(ids);
 
@@ -125,7 +125,7 @@ TEST(IO, taggedIdIdentificationSingleStartGPU)
     std::vector<sphexa::LocalIndex> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef{0};
-    ids[0] = ids[0] | sphexa::msbMask;
+    sphexa::applyTaggingMask(4, ids[0]);
     thrust::device_vector<sphexa::IdType> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
@@ -139,7 +139,7 @@ TEST(IO, taggedIdIdentificationSingleEndGPU)
     std::vector<sphexa::LocalIndex> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef{99};
-    ids[99] = ids[99] | sphexa::msbMask;
+    sphexa::applyTaggingMask(5, ids[99]);
     thrust::device_vector<sphexa::IdType> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const sphexa::IdType>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);

--- a/main/test/io/id_tag_utils_gpu.cu
+++ b/main/test/io/id_tag_utils_gpu.cu
@@ -29,6 +29,8 @@
  * @author Christopher Bignamini <christopher.bignamini@gmail.com>
  */
 
+#include <algorithm>
+#include <numeric>
 #include <vector>
 
 #include <thrust/device_vector.h>

--- a/main/test/io/id_tag_utils_gpu.cu
+++ b/main/test/io/id_tag_utils_gpu.cu
@@ -45,12 +45,12 @@ TEST(IO, taggedIdIdentificationGPU)
     std::vector<uint32_t> taggedIdPos;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
-    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = sphexa::applyTaggingMask(0, ids[idPos]);
-    });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
+                  [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(0, ids[idPos]); });
     thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0,
+                             idsDev.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }
 
@@ -59,20 +59,19 @@ TEST(IO, taggedIdIdentificationWithRangeGPU)
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     std::vector<uint32_t> taggedIdPos;
-    uint32_t first = 3;
-    uint32_t last = 10;
+    uint32_t              first = 3;
+    uint32_t              last  = 10;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::vector<uint32_t> taggedIdPosRefRange;
-    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
-        return idPos >= first && idPos < last;
-    });
-    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = sphexa::applyTaggingMask(1, ids[idPos]);
-    });
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange),
+                 [first, last](auto idPos) { return idPos >= first && idPos < last; });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
+                  [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(1, ids[idPos]); });
     thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first,
+                             last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
@@ -81,20 +80,19 @@ TEST(IO, taggedIdIdentificationWithRangeStartGPU)
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     std::vector<uint32_t> taggedIdPos;
-    uint32_t first = 0;
-    uint32_t last = 3;
+    uint32_t              first = 0;
+    uint32_t              last  = 3;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::vector<uint32_t> taggedIdPosRefRange;
-    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
-        return idPos >= first && idPos < last;
-    });
-    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = sphexa::applyTaggingMask(2, ids[idPos]);
-    });
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange),
+                 [first, last](auto idPos) { return idPos >= first && idPos < last; });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
+                  [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(2, ids[idPos]); });
     thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first,
+                             last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
@@ -103,20 +101,19 @@ TEST(IO, taggedIdIdentificationWithRangeEndGPU)
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
     std::vector<uint32_t> taggedIdPos;
-    uint32_t first = 97;
-    uint32_t last = 100;
+    uint32_t              first = 97;
+    uint32_t              last  = 100;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::vector<uint32_t> taggedIdPosRefRange;
-    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange), [first, last](auto idPos){
-        return idPos >= first && idPos < last;
-    });
-    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(), [&ids = ids](auto idPos){
-        ids[idPos] = sphexa::applyTaggingMask(3, ids[idPos]);
-    });
+    std::copy_if(taggedIdPosRef.begin(), taggedIdPosRef.end(), std::back_inserter(taggedIdPosRefRange),
+                 [first, last](auto idPos) { return idPos >= first && idPos < last; });
+    std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
+                  [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(3, ids[idPos]); });
     thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last, taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first,
+                             last, taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
 }
 
@@ -130,7 +127,8 @@ TEST(IO, taggedIdIdentificationSingleStartGPU)
     ids[0] = sphexa::applyTaggingMask(4, ids[0]);
     thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0,
+                             idsDev.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }
 
@@ -144,6 +142,7 @@ TEST(IO, taggedIdIdentificationSingleEndGPU)
     ids[99] = sphexa::applyTaggingMask(5, ids[99]);
     thrust::device_vector<uint64_t> idsDev(ids);
 
-    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(), taggedIdPos);
+    sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0,
+                             idsDev.size(), taggedIdPos);
     EXPECT_EQ(taggedIdPos, taggedIdPosRef);
 }

--- a/main/test/io/id_tag_utils_gpu.cu
+++ b/main/test/io/id_tag_utils_gpu.cu
@@ -35,6 +35,8 @@
 
 #include <thrust/device_vector.h>
 
+#include "cstone/cuda/device_vector.h"
+#include "cstone/cuda/cuda_utils.cuh"
 #include "gtest/gtest.h"
 #include "io/id_tag_utils.hpp"
 
@@ -42,23 +44,22 @@ TEST(IO, taggedIdIdentificationGPU)
 {
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<uint32_t> taggedIdPos;
+    cstone::DeviceVector<uint32_t> taggedIdPosDev;
 
     std::vector<uint32_t> taggedIdPosRef{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
     std::for_each(taggedIdPosRef.begin(), taggedIdPosRef.end(),
                   [&ids = ids](auto idPos) { ids[idPos] = sphexa::applyTaggingMask(0, ids[idPos]); });
     thrust::device_vector<uint64_t> idsDev(ids);
-
     sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0,
-                             idsDev.size(), taggedIdPos);
-    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+                             idsDev.size(), taggedIdPosDev);
+    EXPECT_EQ(toHost(taggedIdPosDev), taggedIdPosRef);
 }
 
 TEST(IO, taggedIdIdentificationWithRangeGPU)
 {
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<uint32_t> taggedIdPos;
+    cstone::DeviceVector<uint32_t> taggedIdPosDev;
     uint32_t              first = 3;
     uint32_t              last  = 10;
 
@@ -71,15 +72,15 @@ TEST(IO, taggedIdIdentificationWithRangeGPU)
     thrust::device_vector<uint64_t> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first,
-                             last, taggedIdPos);
-    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+                             last, taggedIdPosDev);
+    EXPECT_EQ(toHost(taggedIdPosDev), taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationWithRangeStartGPU)
 {
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<uint32_t> taggedIdPos;
+    cstone::DeviceVector<uint32_t> taggedIdPosDev;
     uint32_t              first = 0;
     uint32_t              last  = 3;
 
@@ -92,15 +93,15 @@ TEST(IO, taggedIdIdentificationWithRangeStartGPU)
     thrust::device_vector<uint64_t> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first,
-                             last, taggedIdPos);
-    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+                             last, taggedIdPosDev);
+    EXPECT_EQ(toHost(taggedIdPosDev), taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationWithRangeEndGPU)
 {
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<uint32_t> taggedIdPos;
+    cstone::DeviceVector<uint32_t> taggedIdPosDev;
     uint32_t              first = 97;
     uint32_t              last  = 100;
 
@@ -113,36 +114,36 @@ TEST(IO, taggedIdIdentificationWithRangeEndGPU)
     thrust::device_vector<uint64_t> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first,
-                             last, taggedIdPos);
-    EXPECT_EQ(taggedIdPos, taggedIdPosRefRange);
+                             last, taggedIdPosDev);
+    EXPECT_EQ(toHost(taggedIdPosDev), taggedIdPosRefRange);
 }
 
 TEST(IO, taggedIdIdentificationSingleStartGPU)
 {
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<uint32_t> taggedIdPos;
+    cstone::DeviceVector<uint32_t> taggedIdPosDev;
 
     std::vector<uint32_t> taggedIdPosRef{0};
     ids[0] = sphexa::applyTaggingMask(4, ids[0]);
     thrust::device_vector<uint64_t> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0,
-                             idsDev.size(), taggedIdPos);
-    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+                             idsDev.size(), taggedIdPosDev);
+    EXPECT_EQ(toHost(taggedIdPosDev), taggedIdPosRef);
 }
 
 TEST(IO, taggedIdIdentificationSingleEndGPU)
 {
     std::vector<uint64_t> ids(100);
     std::iota(ids.begin(), ids.end(), 0);
-    std::vector<uint32_t> taggedIdPos;
+    cstone::DeviceVector<uint32_t> taggedIdPosDev;
 
     std::vector<uint32_t> taggedIdPosRef{99};
     ids[99] = sphexa::applyTaggingMask(5, ids[99]);
     thrust::device_vector<uint64_t> idsDev(ids);
 
     sphexa::findTaggedIdsGPU(std::span<const uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0,
-                             idsDev.size(), taggedIdPos);
-    EXPECT_EQ(taggedIdPos, taggedIdPosRef);
+                             idsDev.size(), taggedIdPosDev);
+    EXPECT_EQ(toHost(taggedIdPosDev), taggedIdPosRef);
 }


### PR DESCRIPTION
This PR contains the basic id tagging and finding components of the particles_subset_gpu branch (https://github.com/sphexa-org/sphexa/pull/483) with the corresponding unit tests. At this stage the id tagging/finding feature is not part of a SPH-EXA run: that part will be included in a following PR. 

@sekelle, as you can see there are two implementations for tagged ids finding in the .cpu e .cu files: I temporarily left in the code two old implementations because they seem to be faster, at least on a "synthetic" set of ids. I can just keep the one you proposed for the CPU implementation and is GPU counterpart, implementing the same strategy, and work on the performances in a later stage.  