### PR TITLE
separate Ascent trigger from its actions

### DIFF
--- a/main/src/ascent_adaptor.h
+++ b/main/src/ascent_adaptor.h
@@ -19,37 +19,52 @@ conduit::Node  actions;
 template<class DataType>
 void Initialize([[maybe_unused]] DataType& d, [[maybe_unused]] long startIndex)
 {
-    conduit::Node ascent_options;
-    // ascent_options["default_dir"] = "/scratch/snx3000/jfavre/DummySPH/datasets";
-    ascent_options["mpi_comm"] = MPI_Comm_c2f(MPI_COMM_WORLD);
+  conduit::Node ascent_options;
+  std::string output_path = "datasets/";
+  if(!conduit::utils::is_directory(output_path))
+    {
+      conduit::utils::create_directory(output_path);
+    }
+  ascent_options["default_dir"] = output_path;
+  ascent_options["mpi_comm"] = MPI_Comm_c2f(MPI_COMM_WORLD);
 #ifdef CAMP_HAVE_CUDA
   ascent_options["runtine/vtkm/backend"] = "cuda";
 #endif
-    a.open(ascent_options);
+  a.open(ascent_options);
 
-    conduit::Node clip_actions;
-    bool dump_data_todisk = false;
-    if(dump_data_todisk == false)
+  std::string trigger_file = conduit::utils::join_file_path("./","sphexa_Ascent_actions.yaml");
+  // verify we can continue
+  if(conduit::utils::is_file(trigger_file))
     {
+    std::cout << "using an existing actions file "<< trigger_file<<std::endl;
+    }
+  else
+    { // create a default actions file valid for the wind-shock test
+    conduit::Node trigger_actions;
+
     conduit::Node queries;
     queries["q1/params/expression"] = "field('kx') * field('m') / field('xm')";
     queries["q1/params/name"] = "density";
-    
-    conduit::Node &add_queries = clip_actions.append();
+    conduit::Node &add_queries = trigger_actions.append();
     add_queries["action"] = "add_queries";
     add_queries["queries"] = queries;
-    
+
     conduit::Node pipelines;
     pipelines["pl_threshold_thin_clip_z/f1/type"] = "threshold";
     conduit::Node &params1 = pipelines["pl_threshold_thin_clip_z/f1/params"];
     params1["field"] = "z";
     params1["min_value"] = 0.12425;
     params1["max_value"] = 0.12575;
+
     pipelines["pl_threshold_thin_clip_y/f1/type"] = "threshold";
     conduit::Node &params2 = pipelines["pl_threshold_thin_clip_y/f1/params"];
     params2["field"] = "y";
     params2["min_value"] = 0.12425;
     params2["max_value"] = 0.12575;
+
+    conduit::Node &add_pipelines = trigger_actions.append();
+    add_pipelines["action"] = "add_pipelines";
+    add_pipelines["pipelines"] = pipelines;
 
     conduit::Node scenes;
     scenes["s1/plots/p1/type"]         = "pseudocolor";
@@ -60,7 +75,7 @@ void Initialize([[maybe_unused]] DataType& d, [[maybe_unused]] long startIndex)
     scenes["s1/plots/p1/color_table/name"] = "Yellow - Gray - Blue";
     scenes["s1/plots/p1/color_table/annotation"] = "false";
     scenes["s1/plots/p1/points/radius"] = 0.001;
-    
+
     scenes["s1/plots/p2/type"]         = "pseudocolor";
     scenes["s1/plots/p2/field"] = "density";
     scenes["s1/plots/p2/pipeline"] = "pl_threshold_thin_clip_y";
@@ -69,8 +84,8 @@ void Initialize([[maybe_unused]] DataType& d, [[maybe_unused]] long startIndex)
     scenes["s1/plots/p2/color_table/name"] = "Yellow - Gray - Blue";
     scenes["s1/plots/p2/color_table/annotation"] = "true";
     scenes["s1/plots/p2/points/radius"] = 0.001;
-    
-    scenes["s1/renders/r1/image_prefix"] = "datasets/density.%05d";
+
+    scenes["s1/renders/r1/image_prefix"] = output_path + "density.%05d";
     scenes["s1/renders/r1/image_width"] = 1920;
     scenes["s1/renders/r1/image_height"] = 1080;
 
@@ -84,34 +99,23 @@ void Initialize([[maybe_unused]] DataType& d, [[maybe_unused]] long startIndex)
 
     scenes["s1/renders/r1/dataset_bounds"].set({0.0, 1.0, 0.0, 0.25, 0.0, 0.25});
     scenes["s1/renders/r1/color_bar_position"].set({0.2, 0.9, -0.9, -0.75});
-    
-    conduit::Node &add_pipelines = clip_actions.append();
-    add_pipelines["action"] = "add_pipelines";
-    add_pipelines["pipelines"] = pipelines;
 
-    conduit::Node &add_scenes= clip_actions.append();
+    conduit::Node &add_scenes= trigger_actions.append();
     add_scenes["action"] = "add_scenes";
     add_scenes["scenes"] = scenes;
+    std::cout << "creating a new actions file "<< trigger_file<<std::endl;
+    trigger_actions.save(trigger_file);
     }
-    else
-    {
-     /* IO to disk */
-    conduit::Node& add_extr = clip_actions.append();
-    add_extr["action"]      = "add_extracts";
-    conduit::Node& savedata = add_extr["extracts"];
-    savedata["e1/type"] = "relay";
-    savedata["e1/params/path"]     = "particles";
-    savedata["e1/params/protocol"] = "hdf5";
-    }
-    std::string condition = "cycle() % 1 == 0";
-    conduit::Node triggers;
-    triggers["t1/params/condition"] = condition;
-    triggers["t1/params/actions"] = clip_actions;
-    conduit::Node &add_triggers= actions.append();
-    add_triggers["action"] = "add_triggers";
-    add_triggers["triggers"] = triggers;
 
-    //actions.print();
+  std::string condition = "cycle() % 200 == 0";
+  conduit::Node triggers;
+  triggers["t1/params/condition"] = condition;
+  triggers["t1/params/actions_file"] = trigger_file;
+  conduit::Node &add_triggers= actions.append();
+  add_triggers["action"] = "add_triggers";
+  add_triggers["triggers"] = triggers;
+
+  //std::cout << actions.to_yaml() << std::endl;
 }
 
 /*! @brief Add a volume-independent vertex field to a mesh


### PR DESCRIPTION
Ascent _in-situ_ actions are separated into a compiled trigger, and a set of actions read from the runtime directory. The file "sphexa_Ascent_actions.yaml" is searched. If not found at run-time, a new file will be created with the default two-clipping planes actions tuned for the wind-shock test. If the file is found, it is executed. This gives the possibility to use multiple actions files tuned for each test cases