### PR TITLE
Update non-grav LET until converged

### DIFF
--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -188,15 +188,27 @@ public:
             focusTree_.converge(box(), keyView, global_.assignment(), global_.treeLeaves(), global_.nodeCounts(),
                                 invThetaEff, std::get<0>(scratch));
         }
-        focusTree_.updateMinMac(global_.assignment(), invThetaEff, true);
-        focusTree_.updateTree(global_.assignment(), global_.treeLeaves(), box(), std::get<0>(scratch));
-        focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
 
-        reallocate(focusTree_.octreeViewAcc().numLeafNodes + 1, allocGrowthRate_, layout_, layoutAcc_);
-        focusTree_.discoverHalos(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(h), {rawPtr(layoutAcc_), layoutAcc_.size()},
-                                 haloSearchExt_, get<0>(scratch), false);
-        focusTree_.computeLayout({rawPtr(layoutAcc_), layoutAcc_.size()}, layout_);
-        halos_.exchangeRequests(focusTree_.treeLeaves(), focusTree_.assignment(), layout_);
+        int fail = 0, maxRep = 10;
+        do
+        {
+            focusTree_.updateMinMac(global_.assignment(), invThetaEff, true);
+            focusTree_.updateTree(global_.assignment(), global_.treeLeaves(), box(), std::get<0>(scratch));
+            focusTree_.updateCounts(keyView, global_.treeLeaves(), global_.nodeCounts(), std::get<0>(scratch));
+
+            reallocate(focusTree_.octreeViewAcc().numLeafNodes + 1, allocGrowthRate_, layout_, layoutAcc_);
+            focusTree_.discoverHalos(rawPtr(x), rawPtr(y), rawPtr(z), rawPtr(h),
+                                     {rawPtr(layoutAcc_), layoutAcc_.size()}, haloSearchExt_, get<0>(scratch), false);
+            fail = focusTree_.computeLayout({rawPtr(layoutAcc_), layoutAcc_.size()}, layout_);
+            MPI_Allreduce(MPI_IN_PLACE, &fail, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+            halos_.exchangeRequests(focusTree_.treeLeaves(), focusTree_.assignment(), layout_);
+
+            if (fail)
+            {
+                if (myRank_ == 0) { std::cout << "LET refine, mode=" << fail << std::endl; }
+            }
+        } while (fail && maxRep--);
 
         updateLayout(sorter, keyView, particleKeys, std::tie(x, y, z, h), particleProperties, scratch);
         setupHalos(particleKeys, x, y, z, h, scratch);
@@ -586,9 +598,8 @@ private:
             {
                 std::cout << "rank " << i << " " << assignedSize << " " << layout_.back()
                           << " focus h/true/peers/loc/tot: " << numFlags << "/" << numFocusTruePeer << "/"
-                          << numFocusPeers << "/" << focusAssignment[myRank_].count() << "/"
-                          << flags.size() << " peers: [" << std::max(hPeers.size(), fPeers.size())
-                          << "] ";
+                          << numFocusPeers << "/" << focusAssignment[myRank_].count() << "/" << flags.size()
+                          << " peers: [" << std::max(hPeers.size(), fPeers.size()) << "] ";
                 if (numRanks_ <= 64)
                 {
                     for (auto r : fPeers)

--- a/domain/include/cstone/domain/domain.hpp
+++ b/domain/include/cstone/domain/domain.hpp
@@ -204,10 +204,7 @@ public:
 
             halos_.exchangeRequests(focusTree_.treeLeaves(), focusTree_.assignment(), layout_);
 
-            if (fail)
-            {
-                if (myRank_ == 0) { std::cout << "LET refine, mode=" << fail << std::endl; }
-            }
+            if (fail && myRank_ == 0) { std::cout << "LET refine, mode=" << fail << std::endl; }
         } while (fail && maxRep--);
 
         updateLayout(sorter, keyView, particleKeys, std::tie(x, y, z, h), particleProperties, scratch);
@@ -274,10 +271,7 @@ public:
 
             halos_.exchangeRequests(focusTree_.treeLeaves(), focusTree_.assignment(), layout_);
 
-            if (fail)
-            {
-                if (myRank_ == 0) { std::cout << "LET refine, mode=" << fail << std::endl; }
-            }
+            if (fail && myRank_ == 0) { std::cout << "LET refine, mode=" << fail << std::endl; }
         } while (fail && maxRep--);
 
         // diagnostics(keyView.size());

--- a/domain/test/coord_samples/random.hpp
+++ b/domain/test/coord_samples/random.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "cstone/findneighbors.hpp"
+#include "cstone/domain/layout.hpp"
 #include "cstone/primitives/gather.hpp"
 #include "cstone/sfc/sfc.hpp"
 #include "cstone/tree/definitions.h"
@@ -67,164 +68,22 @@ std::vector<Integer> makeRandomGaussianKeys(size_t numKeys, int seed = 42)
     return ret;
 }
 
