### PR TITLE
Fully converge global tree when needed

### DIFF
--- a/domain/include/cstone/domain/assignment.hpp
+++ b/domain/include/cstone/domain/assignment.hpp
@@ -111,12 +111,13 @@ public:
         sequence<gpu>(o1.start, numPart, reorderFunctor.getBuf(), growthRate_);
         sortByKey<gpu>(keyView, std::span{reorderFunctor.getMap() + o1.start, keyView.size()}, s0, s1, growthRate_);
 
-        updateOctreeGlobal<KeyType>(keyView, bucketSize_, tree_, leaves_, d_csTree_, nodeCounts_, d_nodeCounts_, false);
-        if (firstCall_)
+        auto maxCount = updateOctreeGlobal<KeyType>(keyView, bucketSize_, tree_, leaves_, d_csTree_, nodeCounts_,
+                                                    d_nodeCounts_, false);
+        if (firstCall_ || maxCount >= 8 * bucketSize_)
         {
             firstCall_ = false;
-            while (!updateOctreeGlobal<KeyType>(keyView, bucketSize_, tree_, leaves_, d_csTree_, nodeCounts_,
-                                                d_nodeCounts_, true))
+            while (updateOctreeGlobal<KeyType>(keyView, bucketSize_, tree_, leaves_, d_csTree_, nodeCounts_,
+                                               d_nodeCounts_, true) > bucketSize_)
                 ;
         }
 

