### PR TITLE
Guard SPH against neighbor convergence failure

### DIFF
--- a/main/src/propagator/std_hydro.hpp
+++ b/main/src/propagator/std_hydro.hpp
@@ -181,7 +181,11 @@ public:
         computeTimestep(first, last, d);
         timer.step("Timestep");
         computePositions(groups_.view(), d, domain.box(), d.minDt, {float(d.minDt_m1)});
-        updateSmoothingLength(groups_.view(), d);
+        bool haveUnconvergedParticles = updateSmoothingLength(groups_.view(), d);
+        if (haveUnconvergedParticles && not d.removeUnconvergedParticles)
+        {
+            throw std::runtime_error("Neighbor search did not converge\n");
+        }
         timer.step("UpdateQuantities");
     }
 

--- a/main/src/propagator/ve_hydro.hpp
+++ b/main/src/propagator/ve_hydro.hpp
@@ -216,7 +216,8 @@ public:
         computeTimestep(first, last, d);
         timer.step("Timestep");
         computePositions(groups_.view(), d, domain.box(), d.minDt, {float(d.minDt_m1)});
-        updateSmoothingLength(groups_.view(), d);
+        bool haveUnconvergedParticles = updateSmoothingLength(groups_.view(), d);
+        if (haveUnconvergedParticles) { throw std::runtime_error("Neighbor search did not converge\n"); }
         timer.step("UpdateQuantities");
     }
 

--- a/main/src/propagator/ve_hydro.hpp
+++ b/main/src/propagator/ve_hydro.hpp
@@ -217,7 +217,10 @@ public:
         timer.step("Timestep");
         computePositions(groups_.view(), d, domain.box(), d.minDt, {float(d.minDt_m1)});
         bool haveUnconvergedParticles = updateSmoothingLength(groups_.view(), d);
-        if (haveUnconvergedParticles) { throw std::runtime_error("Neighbor search did not converge\n"); }
+        if (haveUnconvergedParticles && not d.removeUnconvergedParticles)
+        {
+            throw std::runtime_error("Neighbor search did not converge\n");
+        }
         timer.step("UpdateQuantities");
     }
 

--- a/main/src/propagator/ve_hydro_bdt.hpp
+++ b/main/src/propagator/ve_hydro_bdt.hpp
@@ -373,7 +373,10 @@ public:
         }
 
         bool haveUnconvergedParticles = updateSmoothingLength(activeRungs_, d);
-        if (haveUnconvergedParticles) { throw std::runtime_error("Neighbor search did not converge\n"); }
+        if (haveUnconvergedParticles && not d.removeUnconvergedParticles)
+        {
+            throw std::runtime_error("Neighbor search did not converge\n");
+        }
 
         timestep_.substep++;
         timestep_.elapsedDt += timestep_.nextDt;

--- a/main/src/propagator/ve_hydro_bdt.hpp
+++ b/main/src/propagator/ve_hydro_bdt.hpp
@@ -372,7 +372,8 @@ public:
             }
         }
 
-        updateSmoothingLength(activeRungs_, d);
+        bool haveUnconvergedParticles = updateSmoothingLength(activeRungs_, d);
+        if (haveUnconvergedParticles) { throw std::runtime_error("Neighbor search did not converge\n"); }
 
         timestep_.substep++;
         timestep_.elapsedDt += timestep_.nextDt;

