### PR TITLE
Update CMake CUDA architectures in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ The code requires a **C++20 compiler** for both the CPU and GPU parts.
 * CUDA 12 and later
 * ROCm 6 and later. ROCm 5 compiles, but has bugs preventing the reliable use of GPU-aware-MPI
 
+#### Check your GPU compute capability
+In you need to specify the compute capability of your GPUs, you can look them up here: [https://developer.nvidia.com/cuda-gpus](https://developer.nvidia.com/cuda-gpus)
+
 #### Compilation
 
 Minimal CMake configuration:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ ml CUDA/12.8.0
 
 mkdir build
 cd build
-cmake -DCMAKE_CUDA_ARCHITECTURES="80;85;90" <GIT_SOURCE_DIR>
+cmake -DCMAKE_CUDA_ARCHITECTURES="80;90" <GIT_SOURCE_DIR>
 ```
 CMake configuration on Daint on Alps:
 **CUDA 12.6 + GCC 13.3**:


### PR DESCRIPTION
Removed architecture '85' from CMake configuration.