-template<class T, class KeyType_>
-class RandomCoordinates
-{
-public:
-    using KeyType = KeyType_;
-    using Integer = typename KeyType::ValueType;
-
-    RandomCoordinates(size_t n, Box<T> box, int seed = 42)
-        : box_(std::move(box))
-        , x_(n)
-        , y_(n)
-        , z_(n)
-        , codes_(n)
-    {
-        // std::random_device rd;
-        std::mt19937 gen(seed);
-        std::uniform_real_distribution<T> disX(box_.xmin(), box_.xmax());
-        std::uniform_real_distribution<T> disY(box_.ymin(), box_.ymax());
-        std::uniform_real_distribution<T> disZ(box_.zmin(), box_.zmax());
-
-        auto randX = [&disX, &gen]() { return disX(gen); };
-        auto randY = [&disY, &gen]() { return disY(gen); };
-        auto randZ = [&disZ, &gen]() { return disZ(gen); };
-
-        std::generate(begin(x_), end(x_), randX);
-        std::generate(begin(y_), end(y_), randY);
-        std::generate(begin(z_), end(z_), randZ);
-
-        auto keyData = (KeyType*)(codes_.data());
-        computeSfcKeys(x_.data(), y_.data(), z_.data(), keyData, n, box);
-
-        std::vector<LocalIndex> sfcOrder(n);
-        std::iota(begin(sfcOrder), end(sfcOrder), LocalIndex(0));
-        sort_by_key(begin(codes_), end(codes_), begin(sfcOrder));
-
-        std::vector<T> temp(x_.size());
-        gather<LocalIndex>(sfcOrder, x_.data(), temp.data());
-        swap(x_, temp);
-        gather<LocalIndex>(sfcOrder, y_.data(), temp.data());
-        swap(y_, temp);
-        gather<LocalIndex>(sfcOrder, z_.data(), temp.data());
-        swap(z_, temp);
-    }
-
-    const std::vector<T>& x() const { return x_; }
-    const std::vector<T>& y() const { return y_; }
-    const std::vector<T>& z() const { return z_; }
-    const std::vector<Integer>& particleKeys() const { return codes_; }
-
-private:
-    Box<T> box_;
-    std::vector<T> x_, y_, z_;
-    std::vector<Integer> codes_;
-};
-
-template<class T, class KeyType_>
-class RandomGaussianCoordinates
-{
-public:
-    using KeyType = KeyType_;
-    using Integer = typename KeyType::ValueType;
-
-    RandomGaussianCoordinates(unsigned n, Box<T> box, int seed = 42)
-        : box_(std::move(box))
-        , x_(n)
-        , y_(n)
-        , z_(n)
-        , codes_(n)
-    {
-        // std::random_device rd;
-        std::mt19937 gen(seed);
-        // random gaussian distribution at the center
-        std::normal_distribution<T> disX((box_.xmax() + box_.xmin()) / 2, (box_.xmax() - box_.xmin()) / 5);
-        std::normal_distribution<T> disY((box_.ymax() + box_.ymin()) / 2, (box_.ymax() - box_.ymin()) / 5);
-        std::normal_distribution<T> disZ((box_.zmax() + box_.zmin()) / 2, (box_.zmax() - box_.zmin()) / 5);
-
-        auto randX = [cmin = box_.xmin(), cmax = box_.xmax(), &disX, &gen]()
-        { return std::max(std::min(disX(gen), cmax), cmin); };
-
-        auto randY = [cmin = box_.ymin(), cmax = box_.ymax(), &disY, &gen]()
-        { return std::max(std::min(disY(gen), cmax), cmin); };
-
-        auto randZ = [cmin = box_.zmin(), cmax = box_.zmax(), &disZ, &gen]()
-        { return std::max(std::min(disZ(gen), cmax), cmin); };
-
-        std::generate(begin(x_), end(x_), randX);
-        std::generate(begin(y_), end(y_), randY);
-        std::generate(begin(z_), end(z_), randZ);
-
-        auto keyData = (KeyType*)(codes_.data());
-        computeSfcKeys(x_.data(), y_.data(), z_.data(), keyData, n, box);
-
-        std::vector<LocalIndex> sfcOrder(n);
-        std::iota(begin(sfcOrder), end(sfcOrder), LocalIndex(0));
-        sort_by_key(begin(codes_), end(codes_), begin(sfcOrder));
-
-        std::vector<T> temp(x_.size());
-        gather<LocalIndex>(sfcOrder, x_.data(), temp.data());
-        swap(x_, temp);
-        gather<LocalIndex>(sfcOrder, y_.data(), temp.data());
-        swap(y_, temp);
-        gather<LocalIndex>(sfcOrder, z_.data(), temp.data());
-        swap(z_, temp);
-    }
-
-    const std::vector<T>& x() const { return x_; }
-    const std::vector<T>& y() const { return y_; }
-    const std::vector<T>& z() const { return z_; }
-    const std::vector<Integer>& particleKeys() const { return codes_; }
-
-private:
-    Box<T> box_;
-    std::vector<T> x_, y_, z_;
-    std::vector<Integer> codes_;
-};
-
 //! @brief can be used to calculate reasonable smoothing lengths for each particle
 template<class KeyType, class Tc, class Th>
 void adjustSmoothingLength(LocalIndex numParticles,
                            unsigned ng0,
                            unsigned ngmax,
-                           const std::vector<Tc>& xGlob,
-                           const std::vector<Tc>& yGlob,
-                           const std::vector<Tc>& zGlob,
-                           std::vector<Th>& hGlob,
+                           const std::vector<KeyType>& sfcKeys,
+                           const std::vector<Tc>& x,
+                           const std::vector<Tc>& y,
+                           const std::vector<Tc>& z,
+                           std::vector<Th>& h,
                            const Box<Tc>& box)
 {
-    std::vector<KeyType> sfcKeys(numParticles);
-
-    std::vector<Tc> x = xGlob;
-    std::vector<Tc> y = yGlob;
-    std::vector<Tc> z = zGlob;
-    std::vector<Tc> h = hGlob;
-
-    computeSfcKeys(x.data(), y.data(), z.data(), sfcKindPointer(sfcKeys.data()), numParticles, box);
-    std::vector<LocalIndex> ordering(numParticles);
-    std::iota(ordering.begin(), ordering.end(), LocalIndex(0));
-    sort_by_key(sfcKeys.begin(), sfcKeys.end(), ordering.begin());
-
-    std::vector<Tc> temp(x.size());
-    gather<LocalIndex>(ordering, x.data(), temp.data());
-    swap(temp, x);
-    gather<LocalIndex>(ordering, y.data(), temp.data());
-    swap(temp, y);
-    gather<LocalIndex>(ordering, z.data(), temp.data());
-    swap(temp, z);
-    gather<LocalIndex>(ordering, h.data(), temp.data());
-    swap(temp, h);
-
-    std::vector<LocalIndex> inverseOrdering(numParticles);
-    std::iota(inverseOrdering.begin(), inverseOrdering.end(), 0);
-    std::vector<LocalIndex> orderCpy = ordering;
-    sort_by_key(orderCpy.begin(), orderCpy.end(), inverseOrdering.begin());
-
     std::vector<cstone::LocalIndex> neighbors(numParticles * ngmax);
     std::vector<unsigned> neighborCounts(numParticles);
 
-    unsigned bucketSize   = 64;
+    unsigned bucketSize   = 16;
     auto [csTree, counts] = computeOctree<KeyType>(std::span(sfcKeys), bucketSize);
     OctreeData<KeyType, CpuTag> octree;
     octree.resize(nNodes(csTree));
@@ -263,11 +122,141 @@ void adjustSmoothingLength(LocalIndex numParticles,
             h[i]        = h[i] * 0.5 * pow(1.0 + (c0 * ng0) / nn, 1.0 / 10.0);
         } while ((neighborCounts[i] < ng0 / 4u || neighborCounts[i] >= ngmax) && iteration++ < 10);
     }