--- a/sph/include/sph/find_neighbors.hpp
+++ b/sph/include/sph/find_neighbors.hpp
@@ -16,10 +16,9 @@ void findNeighborsSph(const Tc* x, const Tc* y, const Tc* z, T* h, LocalIndex fi
 
     unsigned ngmin = ng0 / 4;
 
-    size_t        numFails     = 0;
     constexpr int maxIteration = 10;
 
-#pragma omp parallel for reduction(+ : numFails)
+#pragma omp parallel for
     for (LocalIndex i = 0; i < numWork; ++i)
     {
         LocalIndex id    = i + firstId;
@@ -31,15 +30,13 @@ void findNeighborsSph(const Tc* x, const Tc* y, const Tc* z, T* h, LocalIndex fi
             h[id] = updateH(ng0, ncSph, h[id]);
             ncSph = 1 + findNeighbors(id, x, y, z, h, treeView, box, ngmax, neighbors + i * ngmax);
         }
-        numFails += (iteration >= maxIteration);
-
         nc[i] = ncSph;
-    }
 
-    if (numFails)
-    {
-        std::cout << "Coupled h-neighbor count updated failed to converge for " << numFails << " particles"
-                  << std::endl;
+        if (iteration == maxIteration && (ngmin > ncSph || (ncSph - 1) > ngmax))
+        {
+            h[i]  = T(0);
+            nc[i] = 1;
+        }
     }
 }
 

