### PR TITLE
Custom MPI reduction

### DIFF
--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -69,9 +69,6 @@ public:
             d_csTree_     = leaves_;
             d_nodeCounts_ = nodeCounts_;
             buildOctreeGpu(d_csTree_.data(), tree_.data());
-
-            hostTree_.resize(nNodes(leaves_));
-            updateInternalTree<KeyType>(leaves_, hostTree_.data());
         }
         else { updateInternalTree<KeyType>(leaves_, tree_.data()); }
     }
@@ -125,10 +122,10 @@ public:
 
         if constexpr (gpu)
         {
-            hostTree_.resize(tree_.numLeafNodes);
-            memcpyD2H(tree_.prefixes.data(), tree_.prefixes.size(), hostTree_.prefixes.data());
-            memcpyD2H(tree_.childOffsets.data(), tree_.childOffsets.size(), hostTree_.childOffsets.data());
-            std::copy_n(tree_.levelRange.data(), tree_.levelRange.size(), hostTree_.levelRange.data());
+            reallocate(leaves_, d_csTree_.size(), growthRate_);
+            reallocate(nodeCounts_, d_nodeCounts_.size(), growthRate_);
+            memcpyD2H(d_csTree_.data(), d_csTree_.size(), leaves_.data());
+            memcpyD2H(d_nodeCounts_.data(), d_nodeCounts_.size(), nodeCounts_.data());
         }
 
         auto newAssignment = makeSfcAssignment(numRanks_, nodeCounts_, leaves_.data());
@@ -229,26 +226,12 @@ public:
         else { return nodeCounts_; }
     }
 
-    /*! @brief the octree, internal part and leaves
-     *
-     * All data is on the host, except treeData.leaves which is on the GPU if gpu == true
-     */
+    //! @brief the octree, internal part and leaves. All data is on the GPU, when gpu == true
     OctreeView<const KeyType> octree() const
     {
         auto treeData   = tree_.cdata();
         treeData.leaves = treeLeaves().data();
         return treeData;
-    }
-
-    OctreeView<const KeyType> octreeHost() const
-    {
-        if constexpr (gpu)
-        {
-            auto treeData   = hostTree_.cdata();
-            treeData.leaves = leaves_.data();
-            return treeData;
-        }
-        else { return octree(); }
     }
 
     //! @brief the global coordinate bounding box
@@ -291,7 +274,6 @@ private:
 
     //! @brief the fully linked octree
     OctreeData<KeyType, Accelerator> tree_;
-    OctreeData<KeyType, CpuTag> hostTree_;
     std::vector<KeyType> leaves_;
     AccVector<KeyType> d_csTree_;
 

--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -114,12 +114,12 @@ public:
         sequence<gpu>(o1.start, numPart, reorderFunctor.getBuf(), growthRate_);
         sortByKey<gpu>(keyView, std::span{reorderFunctor.getMap() + o1.start, keyView.size()}, s0, s1, growthRate_);
 
-        updateOctreeGlobal<KeyType>(keyView, bucketSize_, tree_, leaves_, d_csTree_, nodeCounts_, d_nodeCounts_);
+        updateOctreeGlobal<KeyType>(keyView, bucketSize_, tree_, leaves_, d_csTree_, nodeCounts_, d_nodeCounts_, false);
         if (firstCall_)
         {
             firstCall_ = false;
             while (!updateOctreeGlobal<KeyType>(keyView, bucketSize_, tree_, leaves_, d_csTree_, nodeCounts_,
-                                                d_nodeCounts_))
+                                                d_nodeCounts_, true))
                 ;
         }
 