-
-    for (LocalIndex i = 0; i < numParticles; ++i)
-    {
-        hGlob[i] = h[inverseOrdering[i]];
-    }
 }
+
+template<class T, class KeyType_>
+class RandomCoordinatesBase
+{
+public:
+    using KeyType = KeyType_;
+    using Integer = typename KeyType::ValueType;
+
+    RandomCoordinatesBase(size_t n, Box<T> box)
+        : box_(std::move(box))
+        , x_(n)
+        , y_(n)
+        , z_(n)
+        , h_(n)
+        , codes_(n)
+    {
+    }
+
+    void sfcSort(int hOffset = 10)
+    {
+        std::size_t n = x_.size();
+        auto keyData  = (KeyType*)(codes_.data());
+        computeSfcKeys(x_.data(), y_.data(), z_.data(), keyData, n, box_);
+
+        std::vector<LocalIndex> sfcOrder(n);
+        std::iota(begin(sfcOrder), end(sfcOrder), LocalIndex(0));
+        sort_by_key(begin(codes_), end(codes_), begin(sfcOrder));
+
+        std::vector<T> temp(x_.size());
+        gatherArrays(sfcOrder, 0, std::tie(x_, y_, z_), std::tie(temp));
+
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            std::size_t j = i > hOffset ? i - hOffset : std::min(n, i + hOffset);
+
+            Vec3<T> pi{x_[i], y_[i], z_[i]};
+            Vec3<T> pj{x_[j], y_[j], z_[j]};
+
+            h_[i] = 0.5001 * std::sqrt(norm2(pi - pj));
+        }
+        isSfcOrdered_ = true;
+    }
+
+    void adjustH(unsigned ng0, unsigned ngmax)
+    {
+        if (not isSfcOrdered_) throw std::runtime_error("adjustH can only be called with SFC ordered particles\n");
+        adjustSmoothingLength(x_.size(), ng0, ngmax, codes_, x_, y_, z_, h_, box_);
+    }
+
+    void shuffle()
+    {
+        std::vector<LocalIndex> permutation(x_.size());
+        std::iota(begin(permutation), end(permutation), LocalIndex(0));
+        std::mt19937 gen(0);
+        std::ranges::shuffle(permutation, gen);
+
+        std::vector<T> s1(x_.size());
+        std::vector<Integer> s2(x_.size());
+        gatherArrays(permutation, 0, std::tie(x_, y_, z_, h_, codes_), std::tie(s1, s2));
+        isSfcOrdered_ = false;
+    }
+
+    const std::vector<T>& x() const { return x_; }
+    const std::vector<T>& y() const { return y_; }
+    const std::vector<T>& z() const { return z_; }
+    const std::vector<T>& h() const { return h_; }
+    const std::vector<Integer>& particleKeys() const { return codes_; }
+
+protected:
+    bool isSfcOrdered_{false};
+    Box<T> box_;
+    std::vector<T> x_, y_, z_, h_;
+    std::vector<Integer> codes_;
+};
+
+template<class T, class KeyType_>
+class RandomCoordinates : public RandomCoordinatesBase<T, KeyType_>
+{
+public:
+    using Base = RandomCoordinatesBase<T, KeyType_>;
+
+    RandomCoordinates(size_t n, Box<T> box, int hOffset = 5, int seed = 42)
+        : Base(n, box)
+    {
+        std::mt19937 gen(seed);
+        std::uniform_real_distribution<T> disX(box.xmin(), box.xmax());
+        std::uniform_real_distribution<T> disY(box.ymin(), box.ymax());
+        std::uniform_real_distribution<T> disZ(box.zmin(), box.zmax());
+
+        auto randX = [&disX, &gen]() { return disX(gen); };
+        auto randY = [&disY, &gen]() { return disY(gen); };
+        auto randZ = [&disZ, &gen]() { return disZ(gen); };
+
+        std::ranges::generate(Base::x_, randX);
+        std::ranges::generate(Base::y_, randX);
+        std::ranges::generate(Base::z_, randX);
+
+        Base::sfcSort(hOffset);
+    }
+};
+
+template<class T, class KeyType_>
+class RandomGaussianCoordinates : public RandomCoordinatesBase<T, KeyType_>
+{
+public:
+    using Base = RandomCoordinatesBase<T, KeyType_>;
+
+    RandomGaussianCoordinates(size_t n, Box<T> box, int hOffset = 5, int seed = 42)
+        : Base(n, box)
+    {
+        std::mt19937 gen(seed);
+        std::normal_distribution<T> disX((box.xmax() + box.xmin()) / 2, box.lx() / 5);
+        std::normal_distribution<T> disY((box.ymax() + box.ymin()) / 2, box.ly() / 5);
+        std::normal_distribution<T> disZ((box.zmax() + box.zmin()) / 2, box.lz() / 5);
+
+        auto makeDist = [&gen](auto& dist, T a, T b)
+        {
+            return [a, b, &dist, &gen]()
+            {
+                T x = dist(gen);
+                while (x < a || x >= b)
+                {
+                    x = dist(gen);
+                }
+                return x;
+            };
+        };
+
+        std::ranges::generate(Base::x_, makeDist(disX, box.xmin(), box.xmax()));
+        std::ranges::generate(Base::y_, makeDist(disY, box.ymin(), box.ymax()));
+        std::ranges::generate(Base::z_, makeDist(disZ, box.zmin(), box.zmax()));
+
+        Base::sfcSort(hOffset);
+    }
+};
 
 } // namespace cstone