--- a/sph/include/sph/hydro_std/iad_kern.hpp
+++ b/sph/include/sph/hydro_std/iad_kern.hpp
@@ -67,6 +67,7 @@ HOST_DEVICE_FUN inline void IADJLoopSTD(cstone::LocalIndex i, Tc K, const cstone
     // Note normalization factor: cij have units of 1/tau because det is proportional to tau^3 so we have to
     // divide by K/h^3.
     T factor = normalization * (hi * hi * hi) / (det * K);
+    if (std::isnan(factor) && neighborsCount == 0) { factor = T(0); }
 
     c11[i] = (tau22 * tau33 - tau23 * tau23) * factor;
     c12[i] = (tau13 * tau23 - tau33 * tau12) * factor;

--- a/sph/include/sph/hydro_std/momentum_energy_gpu.cu
+++ b/sph/include/sph/hydro_std/momentum_energy_gpu.cu
@@ -100,6 +100,33 @@ __global__ void cudaGradP(Tc K, Tc Kcour, unsigned ngmax, cstone::Box<Tc> box, c
     if (threadIdx.x == 0) { cstone::atomicMinFloat(&minDt_device, blockMin); }
 }
 
+/*! @brief Mark particles with NaN acceleration for removal by setting neighbor counts to 0
+ * @param[in]    grp   active particle groups
+ * @param[inout] ax    x particle acceleration
+ * @param[inout] ay
+ * @param[inout] az
+ * @param[inout] h     smoothing lengths
+ */
+template<class Ta, class Tu, class Th>
+__global__ void markNaN(GroupView grp, Ta* ax, Ta* ay, Ta* az, Tu* du, Th* h)
+{
+    LocalIndex laneIdx = threadIdx.x & (cstone::GpuConfig::warpSize - 1);
+    LocalIndex warpIdx = (blockDim.x * blockIdx.x + threadIdx.x) >> cstone::GpuConfig::warpSizeLog2;
+    if (warpIdx >= grp.numGroups) { return; }
+
+    LocalIndex i = grp.groupStart[warpIdx] + laneIdx;
+    if (i >= grp.groupEnd[warpIdx]) { return; }
+
+    if (std::isnan(ax[i]) || std::isnan(ay[i]) || std::isnan(az[i]) || std::isnan(du[i]))
+    {
+        ax[i] = Ta(0);
+        ay[i] = Ta(0);
+        az[i] = Ta(0);
+        du[i] = Tu(0);
+        h[i]  = 0;
+    }
+}
+
 template<class Dataset>
 void computeMomentumEnergyStdGpu(const GroupView& grp, Dataset& d, const cstone::Box<typename Dataset::RealType>& box)
 {
@@ -117,6 +144,17 @@ void computeMomentumEnergyStdGpu(const GroupView& grp, Dataset& d, const cstone:
         rawPtr(d.devData.c11), rawPtr(d.devData.c12), rawPtr(d.devData.c13), rawPtr(d.devData.c22),
         rawPtr(d.devData.c23), rawPtr(d.devData.c33), rawPtr(d.devData.wh), rawPtr(d.devData.whd), rawPtr(d.devData.ax),
         rawPtr(d.devData.ay), rawPtr(d.devData.az), rawPtr(d.devData.du), nidxPool, traversalPool);
+
+    {
+        unsigned numThreads       = 256;
+        unsigned numWarpsPerBlock = numThreads / cstone::GpuConfig::warpSize;
+        unsigned numBlocks        = (grp.numGroups + numWarpsPerBlock - 1) / numWarpsPerBlock;
+        if (numBlocks > 0)
+        {
+            markNaN<<<numBlocks, numThreads>>>(grp, rawPtr(d.devData.ax), rawPtr(d.devData.ay), rawPtr(d.devData.az),
+                                               rawPtr(d.devData.du), rawPtr(d.devData.h));
+        }
+    }
 
     checkGpuErrors(cudaGetLastError());
 

--- a/sph/include/sph/hydro_ve/iad_kern.hpp
+++ b/sph/include/sph/hydro_ve/iad_kern.hpp
@@ -99,6 +99,7 @@ HOST_DEVICE_FUN inline void IADJLoop(cstone::LocalIndex i, Tc K, const cstone::B
     // note normalization factor: cij have units of 1/tau because det is proportional to tau^3, so we have to
     // divide by K/h^3
     T factor = normalization * (hi * hi * hi) / (det * K);
+    if (std::isnan(factor) && neighborsCount == 0) { factor = T(0); }
 
     c11[i] = (tau22 * tau33 - tau23 * tau23) * factor;
     c12[i] = (tau13 * tau23 - tau33 * tau12) * factor;

--- a/sph/include/sph/hydro_ve/xmass_gpu.cu
+++ b/sph/include/sph/hydro_ve/xmass_gpu.cu
@@ -51,8 +51,6 @@ unsigned nsGroupSize() { return TravConfig::targetSize; }
 namespace gpu
 {
 
-__device__ bool nc_h_convergenceFailure = false;
-
 template<class Tc, class Tm, class T, class KeyType>
 __global__ void xmassGpu(Tc K, unsigned ng0, unsigned ngmax, const cstone::Box<Tc> box, const LocalIndex* grpStart,
                          const LocalIndex* grpEnd, LocalIndex numGroups, const cstone::OctreeNsView<Tc, KeyType> tree,
@@ -89,7 +87,12 @@ __global__ void xmassGpu(Tc K, unsigned ng0, unsigned ngmax, const cstone::Box<T
             ncSph =
                 1 + traverseNeighbors(bodyBegin, bodyEnd, x, y, z, h, tree, box, neighborsWarp, ngmax, globalPool)[0];
 
-            if (ncIt == ncMaxIteration) { nc_h_convergenceFailure = true; }
+            bool ncFail = (ncSph < ng0 / 4 || (ncSph - 1) > ngmax) && i < bodyEnd;
+            if (ncIt == ncMaxIteration && ncFail)
+            {
+                h[i]  = T(0);
+                ncSph = 1;
+            }
         }
 
         if (i >= bodyEnd) continue;
@@ -116,16 +119,12 @@ void computeXMass(const GroupView& grp, Dataset& d, const cstone::Box<typename D
     NcStats::type stats[NcStats::numStats];
     checkGpuErrors(cudaMemcpyFromSymbol(stats, GPU_SYMBOL(cstone::ncStats), NcStats::numStats * sizeof(NcStats::type)));
 
-    bool convergenceFailure;
-    checkGpuErrors(cudaMemcpyFromSymbol(&convergenceFailure, GPU_SYMBOL(nc_h_convergenceFailure), sizeof(bool)));
-
     NcStats::type maxP2P   = stats[cstone::NcStats::maxP2P];
     NcStats::type maxStack = stats[cstone::NcStats::maxStack];
 
     d.devData.stackUsedNc = maxStack;
 
     if (maxP2P == 0xFFFFFFFF) { throw std::runtime_error("GPU traversal stack exhausted in neighbor search\n"); }
-    if (convergenceFailure) { throw std::runtime_error("coupled nc/h-updated failed to converge"); }
 }
 
 template void computeXMass(const GroupView& grp, sphexa::ParticlesData<cstone::GpuTag>& d,

--- a/sph/include/sph/kernels.hpp
+++ b/sph/include/sph/kernels.hpp
@@ -8,11 +8,12 @@ namespace sph
 
 //! @brief compute time-step based on the signal velocity
 template<class T1, class T2, class T3>
-HOST_DEVICE_FUN inline auto tsKCourant(T1 maxvsignal, T2 h, T3 c, float Kcour)
+HOST_DEVICE_FUN auto tsKCourant(T1 maxvsignal, T2 h, T3 c, float Kcour)
 {
     using T = std::common_type_t<T1, T2, T3>;
     T v     = maxvsignal > T(0) ? maxvsignal : c;
-    return T(Kcour * h / v);
+    // h == 0 signals neighbor search didn't converge, particle will be removed
+    return h > T2(0) ? T(Kcour * h / v) : INFINITY;
 }
 
 /*! @brief estimate updated smoothing length to bring the neighbor count closer to ng0

--- a/sph/include/sph/particles_data.hpp
+++ b/sph/include/sph/particles_data.hpp
@@ -93,6 +93,9 @@ public:
     //! @brief default maximum number of neighbors per particle before additional h-adjustment will be triggered
     unsigned ngmax{150};
 
+    //! @brief whether to remove unconverged particles when the smoothing length update failed
+    int removeUnconvergedParticles{false};
+
     RealType ttot{0.0}, etot{0.0}, ecin{0.0}, eint{0.0}, egrav{0.0};
     RealType linmom{0.0}, angmom{0.0};
 
@@ -179,6 +182,7 @@ public:
         ar->stepAttribute("numParticlesGlobal", &numParticlesGlobal, 1);
         optionalIO("ng0", &ng0, 1);
         optionalIO("ngmax", &ngmax, 1);
+        optionalIO("removeUnconvergedParticles", &removeUnconvergedParticles, 1);
         ar->stepAttribute("time", &ttot, 1);
         ar->stepAttribute("minDt", &minDt, 1);
         ar->stepAttribute("minDt_m1", &minDt_m1, 1);

--- a/sph/include/sph/sph_gpu.hpp
+++ b/sph/include/sph/sph_gpu.hpp
@@ -81,8 +81,8 @@ extern void computePositionsGpu(const GroupView& grp, float dt, util::array<floa
                                 Ta* az, const uint8_t* rung, Tu* temp, Tu* u, Tdu* du, Tm1* du_m1, Thydro* h,
                                 Thydro* mui, Tc gamma, Tc constCv, const cstone::Box<Tc>& box);
 
-template<class Th>
-extern void updateSmoothingLengthGpu(const GroupView&, unsigned ng0, const unsigned* nc, Th* h);
+template<class Th, class KeyType>
+extern bool updateSmoothingLengthGpu(const GroupView&, unsigned ng0, const unsigned* nc, Th* h, KeyType* keys);
 
 template<class T>
 extern void groupDivvTimestepGpu(float Krho, const GroupView&, const T* divv, float* groupDt);

--- a/sph/include/sph/update_h.hpp
+++ b/sph/include/sph/update_h.hpp
@@ -9,29 +9,41 @@
 namespace sph
 {
 
-template<class T>
-void updateSmoothingLengthCpu(size_t startIndex, size_t endIndex, unsigned ng0, const unsigned* nc, T* h)
+template<class T, class KeyType>
+bool updateSmoothingLengthCpu(size_t startIndex, size_t endIndex, unsigned ng0, const unsigned* nc, T* h, KeyType* keys)
 {
+    bool keysRemoved = false;
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
+        if (h[i] == 0)
+        {
+            keys[i]     = cstone::removeKey<KeyType>{};
+            keysRemoved = true;
+        }
         h[i] = updateH(ng0, nc[i], h[i]);
 
 #ifndef NDEBUG
         if (std::isinf(h[i]) || std::isnan(h[i])) printf("ERROR::h(%lu) ngi %d h %f\n", i, nc[i], h[i]);
 #endif
     }
+    return keysRemoved;
 }
 
 template<class Dataset>
-void updateSmoothingLength(const GroupView& grp, Dataset& d)
+bool updateSmoothingLength(const GroupView& grp, Dataset& d)
 {
     if constexpr (cstone::HaveGpu<typename Dataset::AcceleratorType>{})
     {
-        updateSmoothingLengthGpu(grp, d.ng0, rawPtr(d.devData.nc), rawPtr(d.devData.h));
+        bool keysRemoved =
+            updateSmoothingLengthGpu(grp, d.ng0, rawPtr(d.devData.nc), rawPtr(d.devData.h), rawPtr(d.devData.keys));
         syncGpu();
+        return keysRemoved;
     }
-    else { updateSmoothingLengthCpu(grp.firstBody, grp.lastBody, d.ng0, rawPtr(d.nc), rawPtr(d.h)); }
+    else
+    {
+        return updateSmoothingLengthCpu(grp.firstBody, grp.lastBody, d.ng0, rawPtr(d.nc), rawPtr(d.h), rawPtr(d.keys));
+    }
 }
 
 } // namespace sph

--- a/sph/include/sph/update_h_gpu.cu
+++ b/sph/include/sph/update_h_gpu.cu
@@ -36,8 +36,10 @@ namespace sph
 {
 using cstone::LocalIndex;
 
-template<class Th>
-__global__ void updateSmoothingLengthGpuKernel(GroupView grp, unsigned ng0, const unsigned* nc, Th* h)
+__device__ bool nc_h_convergenceFailure = false;
+
+template<class Th, class KeyType>
+__global__ void updateSmoothingLengthGpuKernel(GroupView grp, unsigned ng0, const unsigned* nc, Th* h, KeyType* keys)
 {
     LocalIndex laneIdx = threadIdx.x & (cstone::GpuConfig::warpSize - 1);
     LocalIndex warpIdx = (blockDim.x * blockIdx.x + threadIdx.x) >> cstone::GpuConfig::warpSizeLog2;
@@ -46,20 +48,29 @@ __global__ void updateSmoothingLengthGpuKernel(GroupView grp, unsigned ng0, cons
     LocalIndex i = grp.groupStart[warpIdx] + laneIdx;
     if (i >= grp.groupEnd[warpIdx]) { return; }
 
+    if (h[i] == 0)
+    {
+        keys[i] = cstone::removeKey<KeyType>{};
+        nc_h_convergenceFailure = true;
+    }
     h[i] = updateH(ng0, nc[i], h[i]);
 }
 
-template<class Th>
-void updateSmoothingLengthGpu(const GroupView& grp, unsigned ng0, const unsigned* nc, Th* h)
+template<class Th, class KeyType>
+bool updateSmoothingLengthGpu(const GroupView& grp, unsigned ng0, const unsigned* nc, Th* h, KeyType* keys)
 {
     unsigned numThreads       = 256;
     unsigned numWarpsPerBlock = numThreads / cstone::GpuConfig::warpSize;
     unsigned numBlocks        = (grp.numGroups + numWarpsPerBlock - 1) / numWarpsPerBlock;
-    if (numBlocks == 0) { return; }
-    updateSmoothingLengthGpuKernel<<<numBlocks, numThreads>>>(grp, ng0, nc, h);
+    if (numBlocks == 0) { return false; }
+    updateSmoothingLengthGpuKernel<<<numBlocks, numThreads>>>(grp, ng0, nc, h, keys);
+
+    bool convergenceFailure;
+    checkGpuErrors(cudaMemcpyFromSymbol(&convergenceFailure, GPU_SYMBOL(nc_h_convergenceFailure), sizeof(bool)));
+    return convergenceFailure;
 }
 
-template void updateSmoothingLengthGpu(const GroupView& grp, unsigned ng0, const unsigned* nc, float* h);
-template void updateSmoothingLengthGpu(const GroupView& grp, unsigned ng0, const unsigned* nc, double* h);
+template bool updateSmoothingLengthGpu(const GroupView& grp, unsigned ng0, const unsigned* nc, float* h, uint64_t*);
+template bool updateSmoothingLengthGpu(const GroupView& grp, unsigned ng0, const unsigned* nc, double* h, uint64_t*);
 
 } // namespace sph

--- a/sph/test/std.cpp
+++ b/sph/test/std.cpp
@@ -125,3 +125,19 @@ TEST_F(SphKernelTestsStd, MomentumEnergy)
     EXPECT_NEAR(du, -0.40541191600274296, 1e-8);
     EXPECT_NEAR(maxvsignal, 1.4112466828564341, 1e-10);
 }
+
+TEST_F(SphKernelTestsStd, MomentumEnergyZero)
+{
+    auto [du, grad_Px, grad_Py, grad_Pz, maxvsignal] = std::array<T, 5>{-1, -1, -1, -1, -1};
+
+    momentumAndEnergyJLoop(0, K, box(), neighbors.data(), 0, x.data(), y.data(), z.data(), vx.data(), vy.data(),
+                           vz.data(), h.data(), m.data(), rho.data(), p.data(), c.data(), c11.data(), c12.data(),
+                           c13.data(), c22.data(), c23.data(), c33.data(), wh.data(), whd.data(), &grad_Px, &grad_Py,
+                           &grad_Pz, &du, &maxvsignal);
+
+    EXPECT_EQ(grad_Px, 0.0);
+    EXPECT_EQ(grad_Py, 0.0);
+    EXPECT_EQ(grad_Pz, 0.0);
+    EXPECT_EQ(du, 0.0);
+    EXPECT_EQ(maxvsignal, 0.0);
+}

--- a/sph/test/ve.cpp
+++ b/sph/test/ve.cpp
@@ -208,6 +208,22 @@ TEST_F(SphKernelTests, MomentumEnergy)
         EXPECT_NEAR(du, 7.1838438980436924e12, 3.1e5);
         EXPECT_NEAR(maxvsignal, 26490876.319252387, 1e-6);
     }
+    { // test zero neighbors
+        auto [du, grad_Px, grad_Py, grad_Pz, maxvsignal] = std::array<T, 5>{-1, -1, -1, -1, -1};
+
+        momentumAndEnergyJLoop<false>(0, K, box(), neighbors.data(), 0, x.data(), y.data(), z.data(), vx.data(),
+                                      vy.data(), vz.data(), h.data(), m.data(), prho.data(), (const T*)nullptr,
+                                      c.data(), c11.data(), c12.data(), c13.data(), c22.data(), c23.data(), c33.data(),
+                                      Atmin, Atmax, ramp, wh.data(), kx.data(), xm.data(), alpha.data(), dV11.data(),
+                                      dV12.data(), dV13.data(), dV22.data(), dV23.data(), dV33.data(), &grad_Px,
+                                      &grad_Py, &grad_Pz, &du, &maxvsignal);
+
+        EXPECT_EQ(grad_Px, 0.0);
+        EXPECT_EQ(grad_Py, 0.0);
+        EXPECT_EQ(grad_Pz, 0.0);
+        EXPECT_EQ(du, 0.0);
+        EXPECT_EQ(maxvsignal, 0.0);
+    }
 }
 
 TEST_F(SphKernelTests, VeDefGradh)


### PR DESCRIPTION
Particles that failed the smoothing length update, i.e. failed to keep neighbor counts within [ngmin, ngmax]
will be removed.

Currently this is active in the STD hydro propagator, and disabled in the VE propagator variants.
For now this is enough to do further tests on the TDE simulations.

A nicer interface with a controllable setting and an exception-based mechanism to write a checkpoint before failing
is in the works.