--- a/domain/include/cstone/halos/gather_halos_gpu.cu
+++ b/domain/include/cstone/halos/gather_halos_gpu.cu
@@ -52,6 +52,7 @@ void gatherRanges(const IndexType* rangeScan,
 {
     int numThreads = 256;
     int numBlocks  = iceil(bufferSize, numThreads);
+    if (numBlocks == 0) { return; }
     gatherRangesKernel<<<numBlocks, numThreads>>>(rangeScan, rangeOffsets, numRanges, src, buffer, bufferSize);
 }
 

--- a/domain/include/cstone/primitives/primitives_gpu.cu
+++ b/domain/include/cstone/primitives/primitives_gpu.cu
@@ -185,6 +185,7 @@ std::tuple<T, T> MinMaxGpu<T>::operator()(const T* first, const T* last)
 
 template class MinMaxGpu<double>;
 template class MinMaxGpu<float>;
+template class MinMaxGpu<unsigned>;
 
 using thrust::get;
 

--- a/domain/include/cstone/traversal/groups_gpu.cu
+++ b/domain/include/cstone/traversal/groups_gpu.cu
@@ -82,6 +82,7 @@ void computeGroupSplitsImpl(
     numSplitsPerGroup.reserve(numFixedGroups * 1.1);
     numSplitsPerGroup.resize(numFixedGroups + 1);
 
+    if (numFixedGroups > 0)
     groupSplitsKernel<groupSize><<<iceil(gridSize, numThreads), numThreads>>>(
         first, last, x, y, z, h, leaves, numLeaves, layout, box, tolFactor, rawPtr(splitMasks),
         rawPtr(numSplitsPerGroup), numFixedGroups);
@@ -95,6 +96,7 @@ void computeGroupSplitsImpl(
     auto& newGroupSizes = numSplitsPerGroup;
     newGroupSizes.resize(newNumGroups + 1);
 
+    if (numFixedGroups > 0)
     makeSplitsKernel<<<numFixedGroups, numThreads>>>(rawPtr(splitMasks), rawPtr(groups), numFixedGroups,
                                                      rawPtr(newGroupSizes));
 

--- a/domain/include/cstone/tree/update_mpi.hpp
+++ b/domain/include/cstone/tree/update_mpi.hpp
@@ -40,7 +40,7 @@ bool updateOctreeGlobal(std::span<const KeyType> keys,
     bool converged = updateOctree(keys, bucketSize, tree, counts, maxCount);
 
     std::vector<unsigned> counts_reduced(counts.size());
-    MPI_Allreduce(counts.data(), counts_reduced.data(), counts.size(), MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
+    mpiAllreduce(counts.data(), counts_reduced.data(), counts.size(), MPI_SUM, MPI_COMM_WORLD);
 
 #pragma omp parallel for schedule(static)
     for (size_t i = 0; i < counts.size(); ++i)
@@ -58,17 +58,15 @@ bool updateOctreeGlobal(std::span<const KeyType> keys,
  * @param[in]     bucketSize  max number of particles per leaf
  * @param[inout]  tree        a fully linked octree
  * @param[inout]  counts      leaf node particle counts
- * @param[in]     numRanks    number of MPI ranks
- * @return                    true if tree was not changed
+ * @return                    maximum number of particles per cell capped to 2^32-1 or 0 if tree has max depth
  */
 template<class KeyType>
-bool updateOctreeGlobal(std::span<const KeyType> keys,
-                        unsigned bucketSize,
-                        OctreeData<KeyType, CpuTag>& tree,
-                        std::vector<KeyType>& leaves,
-                        std::vector<unsigned>& counts)
+unsigned updateOctreeGlobal(std::span<const KeyType> keys,
+                            unsigned bucketSize,
+                            OctreeData<KeyType, CpuTag>& tree,
+                            std::vector<KeyType>& leaves,
+                            std::vector<unsigned>& counts)
 {
-    unsigned maxCount = std::numeric_limits<unsigned>::max();
     bool converged =
         rebalanceDecision(leaves.data(), counts.data(), nNodes(leaves), bucketSize, tree.childOffsets.data());
     rebalanceTree(leaves, tree.prefixes, tree.childOffsets.data());
@@ -78,18 +76,22 @@ bool updateOctreeGlobal(std::span<const KeyType> keys,
     updateInternalTree<KeyType>(leaves, tree.data());
 
     counts.resize(tree.numLeafNodes);
-    computeNodeCounts(leaves.data(), counts.data(), tree.numLeafNodes, keys, maxCount, true);
+    computeNodeCounts(leaves.data(), counts.data(), tree.numLeafNodes, keys, std::numeric_limits<unsigned>::max(),
+                      true);
 
     std::vector<unsigned> counts_reduced(counts.size());
-    MPI_Allreduce(counts.data(), counts_reduced.data(), counts.size(), MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
+    mpiAllreduce(counts.data(), counts_reduced.data(), counts.size(), MPI_SUM, MPI_COMM_WORLD);
 
-#pragma omp parallel for schedule(static)
+    unsigned maxCount = 0;
+#pragma omp parallel for schedule(static) reduction(max : maxCount)
     for (size_t i = 0; i < counts.size(); ++i)
     {
         counts[i] = std::max(counts[i], counts_reduced[i]);
+        maxCount  = std::max(counts[i], maxCount);
     }
 
-    return converged;
+    if (converged) { return 0; }
+    return maxCount;
 }
 
 } // namespace cstone

--- a/domain/include/cstone/tree/update_mpi_gpu.cuh
+++ b/domain/include/cstone/tree/update_mpi_gpu.cuh
@@ -50,17 +50,16 @@ inline void sumCapped(void* inP, void* inoutP, int* len, MPI_Datatype*)
  * @param[inout]  d_csTree    leaf nodes
  * @param[out]    d_countsBuf leaf node particle counts
  * @param[in]     expectOverflows  use sum-reduction that guards against integer overflow if true
- * @return                         true if tree was not changed
+ * @return                         maximum number of particles per cell capped to 2^32-1 or 0 if tree has max depth
  */
 template<class KeyType, class DevKeyVec, class DevCountVec>
-bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
-                           unsigned bucketSize,
-                           OctreeData<KeyType, GpuTag>& tree,
-                           DevKeyVec& d_csTree,
-                           DevCountVec& d_countsBuf,
-                           bool expectOverflows)
+unsigned updateOctreeGlobalGpu(std::span<const KeyType> keys,
+                               unsigned bucketSize,
+                               OctreeData<KeyType, GpuTag>& tree,
+                               DevKeyVec& d_csTree,
+                               DevCountVec& d_countsBuf,
+                               bool expectOverflows)
 {
-    unsigned maxCount = std::numeric_limits<unsigned>::max();
     auto newNumNodes =
         computeNodeOpsGpu(d_csTree.data(), nNodes(d_csTree), d_countsBuf.data(), bucketSize, tree.childOffsets.data());
     reallocate(tree.prefixes, newNumNodes + 1, 1.01);
@@ -75,7 +74,8 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
     auto [d_counts, d_countsRed] =
         util::packAllocBuffer(d_countsBuf, util::TypeList<unsigned, unsigned>{}, {numLeafNodes, numLeafNodes}, 128);
 
-    computeNodeCountsGpu(rawPtr(d_csTree), d_counts.data(), numLeafNodes, keys, maxCount, true);
+    computeNodeCountsGpu(rawPtr(d_csTree), d_counts.data(), numLeafNodes, keys, std::numeric_limits<unsigned>::max(),
+                         true);
 
     syncGpu();
     if (expectOverflows)
@@ -89,18 +89,21 @@ bool updateOctreeGlobalGpu(std::span<const KeyType> keys,
     sequenceMax(d_counts.data(), d_counts.data() + d_counts.size(), d_countsRed.data(), d_counts.data());
     d_countsBuf.resize(numLeafNodes);
 
-    return converged;
+    if (converged) { return 0; }
+
+    auto [minCount, maxCount] = MinMaxGpu<unsigned>{}(d_counts.data(), d_counts.data() + d_counts.size());
+    return maxCount;
 }
 
 template<class KeyType, class Accelerator, class DevKeyVec, class DevCountVec>
-bool updateOctreeGlobal(std::span<const KeyType> keys,
-                        unsigned bucketSize,
-                        OctreeData<KeyType, Accelerator>& tree,
-                        std::vector<KeyType>& leaves,
-                        DevKeyVec& d_csTree,
-                        std::vector<unsigned>& counts,
-                        DevCountVec& d_counts,
-                        bool firstCall)
+unsigned updateOctreeGlobal(std::span<const KeyType> keys,
+                            unsigned bucketSize,
+                            OctreeData<KeyType, Accelerator>& tree,
+                            std::vector<KeyType>& leaves,
+                            DevKeyVec& d_csTree,
+                            std::vector<unsigned>& counts,
+                            DevCountVec& d_counts,
+                            bool firstCall)
 {
     if constexpr (HaveGpu<Accelerator>{})
     {

--- a/ryoanji/src/ryoanji/nbody/traversal_gpu.cu
+++ b/ryoanji/src/ryoanji/nbody/traversal_gpu.cu
@@ -563,6 +563,7 @@ double traverse(cstone::GroupView grp, const int initNodeIdx, const Tc* __restri
     numBlocks            = std::min(numBlocks, TravConfig::maxNumActiveBlocks);
 
     resetTraversalCounters<<<1, 1>>>();
+    if (numBlocks > 0)
     traverseKernel<<<numBlocks, TravConfig::numThreads>>>(grp, initNodeIdx, xt, yt, zt, mt, ht, xs, ys, zs, ms, hs,
                                                           childOffsets, internalToLeaf, layout, sourceCenter,
                                                           multipoles, G, numShells, boxL, p, ax, ay, az, gmPool);

--- a/sph/include/sph/hydro_std/iad_gpu.cu
+++ b/sph/include/sph/hydro_std/iad_gpu.cu
@@ -101,9 +101,13 @@ __global__ void IADGpuKernel(Tc K, unsigned ngmax, cstone::Box<Tc> box, const Lo
 
         if (i >= bodyEnd) { continue; }
 
-        unsigned ncCapped = stl::min(ncTrue[0], ngmax);
-        sph::IADJLoopSTD<TravConfig::targetSize>(i, K, box, neighborsWarp + laneIdx, ncCapped, x, y, z, h, m, rho, wh,
-                                                 whd, c11, c12, c13, c22, c23, c33);
+        if (ncTrue[0] < 25 || ncTrue[0] > ngmax) { c11[i] = c12[i] = c13[i] = c22[i] = c23[i] = c33[i] = 0.; }
+        else
+        {
+            unsigned ncCapped = stl::min(ncTrue[0], ngmax);
+            sph::IADJLoopSTD<TravConfig::targetSize>(i, K, box, neighborsWarp + laneIdx, ncCapped, x, y, z, h, m, rho,
+                                                     wh, whd, c11, c12, c13, c22, c23, c33);
+        }
     }
 }
 

--- a/sph/include/sph/hydro_std/iad_gpu.cu
+++ b/sph/include/sph/hydro_std/iad_gpu.cu
@@ -104,8 +104,7 @@ __global__ void IADGpuKernel(Tc K, unsigned ngmax, cstone::Box<Tc> box, const Lo
         if (ncTrue[0] < 25 || ncTrue[0] > ngmax) { c11[i] = c12[i] = c13[i] = c22[i] = c23[i] = c33[i] = 0.; }
         else
         {
-            unsigned ncCapped = stl::min(ncTrue[0], ngmax);
-            sph::IADJLoopSTD<TravConfig::targetSize>(i, K, box, neighborsWarp + laneIdx, ncCapped, x, y, z, h, m, rho,
+            sph::IADJLoopSTD<TravConfig::targetSize>(i, K, box, neighborsWarp + laneIdx, ncTrue[0], x, y, z, h, m, rho,
                                                      wh, whd, c11, c12, c13, c22, c23, c33);
         }
     }

--- a/sph/include/sph/hydro_std/momentum_energy_gpu.cu
+++ b/sph/include/sph/hydro_std/momentum_energy_gpu.cu
@@ -80,14 +80,24 @@ __global__ void cudaGradP(Tc K, Tc Kcour, unsigned ngmax, cstone::Box<Tc> box, c
 
         if (i >= bodyEnd) continue;
 
-        unsigned ncCapped = stl::min(ncTrue[0], ngmax);
-        T        maxvsignal;
+        if (ncTrue[0] >= 25 && ncTrue[0] <= ngmax)
+        {
+            unsigned ncCapped = stl::min(ncTrue[0], ngmax);
+            T        maxvsignal;
 
-        momentumAndEnergyJLoop<TravConfig::targetSize>(i, K, box, neighborsWarp + laneIdx, ncCapped, x, y, z, vx, vy,
-                                                       vz, h, m, rho, p, c, c11, c12, c13, c22, c23, c33, wh, whd,
-                                                       grad_P_x, grad_P_y, grad_P_z, du, &maxvsignal);
+            momentumAndEnergyJLoop<TravConfig::targetSize>(i, K, box, neighborsWarp + laneIdx, ncCapped, x, y, z, vx,
+                                                           vy, vz, h, m, rho, p, c, c11, c12, c13, c22, c23, c33, wh,
+                                                           whd, grad_P_x, grad_P_y, grad_P_z, du, &maxvsignal);
 
-        dt_i = stl::min(dt_i, tsKCourant(maxvsignal, h[i], c[i], Kcour));
+            dt_i = stl::min(dt_i, tsKCourant(maxvsignal, h[i], c[i], Kcour));
+        }
+        else
+        {
+            du[i]       = 0.;
+            grad_P_x[i] = 0.;
+            grad_P_y[i] = 0.;
+            grad_P_z[i] = 0.;
+        }
     }
 
     typedef cub::BlockReduce<T, TravConfig::numThreads> BlockReduce;
@@ -105,10 +115,10 @@ __global__ void cudaGradP(Tc K, Tc Kcour, unsigned ngmax, cstone::Box<Tc> box, c
  * @param[inout] ax    x particle acceleration
  * @param[inout] ay
  * @param[inout] az
- * @param[inout] h     smoothing lengths
+ * @param[inout] nc    neighbor counts
  */
-template<class Ta, class Tu, class Th>
-__global__ void markNaN(GroupView grp, Ta* ax, Ta* ay, Ta* az, Tu* du, Th* h)
+template<class Ta, class Tu>
+__global__ void markNaN(GroupView grp, Ta* ax, Ta* ay, Ta* az, Tu* du, unsigned* nc)
 {
     LocalIndex laneIdx = threadIdx.x & (cstone::GpuConfig::warpSize - 1);
     LocalIndex warpIdx = (blockDim.x * blockIdx.x + threadIdx.x) >> cstone::GpuConfig::warpSizeLog2;
@@ -123,7 +133,7 @@ __global__ void markNaN(GroupView grp, Ta* ax, Ta* ay, Ta* az, Tu* du, Th* h)
         ay[i] = Ta(0);
         az[i] = Ta(0);
         du[i] = Tu(0);
-        h[i]  = 0;
+        nc[i] = 1;
     }
 }
 
@@ -152,7 +162,7 @@ void computeMomentumEnergyStdGpu(const GroupView& grp, Dataset& d, const cstone:
         if (numBlocks > 0)
         {
             markNaN<<<numBlocks, numThreads>>>(grp, rawPtr(d.devData.ax), rawPtr(d.devData.ay), rawPtr(d.devData.az),
-                                               rawPtr(d.devData.du), rawPtr(d.devData.h));
+                                               rawPtr(d.devData.du), rawPtr(d.devData.nc));
         }
     }
 

--- a/sph/include/sph/hydro_std/momentum_energy_gpu.cu
+++ b/sph/include/sph/hydro_std/momentum_energy_gpu.cu
@@ -82,10 +82,8 @@ __global__ void cudaGradP(Tc K, Tc Kcour, unsigned ngmax, cstone::Box<Tc> box, c
 
         if (ncTrue[0] >= 25 && ncTrue[0] <= ngmax)
         {
-            unsigned ncCapped = stl::min(ncTrue[0], ngmax);
-            T        maxvsignal;
-
-            momentumAndEnergyJLoop<TravConfig::targetSize>(i, K, box, neighborsWarp + laneIdx, ncCapped, x, y, z, vx,
+            T maxvsignal;
+            momentumAndEnergyJLoop<TravConfig::targetSize>(i, K, box, neighborsWarp + laneIdx, ncTrue[0], x, y, z, vx,
                                                            vy, vz, h, m, rho, p, c, c11, c12, c13, c22, c23, c33, wh,
                                                            whd, grad_P_x, grad_P_y, grad_P_z, du, &maxvsignal);
 

--- a/sph/include/sph/hydro_ve/xmass_gpu.cu
+++ b/sph/include/sph/hydro_ve/xmass_gpu.cu
@@ -88,11 +88,7 @@ __global__ void xmassGpu(Tc K, unsigned ng0, unsigned ngmax, const cstone::Box<T
                 1 + traverseNeighbors(bodyBegin, bodyEnd, x, y, z, h, tree, box, neighborsWarp, ngmax, globalPool)[0];
 
             bool ncFail = (ncSph < ng0 / 4 || (ncSph - 1) > ngmax) && i < bodyEnd;
-            if (ncIt == ncMaxIteration && ncFail)
-            {
-                h[i]  = T(0);
-                ncSph = 1;
-            }
+            if (ncIt == ncMaxIteration && ncFail) { ncSph = 1; }
         }
 
         if (i >= bodyEnd) continue;

--- a/sph/include/sph/update_h.hpp
+++ b/sph/include/sph/update_h.hpp
@@ -16,7 +16,7 @@ bool updateSmoothingLengthCpu(size_t startIndex, size_t endIndex, unsigned ng0, 
 #pragma omp parallel for schedule(static)
     for (size_t i = startIndex; i < endIndex; i++)
     {
-        if (h[i] == 0)
+        if (nc[i] <= 1)
         {
             keys[i]     = cstone::removeKey<KeyType>{};
             keysRemoved = true;

--- a/sph/include/sph/update_h_gpu.cu
+++ b/sph/include/sph/update_h_gpu.cu
@@ -48,9 +48,9 @@ __global__ void updateSmoothingLengthGpuKernel(GroupView grp, unsigned ng0, cons
     LocalIndex i = grp.groupStart[warpIdx] + laneIdx;
     if (i >= grp.groupEnd[warpIdx]) { return; }
 
-    if (h[i] == 0)
+    if (nc[i] <= 1)
     {
-        keys[i] = cstone::removeKey<KeyType>{};
+        keys[i]                 = cstone::removeKey<KeyType>{};
         nc_h_convergenceFailure = true;
     }
     h[i] = updateH(ng0, nc[i], h[i]);


### PR DESCRIPTION
* Perform additional updates on the global tree when leaf counts are bigger than the configured maximum
* Avoid setting h_i = 0 to flag particles for removal, set neighbor counts nc_i = 1 instead