--- a/domain/test/coord_samples/random.hpp
+++ b/domain/test/coord_samples/random.hpp
@@ -141,31 +141,6 @@ public:
     {
     }
 
-    void sfcSort(int hOffset = 10)
-    {
-        std::size_t n = x_.size();
-        auto keyData  = (KeyType*)(codes_.data());
-        computeSfcKeys(x_.data(), y_.data(), z_.data(), keyData, n, box_);
-
-        std::vector<LocalIndex> sfcOrder(n);
-        std::iota(begin(sfcOrder), end(sfcOrder), LocalIndex(0));
-        sort_by_key(begin(codes_), end(codes_), begin(sfcOrder));
-
-        std::vector<T> temp(x_.size());
-        gatherArrays(sfcOrder, 0, std::tie(x_, y_, z_), std::tie(temp));
-
-        for (std::size_t i = 0; i < n; ++i)
-        {
-            std::size_t j = i > hOffset ? i - hOffset : std::min(n, i + hOffset);
-
-            Vec3<T> pi{x_[i], y_[i], z_[i]};
-            Vec3<T> pj{x_[j], y_[j], z_[j]};
-
-            h_[i] = 0.5001 * std::sqrt(norm2(pi - pj));
-        }
-        isSfcOrdered_ = true;
-    }
-
     void adjustH(unsigned ng0, unsigned ngmax)
     {
         if (not isSfcOrdered_) throw std::runtime_error("adjustH can only be called with SFC ordered particles\n");
@@ -192,6 +167,37 @@ public:
     const std::vector<Integer>& particleKeys() const { return codes_; }
 
 protected:
+    void sfcSort()
+    {
+        std::size_t n = x_.size();
+        auto keyData  = (KeyType*)(codes_.data());
+        computeSfcKeys(x_.data(), y_.data(), z_.data(), keyData, n, box_);
+
+        std::vector<LocalIndex> sfcOrder(n);
+        std::iota(begin(sfcOrder), end(sfcOrder), LocalIndex(0));
+        sort_by_key(begin(codes_), end(codes_), begin(sfcOrder));
+
+        std::vector<T> temp(x_.size());
+        gatherArrays(sfcOrder, 0, std::tie(x_, y_, z_, h_), std::tie(temp));
+        isSfcOrdered_ = true;
+    }
+
+    void estimateH(std::size_t hOffset)
+    {
+        if (not isSfcOrdered_) throw std::runtime_error("estimateH can only be called with SFC ordered particles\n");
+        std::size_t n = x_.size();
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            std::size_t j = i > hOffset ? i - hOffset : std::min(n, i + hOffset);
+
+            Vec3<T> pi{x_[i], y_[i], z_[i]};
+            Vec3<T> pj{x_[j], y_[j], z_[j]};
+
+            // avoid exact 0.5, because this will lead to lots of borderline particle pairs with dist == searchRadius
+            h_[i] = 0.5001 * std::sqrt(norm2(pi - pj));
+        }
+    }
+
     bool isSfcOrdered_{false};
     Box<T> box_;
     std::vector<T> x_, y_, z_, h_;
@@ -204,7 +210,7 @@ class RandomCoordinates : public RandomCoordinatesBase<T, KeyType_>
 public:
     using Base = RandomCoordinatesBase<T, KeyType_>;
 
