### PR TITLE
Fix ryoanji CMake config

### DIFF
--- a/ryoanji/src/ryoanji/interface/CMakeLists.txt
+++ b/ryoanji/src/ryoanji/interface/CMakeLists.txt
@@ -12,10 +12,11 @@ if(CMAKE_CUDA_COMPILER OR CMAKE_HIP_COMPILER)
 
     # intermdiate object to prevent --hip-link from hipcub to propagate to the final link line
     add_library(ryoanji_obj OBJECT ewald.cu multipole_holder.cu)
-    target_include_directories(ryoanji_obj PUBLIC ${PROJECT_SOURCE_DIR}/src ${CSTONE_DIR} ${MPI_CXX_INCLUDE_PATH})
+    # link to cstone_gpu because of its INTERFACE compile definition
+    target_link_libraries(ryoanji_obj PUBLIC cstone_gpu)
+    target_include_directories(ryoanji_obj PUBLIC ${PROJECT_SOURCE_DIR}/src ${MPI_CXX_INCLUDE_PATH})
     add_library(ryoanji $<TARGET_OBJECTS:ryoanji_obj> $<TARGET_OBJECTS:ryoanji_kernels>)
     target_link_libraries(ryoanji PUBLIC cstone_gpu ${MPI_CXX_LIBRARIES})
-    target_include_directories(ryoanji PUBLIC ${MPI_CXX_INCLUDE_PATH})
 endif()
 
 if (CMAKE_HIP_COMPILER)

--- a/ryoanji/test/CMakeLists.txt
+++ b/ryoanji/test/CMakeLists.txt
@@ -25,9 +25,8 @@ endif()
 if (CMAKE_CUDA_COMPILER OR CMAKE_HIP_COMPILER)
     set(testname ryoanji_demo_mpi)
     add_executable(${testname} demo_mpi.cpp)
-    target_include_directories(${testname} PRIVATE ${RYOANJI_TEST_INCLUDE_DIRS})
-
-    target_link_libraries(${testname} PRIVATE cstone_gpu ryoanji)
+    target_include_directories(${testname} PRIVATE ${RYOANJI_TEST_INCLUDE_DIRS} ${MPI_CXX_INCLUDE_PATH})
+    target_link_libraries(${testname} PRIVATE cstone_gpu ryoanji ${MPI_CXX_LIBRARIES})
 
     if (CMAKE_HIP_COMPILER)
         target_link_libraries(${testname} PRIVATE hip::host)


### PR DESCRIPTION
The object library was missing linkage to cstone_gpu and therefore missing some compile definitions.