--- a/domain/include/cstone/tree/update_mpi_gpu.cuh
+++ b/domain/include/cstone/tree/update_mpi_gpu.cuh
@@ -28,6 +28,18 @@
 namespace cstone
 {
 
+inline void summax(void* inP, void* inoutP, int* len, MPI_Datatype*)
+{
+    auto* in    = reinterpret_cast<unsigned*>(inP);
+    auto* inout = reinterpret_cast<unsigned*>(inoutP);
+    for (int i = 0; i < *len; ++i)
+    {
+        auto a   = in[i];
+        auto b   = inout[i];
+        inout[i] = std::max(a + b, std::max(a, b));
+    }
+}
+
 /*! @brief global update step of an octree, including regeneration of the internal node structure
  *
  * @tparam        KeyType     unsigned 32- or 64-bit integer
@@ -69,7 +81,10 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
     computeNodeCountsGpu(rawPtr(d_csTree), d_counts.data(), numLeafNodes, keys, maxCount, true);
 
     syncGpu();
-    mpiAllreduceGpuDirect(d_counts.data(), d_countsRed.data(), d_counts.size(), MPI_SUM, MPI_COMM_WORLD);
+    MPI_Op limitSum;
+    MPI_Op_create(&summax, true, &limitSum);
+    mpiAllreduceGpuDirect(d_counts.data(), d_countsRed.data(), d_counts.size(), limitSum, MPI_COMM_WORLD);
+    MPI_Op_free(&limitSum);
     sequenceMax(d_counts.data(), d_counts.data() + d_counts.size(), d_countsRed.data(), d_counts.data());
 
     reallocate(counts, numLeafNodes, 1.01);

--- a/domain/include/cstone/tree/update_mpi_gpu.cuh
+++ b/domain/include/cstone/tree/update_mpi_gpu.cuh
@@ -53,9 +53,7 @@ template<class KeyType, class DevKeyVec, class DevCountVec>
 bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
                            unsigned bucketSize,
                            OctreeData<KeyType, GpuTag>& tree,
-                           std::vector<KeyType>& leaves,
                            DevKeyVec& d_csTree,
-                           std::vector<unsigned>& counts,
                            DevCountVec& d_countsBuf,
                            bool firstCall)
 {
@@ -69,10 +67,6 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
 
     tree.resize(newNumNodes);
     buildOctreeGpu(d_csTree.data(), tree.data());
-
-    counts.resize(tree.numLeafNodes);
-    reallocate(leaves, tree.numLeafNodes + 1, 1.01);
-    memcpyD2H(d_csTree.data(), d_csTree.size(), leaves.data());
 
     size_t numLeafNodes = tree.numLeafNodes;
     auto [d_counts, d_countsRed] =
@@ -90,9 +84,6 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
     }
     else { mpiAllreduceGpuDirect(d_counts.data(), d_countsRed.data(), d_counts.size(), MPI_SUM, MPI_COMM_WORLD); }
     sequenceMax(d_counts.data(), d_counts.data() + d_counts.size(), d_countsRed.data(), d_counts.data());
-
-    reallocate(counts, numLeafNodes, 1.01);
-    memcpyD2H(d_counts.data(), d_counts.size(), counts.data());
     d_countsBuf.resize(numLeafNodes);
 
     return converged;
@@ -110,7 +101,7 @@ bool updateOctreeGlobal(std::span<const KeyType> keys,
 {
     if constexpr (HaveGpu<Accelerator>{})
     {
-        return updateOctreeGlobalGpu(keys, bucketSize, tree, leaves, d_csTree, counts, d_counts, firstCall);
+        return updateOctreeGlobalGpu(keys, bucketSize, tree, d_csTree, d_counts, firstCall);
     }
     else { return updateOctreeGlobal(keys, bucketSize, tree, leaves, counts); }
 }

--- a/domain/include/cstone/tree/update_mpi_gpu.cuh
+++ b/domain/include/cstone/tree/update_mpi_gpu.cuh
@@ -28,7 +28,8 @@
 namespace cstone
 {
 
-inline void summax(void* inP, void* inoutP, int* len, MPI_Datatype*)
+//! @brief sum reduction like MPI_SUM, but cap maximum values before they overflow
+inline void sumCapped(void* inP, void* inoutP, int* len, MPI_Datatype*)
 {
     auto* in    = reinterpret_cast<unsigned*>(inP);
     auto* inout = reinterpret_cast<unsigned*>(inoutP);
@@ -36,18 +37,20 @@ inline void summax(void* inP, void* inoutP, int* len, MPI_Datatype*)
     {
         auto a   = in[i];
         auto b   = inout[i];
-        inout[i] = std::max(a + b, std::max(a, b));
+        inout[i] = a + b >= std::max(a, b) ? a + b : std::numeric_limits<unsigned>::max();
     }
 }
 
 /*! @brief global update step of an octree, including regeneration of the internal node structure
  *
  * @tparam        KeyType     unsigned 32- or 64-bit integer
- * @param[in]     keys    first particle key, on device
+ * @param[in]     keys        first particle key, on device
  * @param[in]     bucketSize  max number of particles per leaf
- * @param[inout]  tree        a fully linked octree
- * @param[inout]  counts      leaf node particle counts
- * @return                    true if tree was not changed
+ * @param[out]    tree        output fully linked octree built on top of updated leaves
+ * @param[inout]  d_csTree    leaf nodes
+ * @param[out]    d_countsBuf leaf node particle counts
+ * @param[in]     expectOverflows  use sum-reduction that guards against integer overflow if true
+ * @return                         true if tree was not changed
  */
 template<class KeyType, class DevKeyVec, class DevCountVec>
 bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
@@ -55,7 +58,7 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
                            OctreeData<KeyType, GpuTag>& tree,
                            DevKeyVec& d_csTree,
                            DevCountVec& d_countsBuf,
-                           bool firstCall)
+                           bool expectOverflows)
 {
     unsigned maxCount = std::numeric_limits<unsigned>::max();
     auto newNumNodes =
@@ -75,10 +78,10 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
     computeNodeCountsGpu(rawPtr(d_csTree), d_counts.data(), numLeafNodes, keys, maxCount, true);
 
     syncGpu();
-    if (firstCall)
+    if (expectOverflows)
     {
         MPI_Op limitSum;
-        MPI_Op_create(&summax, true, &limitSum);
+        MPI_Op_create(&sumCapped, true, &limitSum);
         mpiAllreduceGpuDirect(d_counts.data(), d_countsRed.data(), d_counts.size(), limitSum, MPI_COMM_WORLD);
         MPI_Op_free(&limitSum);
     }

--- a/domain/include/cstone/tree/update_mpi_gpu.cuh
+++ b/domain/include/cstone/tree/update_mpi_gpu.cuh
@@ -47,7 +47,6 @@ inline void summax(void* inP, void* inoutP, int* len, MPI_Datatype*)
  * @param[in]     bucketSize  max number of particles per leaf
  * @param[inout]  tree        a fully linked octree
  * @param[inout]  counts      leaf node particle counts
- * @param[in]     numRanks    number of MPI ranks
  * @return                    true if tree was not changed
  */
 template<class KeyType, class DevKeyVec, class DevCountVec>
@@ -57,7 +56,8 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
                            std::vector<KeyType>& leaves,
                            DevKeyVec& d_csTree,
                            std::vector<unsigned>& counts,
-                           DevCountVec& d_countsBuf)
+                           DevCountVec& d_countsBuf,
+                           bool firstCall)
 {
     unsigned maxCount = std::numeric_limits<unsigned>::max();
     auto newNumNodes =
@@ -81,10 +81,14 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
     computeNodeCountsGpu(rawPtr(d_csTree), d_counts.data(), numLeafNodes, keys, maxCount, true);
 
     syncGpu();
-    MPI_Op limitSum;
-    MPI_Op_create(&summax, true, &limitSum);
-    mpiAllreduceGpuDirect(d_counts.data(), d_countsRed.data(), d_counts.size(), limitSum, MPI_COMM_WORLD);
-    MPI_Op_free(&limitSum);
+    if (firstCall)
+    {
+        MPI_Op limitSum;
+        MPI_Op_create(&summax, true, &limitSum);
+        mpiAllreduceGpuDirect(d_counts.data(), d_countsRed.data(), d_counts.size(), limitSum, MPI_COMM_WORLD);
+        MPI_Op_free(&limitSum);
+    }
+    else { mpiAllreduceGpuDirect(d_counts.data(), d_countsRed.data(), d_counts.size(), MPI_SUM, MPI_COMM_WORLD); }
     sequenceMax(d_counts.data(), d_counts.data() + d_counts.size(), d_countsRed.data(), d_counts.data());
 
     reallocate(counts, numLeafNodes, 1.01);
@@ -101,11 +105,12 @@ bool updateOctreeGlobal(std::span<const KeyType> keys,
                         std::vector<KeyType>& leaves,
                         DevKeyVec& d_csTree,
                         std::vector<unsigned>& counts,
-                        DevCountVec& d_counts)
+                        DevCountVec& d_counts,
+                        bool firstCall)
 {
     if constexpr (HaveGpu<Accelerator>{})
     {
-        return updateOctreeGlobalGpu(keys, bucketSize, tree, leaves, d_csTree, counts, d_counts);
+        return updateOctreeGlobalGpu(keys, bucketSize, tree, leaves, d_csTree, counts, d_counts, firstCall);
     }
     else { return updateOctreeGlobal(keys, bucketSize, tree, leaves, counts); }
 }


### PR DESCRIPTION
Prevents overflow issues that may occur when the global octree is not close to converged during first build.