-    RandomCoordinates(size_t n, Box<T> box, int hOffset = 5, int seed = 42)
+    RandomCoordinates(std::size_t n, Box<T> box, std::size_t hOffset = 5, int seed = 42)
         : Base(n, box)
     {
         std::mt19937 gen(seed);
@@ -217,10 +223,11 @@ public:
         auto randZ = [&disZ, &gen]() { return disZ(gen); };
 
         std::ranges::generate(Base::x_, randX);
-        std::ranges::generate(Base::y_, randX);
-        std::ranges::generate(Base::z_, randX);
+        std::ranges::generate(Base::y_, randY);
+        std::ranges::generate(Base::z_, randZ);
 
-        Base::sfcSort(hOffset);
+        Base::sfcSort();
+        Base::estimateH(hOffset);
     }
 };
 
@@ -230,7 +237,7 @@ class RandomGaussianCoordinates : public RandomCoordinatesBase<T, KeyType_>
 public:
     using Base = RandomCoordinatesBase<T, KeyType_>;
 
-    RandomGaussianCoordinates(size_t n, Box<T> box, int hOffset = 5, int seed = 42)
+    RandomGaussianCoordinates(std::size_t n, Box<T> box, std::size_t hOffset = 5, int seed = 42)
         : Base(n, box)
     {
         std::mt19937 gen(seed);
@@ -255,7 +262,8 @@ public:
         std::ranges::generate(Base::y_, makeDist(disY, box.ymin(), box.ymax()));
         std::ranges::generate(Base::z_, makeDist(disZ, box.zmin(), box.zmax()));
 
-        Base::sfcSort(hOffset);
+        Base::sfcSort();
+        Base::estimateH(hOffset);
     }
 };
 

--- a/domain/test/integration_mpi/domain_gpu.cpp
+++ b/domain/test/integration_mpi/domain_gpu.cpp
@@ -34,50 +34,25 @@
 
 using namespace cstone;
 
-/*! @brief random gaussian coordinate init
- *
- * We're not using the coordinates from coord_samples, because we don't
- * want them sorted in Morton order.
- */
-template<class T>
-void initCoordinates(std::vector<T>& x, std::vector<T>& y, std::vector<T>& z, Box<T>& box, int rank)
-{
-    // std::random_device rd;
-    std::mt19937 gen(rank);
-    // random gaussian distribution at the center
-    std::normal_distribution<T> disX((box.xmax() + box.xmin()) / 2, (box.xmax() - box.xmin()) / 5);
-    std::normal_distribution<T> disY((box.ymax() + box.ymin()) / 2, (box.ymax() - box.ymin()) / 5);
-    std::normal_distribution<T> disZ((box.zmax() + box.zmin()) / 2, (box.zmax() - box.zmin()) / 5);
-
-    auto randX = [cmin = box.xmin(), cmax = box.xmax(), &disX, &gen]()
-    { return std::max(std::min(disX(gen), cmax), cmin); };
-    auto randY = [cmin = box.ymin(), cmax = box.ymax(), &disY, &gen]()
-    { return std::max(std::min(disY(gen), cmax), cmin); };
-    auto randZ = [cmin = box.zmin(), cmax = box.zmax(), &disZ, &gen]()
-    { return std::max(std::min(disZ(gen), cmax), cmin); };
-
-    std::generate(begin(x), end(x), randX);
-    std::generate(begin(y), end(y), randY);
-    std::generate(begin(z), end(z), randZ);
-}
-
 template<class KeyType, class T>
 void randomGaussianAssignment(int rank, int numRanks)
 {
     LocalIndex numParticles = 1000;
     Box<T> box(0, 1);
-    int bucketSize      = 20;
+    int bucketSize      = 60;
     int bucketSizeFocus = 10;
 
-    // Note: NOT sorted in SFC order
+    RandomGaussianCoordinates<T, SfcKind<KeyType>> coords(numParticles, box, 5, rank);
+    coords.adjustH(10, 20);
+    coords.shuffle(); // destroy SFC order
+
     std::vector<KeyType> keys(numParticles);
-    std::vector<T> x(numParticles);
-    std::vector<T> y(numParticles);
-    std::vector<T> z(numParticles);
-    std::vector<T> h(numParticles, 0.0000001);
+    std::vector<T> x = coords.x();
+    std::vector<T> y = coords.y();
+    std::vector<T> z = coords.z();
+    std::vector<T> h = coords.h();
     std::vector<T> m(numParticles, 1.0 / (numParticles * numRanks));
     std::vector<uint8_t> rungs(numParticles, rank);
-    initCoordinates(x, y, z, box, rank);
 
     DeviceVector<KeyType> d_keys;
     reallocate(d_keys, numParticles, 1.0);
@@ -105,20 +80,21 @@ void randomGaussianAssignment(int rank, int numRanks)
     EXPECT_EQ(domainCpu.nParticlesWithHalos(), domainGpu.nParticlesWithHalos());
     EXPECT_EQ(domainCpu.globalTree().numNodes, domainGpu.globalTree().numNodes);
     EXPECT_EQ(d_x.size(), x.size());
+    EXPECT_EQ(std::ranges::count(x, 0.0), 0);
+    EXPECT_EQ(std::ranges::count(y, 0.0), 0);
+    EXPECT_EQ(std::ranges::count(z, 0.0), 0);
 
-    {
-        std::vector<KeyType> dl = toHost(d_keys);
-        EXPECT_TRUE(std::equal(dl.begin(), dl.end(), keys.begin()));
-    }
-    {
-        std::vector<T> dl = toHost(d_x);
-        EXPECT_TRUE(std::equal(dl.begin(), dl.end(), x.begin()));
-    }
-    {
-        std::vector<uint8_t> rung_dl = toHost(d_rungs);
-        EXPECT_TRUE(std::equal(rung_dl.begin() + domainGpu.startIndex(), rung_dl.begin() + domainGpu.endIndex(),
-                               rungs.begin() + domainGpu.startIndex()));
-    }
+    std::vector<KeyType> dkeys = toHost(d_keys);
+    EXPECT_TRUE(std::equal(dkeys.begin(), dkeys.end(), keys.begin()));
+
+    std::vector<T> dx = toHost(d_x), dy = toHost(d_y), dz = toHost(d_z);
+    EXPECT_TRUE(std::equal(dx.begin(), dx.end(), x.begin()));
+    EXPECT_TRUE(std::equal(dy.begin(), dy.end(), y.begin()));
+    EXPECT_TRUE(std::equal(dz.begin(), dz.end(), z.begin()));
+
+    std::vector<uint8_t> rung_dl = toHost(d_rungs);
+    EXPECT_TRUE(std::equal(rung_dl.begin() + domainGpu.startIndex(), rung_dl.begin() + domainGpu.endIndex(),
+                           rungs.begin() + domainGpu.startIndex()));
 }
 
 TEST(DomainGpu, matchTreeCpu)

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -33,33 +33,6 @@
 
 using namespace cstone;
 
-/*! @brief random gaussian coordinate init
- *
- * We're not using the coordinates from coord_samples, because we don't
- * want them sorted in Morton order.
- */
-template<class T>
-void initCoordinates(std::vector<T>& x, std::vector<T>& y, std::vector<T>& z, Box<T>& box)
-{
-    // std::random_device rd;
-    std::mt19937 gen(42);
-    // random gaussian distribution at the center
-    std::normal_distribution<T> disX((box.xmax() + box.xmin()) / 2, (box.xmax() - box.xmin()) / 5);
-    std::normal_distribution<T> disY((box.ymax() + box.ymin()) / 2, (box.ymax() - box.ymin()) / 5);
-    std::normal_distribution<T> disZ((box.zmax() + box.zmin()) / 2, (box.zmax() - box.zmin()) / 5);
-
-    auto randX = [cmin = box.xmin(), cmax = box.xmax(), &disX, &gen]()
-    { return std::max(std::min(disX(gen), cmax), cmin); };
-    auto randY = [cmin = box.ymin(), cmax = box.ymax(), &disY, &gen]()
-    { return std::max(std::min(disY(gen), cmax), cmin); };
-    auto randZ = [cmin = box.zmin(), cmax = box.zmax(), &disZ, &gen]()
-    { return std::max(std::min(disZ(gen), cmax), cmin); };
-
-    std::generate(begin(x), end(x), randX);
-    std::generate(begin(y), end(y), randY);
-    std::generate(begin(z), end(z), randZ);
-}
-
 template<class KeyType, class T, class DomainType>
 void randomGaussianDomain(DomainType domain, int rank, int nRanks, bool equalizeH = false)
 {
@@ -67,30 +40,17 @@ void randomGaussianDomain(DomainType domain, int rank, int nRanks, bool equalize
     Box<T> box              = domain.box();
 
     // numParticles identical coordinates on each rank
-    // Note: NOT sorted in morton order
-    std::vector<T> xGlobal(numParticles);
-    std::vector<T> yGlobal(numParticles);
-    std::vector<T> zGlobal(numParticles);
-    initCoordinates(xGlobal, yGlobal, zGlobal, box);
-
-    std::vector<T> hGlobal(numParticles, 0.1);
-
-    if (!equalizeH)
-    {
-        for (std::size_t i = 0; i < hGlobal.size(); ++i)
-        {
-            // tuned such that the particles far from the center have a bigger radius to compensate for lower density
-            hGlobal[i] = 0.05 + 0.2 * (xGlobal[i] * xGlobal[i] + yGlobal[i] * yGlobal[i] + zGlobal[i] * zGlobal[i]);
-        }
-    }
+    RandomGaussianCoordinates<T, SfcKind<KeyType>> coords(numParticles, box, 5);
+    coords.adjustH(10, 20);
+    coords.shuffle(); // destroy SFC order
 
     LocalIndex firstExtract = rank * numParticles / nRanks;
     LocalIndex lastExtract  = (rank + 1) * numParticles / nRanks;
 
-    std::vector<T> x{xGlobal.begin() + firstExtract, xGlobal.begin() + lastExtract};
-    std::vector<T> y{yGlobal.begin() + firstExtract, yGlobal.begin() + lastExtract};
-    std::vector<T> z{zGlobal.begin() + firstExtract, zGlobal.begin() + lastExtract};
-    std::vector<T> h{hGlobal.begin() + firstExtract, hGlobal.begin() + lastExtract};
+    std::vector<T> x{coords.x().begin() + firstExtract, coords.x().begin() + lastExtract};
+    std::vector<T> y{coords.y().begin() + firstExtract, coords.y().begin() + lastExtract};
+    std::vector<T> z{coords.z().begin() + firstExtract, coords.z().begin() + lastExtract};
+    std::vector<T> h{coords.h().begin() + firstExtract, coords.h().begin() + lastExtract};
 
     std::vector<KeyType> keys(x.size());
     std::vector<T> s1, s2, s3;
@@ -125,7 +85,7 @@ void randomGaussianDomain(DomainType domain, int rank, int nRanks, bool equalize
         // calculate reference neighbor sum from the full arrays
         std::vector<cstone::LocalIndex> neighborsRef(numParticles * ngmax);
         std::vector<unsigned> neighborsCountRef(numParticles);
-        all2allNeighbors(xGlobal.data(), yGlobal.data(), zGlobal.data(), hGlobal.data(), numParticles,
+        all2allNeighbors(coords.x().data(), coords.y().data(), coords.z().data(), coords.h().data(), numParticles,
                          neighborsRef.data(), neighborsCountRef.data(), ngmax, box);
 
         int neighborSumRef = std::accumulate(begin(neighborsCountRef), end(neighborsCountRef), 0);

--- a/domain/test/performance/neighbor_driver.cu
+++ b/domain/test/performance/neighbor_driver.cu
@@ -158,12 +158,9 @@ void benchmarkGpu()
     int n = 2000000;
 
     RandomCoordinates<T, StrongKeyType> coords(n, box);
-    std::vector<T> h(n, 0.012);
-
-    // RandomGaussianCoordinates<T, StrongKeyType> coords(n, box);
-    // adjustSmoothingLength<KeyType>(n, 100, 200, coords.x(), coords.y(), coords.z(), h, box);
 
     int ngmax = 200;
+    coords.adjustH(ngmax / 2, ngmax);
 
     std::vector<LocalIndex> neighborsCPU(ngmax * n);
     std::vector<unsigned> neighborsCountCPU(n);
@@ -171,6 +168,7 @@ void benchmarkGpu()
     const T* x = coords.x().data();
     const T* y = coords.y().data();
     const T* z = coords.z().data();
+    const T* h = coords.h().data();
 
     unsigned bucketSize   = 64;
     auto [csTree, counts] = computeOctree(std::span(coords.particleKeys()), bucketSize);
@@ -201,8 +199,7 @@ void benchmarkGpu()
 #pragma omp parallel for
         for (LocalIndex i = 0; i < n; ++i)
         {
-            neighborsCountCPU[i] =
-                findNeighbors(i, x, y, z, h.data(), nsView, box, ngmax, neighborsCPU.data() + i * ngmax);
+            neighborsCountCPU[i] = findNeighbors(i, x, y, z, h, nsView, box, ngmax, neighborsCPU.data() + i * ngmax);
         }
     };
 
@@ -218,7 +215,7 @@ void benchmarkGpu()
     thrust::device_vector<T> d_x(coords.x().begin(), coords.x().end());
     thrust::device_vector<T> d_y(coords.y().begin(), coords.y().end());
     thrust::device_vector<T> d_z(coords.z().begin(), coords.z().end());
-    thrust::device_vector<T> d_h = h;
+    thrust::device_vector<T> d_h(coords.h().begin(), coords.h().end());
 
     thrust::device_vector<KeyType> d_prefixes             = octree.prefixes;
     thrust::device_vector<TreeNodeIndex> d_childOffsets   = octree.childOffsets;

--- a/ryoanji/test/interface/global_forces_gpu.cpp
+++ b/ryoanji/test/interface/global_forces_gpu.cpp
@@ -38,16 +38,16 @@ static int multipoleHolderTest(int thisRank, int numRanks)
     float            theta           = 0.5;
     T                G               = 1.0;
 
-    cstone::Box<T> box{-1, 1};
+    // Fixed boundary to prevent the domain from computing a tightly fitting box, because domain.sync would then
+    // change the relative SFC order of the local particles w.r.t to the global reference set.
+    cstone::Box<T> box(-1, 1, cstone::BoundaryType::fixed);
     // setting numShells to non-zero won't match the direct sum reference because it only includes the replica shells,
     // but not the Ewald corrections, whereas the Barnes-Hut implementation contains both
     int numShells = 0;
 
     // common pool of coordinates, identical on all ranks
     cstone::RandomGaussianCoordinates<T, cstone::SfcKind<KeyType>> coords(numParticles, box);
-
-    std::vector<T> globalH(numParticles, 0.1);
-    adjustSmoothingLength<KeyType>(globalH.size(), 5, 10, coords.x(), coords.y(), coords.z(), globalH, box);
+    coords.adjustH(5, 10);
 
     std::vector<T> globalMasses(numParticles, 1.0 / numParticles);
 
@@ -59,7 +59,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
     std::vector<T>       x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
     std::vector<T>       y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
     std::vector<T>       z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
-    std::vector<T>       h(globalH.begin() + firstIndex, globalH.begin() + lastIndex);
+    std::vector<T>       h(coords.h().begin() + firstIndex, coords.h().begin() + lastIndex);
     std::vector<T>       m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
     std::vector<KeyType> h_keys(x.size());
 
@@ -132,7 +132,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
 
         cstone::DeviceVector<T> d_xref = coords.x(), d_yref = coords.y(), d_zref = coords.z();
         cstone::DeviceVector<T> d_mref = globalMasses;
-        cstone::DeviceVector<T> d_href = globalH;
+        cstone::DeviceVector<T> d_href = coords.h();
 
         cstone::DeviceVector<T> d_potref(numParticles, 0);
         cstone::DeviceVector<T> d_axref(numParticles, 0), d_ayref(numParticles, 0), d_azref(numParticles, 0);

--- a/ryoanji/test/interface/global_upsweep_cpu.cpp
+++ b/ryoanji/test/interface/global_upsweep_cpu.cpp
@@ -33,13 +33,11 @@ static int multipoleExchangeTest(int thisRank, int numRanks)
     unsigned         bucketSizeLocal = 16;
     float            theta           = 1.0;
 
-    cstone::Box<T> box{-1, 1};
+    cstone::Box<T> box(-1, 1, cstone::BoundaryType::fixed);
 
     // common pool of coordinates, identical on all ranks
     cstone::RandomGaussianCoordinates<T, cstone::SfcKind<KeyType>> coords(numRanks * numParticles, box);
-
-    std::vector<T> globalH(numRanks * numParticles, 0.1);
-    adjustSmoothingLength<KeyType>(globalH.size(), 5, 10, coords.x(), coords.y(), coords.z(), globalH, box);
+    coords.adjustH(5, 10);
 
     std::vector<T> globalMasses(numRanks * numParticles, 1.0 / (numRanks * numParticles));
 
@@ -51,7 +49,7 @@ static int multipoleExchangeTest(int thisRank, int numRanks)
     std::vector<T> x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
     std::vector<T> y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
     std::vector<T> z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
-    std::vector<T> h(globalH.begin() + firstIndex, globalH.begin() + lastIndex);
+    std::vector<T> h(coords.h().begin() + firstIndex, coords.h().begin() + lastIndex);
     std::vector<T> m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
 
     std::vector<KeyType> particleKeys(x.size());

--- a/ryoanji/test/interface/global_upsweep_gpu.cpp
+++ b/ryoanji/test/interface/global_upsweep_gpu.cpp
@@ -36,13 +36,11 @@ static int multipoleHolderTest(int thisRank, int numRanks)
     unsigned         bucketSizeLocal = 16;
     float            theta           = 1.0;
 
-    cstone::Box<T> box{-1, 1};
+    cstone::Box<T> box(-1, 1, cstone::BoundaryType::fixed);
 
     // common pool of coordinates, identical on all ranks
     cstone::RandomGaussianCoordinates<T, cstone::SfcKind<KeyType>> coords(numRanks * numParticles, box);
-
-    std::vector<T> globalH(numRanks * numParticles, 0.1);
-    adjustSmoothingLength<KeyType>(globalH.size(), 5, 10, coords.x(), coords.y(), coords.z(), globalH, box);
+    coords.adjustH(5, 10);
 
     std::vector<T> globalMasses(numRanks * numParticles, 1.0 / (numRanks * numParticles));
 
@@ -54,7 +52,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
     std::vector<T> x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
     std::vector<T> y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
     std::vector<T> z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
-    std::vector<T> h(globalH.begin() + firstIndex, globalH.begin() + lastIndex);
+    std::vector<T> h(coords.h().begin() + firstIndex, coords.h().begin() + lastIndex);
     std::vector<T> m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
 
     std::vector<KeyType> particleKeys(x.size());

--- a/ryoanji/test/nbody/traversal_cpu.cpp
+++ b/ryoanji/test/nbody/traversal_cpu.cpp
@@ -39,13 +39,12 @@ TEST(Gravity, TreeWalk)
     LocalIndex     numParticles = 100000;
 
     RandomGaussianCoordinates<T, SfcKind<KeyType>> coordinates(numParticles, box);
+    coordinates.adjustH(2, 5);
 
     const T* x = coordinates.x().data();
     const T* y = coordinates.y().data();
     const T* z = coordinates.z().data();
-
-    std::vector<T> h(numParticles, 0.1);
-    adjustSmoothingLength<KeyType>(h.size(), 2, 5, coordinates.x(), coordinates.y(), coordinates.z(), h, box);
+    const T* h = coordinates.h().data();
 
     std::vector<T> masses(numParticles, T(1) / numParticles);
     for (size_t i = 0; i < masses.size(); ++i)
@@ -87,7 +86,7 @@ TEST(Gravity, TreeWalk)
     auto t0       = std::chrono::high_resolution_clock::now();
     T    egravTot = 0;
     computeGravity(octree.childOffsets.data(), octree.parents.data(), octree.internalToLeaf.data(), centers.data(),
-                   multipoles.data(), layout.data(), 0, octree.numLeafNodes, x, y, z, h.data(), masses.data(), box, G,
+                   multipoles.data(), layout.data(), 0, octree.numLeafNodes, x, y, z, h, masses.data(), box, G,
                    (T*)nullptr, ax.data(), ay.data(), az.data(), &egravTot, numShells);
     auto   t1      = std::chrono::high_resolution_clock::now();
     double elapsed = std::chrono::duration<double>(t1 - t0).count();
@@ -102,7 +101,7 @@ TEST(Gravity, TreeWalk)
     std::vector<T> potentialReference(numParticles, 0);
 
     t0 = std::chrono::high_resolution_clock::now();
-    directSum(x, y, z, h.data(), masses.data(), numParticles, G, {box.lx(), box.ly(), box.lz()}, numShells, Ax.data(),
+    directSum(x, y, z, h, masses.data(), numParticles, G, {box.lx(), box.ly(), box.lz()}, numShells, Ax.data(),
               Ay.data(), Az.data(), potentialReference.data());
     t1      = std::chrono::high_resolution_clock::now();
     elapsed = std::chrono::duration<double>(t1 - t0).count();


### PR DESCRIPTION
* The LET for the non-gravity case also needs to be checked for convergence as we no longer enforce the SFC-key boundaries of peer ranks.

* Improved the `RandomCoordinates` and `RandomGaussianCoordinates` sample sets with h-value estimation based on the distance of nearby particles along the space-filling-curve. Added an option to adjust h for neighbor counts within a given range based on the SFC estimates and added an option to randomly shuffle particles to destroy the SFC order.

* Use the improved sample coordinates with reasonable h values in domain tests to provide better coverage for halo particle detection and exchanges.