### PR TITLE
Expand domain.syncGrav test coverage

### DIFF
--- a/domain/include/cstone/tree/octree.hpp
+++ b/domain/include/cstone/tree/octree.hpp
@@ -238,6 +238,7 @@ struct OctreeView
     TreeNodeIndex numLeafNodes;
     TreeNodeIndex numInternalNodes;
     TreeNodeIndex numNodes;
+    TreeNodeIndex numParents;
 
     KeyType* prefixes;
     NodeType* childOffsets;
@@ -309,6 +310,7 @@ public:
         return {numLeafNodes,
                 numInternalNodes,
                 numNodes,
+                TreeNodeIndex(parents.size()),
                 rawPtr(prefixes),
                 rawPtr(childOffsets),
                 rawPtr(parents),
@@ -324,6 +326,7 @@ public:
         return {numLeafNodes,
                 numInternalNodes,
                 numNodes,
+                TreeNodeIndex(parents.size()),
                 rawPtr(prefixes),
                 rawPtr(childOffsets),
                 rawPtr(parents),
@@ -410,6 +413,7 @@ public:
     {
         return {numLeafNodes_,
                 numInternalNodes_,
+                TreeNodeIndex(parents_.size()),
                 levelRange_.back(),
                 prefixes_.data(),
                 childOffsets_.data(),
@@ -425,6 +429,7 @@ public:
     {
         return {numLeafNodes_,
                 numInternalNodes_,
+                TreeNodeIndex(parents_.size()),
                 levelRange_.back(),
                 prefixes_.data(),
                 childOffsets_.data(),

--- a/domain/test/integration_mpi/domain_gpu.cpp
+++ b/domain/test/integration_mpi/domain_gpu.cpp
@@ -274,3 +274,94 @@ TEST(DomainGpu, Allgatherv)
 
     EXPECT_EQ(dstDl, ref);
 }
+
+template<class KeyType, class T>
+void randomGaussianGrav(int thisRank, int numRanks)
+{
+    const LocalIndex numParticles    = 100000;
+    unsigned         bucketSize      = numParticles / (100 * numRanks);
+    unsigned         bucketSizeLocal = std::min(64u, bucketSize);
+    float            theta           = 0.5;
+
+    Box<T> box{-1, 1};
+
+    // common pool of coordinates, identical on all ranks
+    RandomGaussianCoordinates<T, SfcKind<KeyType>> coords(numParticles, box);
+    coords.adjustH(20, 50);
+
+    std::vector<T> globalMasses(numParticles, 1.0 / numParticles);
+
+    LocalIndex firstIndex = (numParticles * thisRank) / numRanks;
+    LocalIndex lastIndex  = (numParticles * (thisRank + 1)) / numRanks;
+
+    // extract a slice of the common pool, each rank takes a different slice, but all slices together
+    // are equal to the common pool
+    std::vector<T>       x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
+    std::vector<T>       y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
+    std::vector<T>       z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
+    std::vector<T>       h(coords.h().begin() + firstIndex, coords.h().begin() + lastIndex);
+    std::vector<T>       m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
+    std::vector<KeyType> keys(x.size());
+
+    DeviceVector<T> d_x          = x;
+    DeviceVector<T> d_y          = y;
+    DeviceVector<T> d_z          = z;
+    DeviceVector<T> d_h          = h;
+    DeviceVector<T> d_m          = m;
+    DeviceVector<KeyType> d_keys = keys;
+
+    auto cpToHost = []<class X>(const X* ptr, int n)
+    {
+        std::vector<X> ret(n);
+        memcpyD2H(ptr, n, ret.data());
+        return ret;
+    };
+
+    std::vector<LocalIndex> layout, h_layout;
+    std::vector<SourceCenterType<T>> centers, h_centers;
+    {
+        Domain<KeyType, T, CpuTag> domain(thisRank, numRanks, bucketSize, bucketSizeLocal, theta, box);
+        std::vector<T> s1, s2, s3;
+        domain.syncGrav(keys, x, y, z, h, m, std::tuple{}, std::tie(s1, s2, s3));
+        domain.exchangeHalos(std::tie(m), s1, s2);
+        layout  = std::vector(domain.layout().begin(), domain.layout().end());
+        centers = std::vector<SourceCenterType<T>>(domain.focusTree().expansionCentersAcc().begin(),
+                                                   domain.focusTree().expansionCentersAcc().end());
+    }
+    {
+        Domain<KeyType, T, GpuTag> domainGpu(thisRank, numRanks, bucketSize, bucketSizeLocal, theta, box);
+        DeviceVector<T> ds1, ds2, gpuOrdering;
+        domainGpu.syncGrav(d_keys, d_x, d_y, d_z, d_h, d_m, std::tuple{}, std::tie(ds1, ds2, gpuOrdering));
+        domainGpu.exchangeHalos(std::tie(d_m), ds1, ds2);
+
+        h_layout  = cpToHost(domainGpu.layout().data(), domainGpu.layout().size());
+        h_centers = cpToHost(domainGpu.focusTree().expansionCentersAcc().data(),
+                             domainGpu.focusTree().expansionCentersAcc().size());
+    }
+
+    EXPECT_EQ(layout, h_layout);
+    for (TreeNodeIndex i = 0; i < centers.size(); ++i)
+    {
+        EXPECT_NEAR(norm2(centers[i] - h_centers[i]), 0.0, 1e-6);
+    }
+
+    auto h_x = toHost(d_x);
+    auto h_y = toHost(d_y);
+    auto h_z = toHost(d_z);
+    auto h_h = toHost(d_h);
+    auto h_m = toHost(d_m);
+
+    EXPECT_EQ(h_x, x);
+    EXPECT_EQ(h_y, y);
+    EXPECT_EQ(h_z, z);
+    EXPECT_EQ(h_h, h);
+    EXPECT_EQ(h_m, m);
+}
+
+TEST(DomainGpu, gravMatchCpu)
+{
+    int rank = 0, nRanks = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nRanks);
+    randomGaussianGrav<uint64_t, double>(rank, nRanks);
+}

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -342,7 +342,7 @@ void randomGaussianGrav(int thisRank, int numRanks)
     RandomGaussianCoordinates<T, SfcKind<KeyType>> coords(numParticles, box);
 
     std::vector<T> globalH(numParticles, 0.1);
-    adjustSmoothingLength<KeyType>(globalH.size(), 100, 150, coords.x(), coords.y(), coords.z(), globalH, box);
+    adjustSmoothingLength<KeyType>(globalH.size(), 200, 250, coords.x(), coords.y(), coords.z(), globalH, box);
 
     std::vector<T> globalMasses(numParticles, 1.0 / numParticles);
 
@@ -441,8 +441,6 @@ void randomGaussianGrav(int thisRank, int numRanks)
                   domain.octreeProperties(), ngmax, neighbors.data(), neighborsCount.data());
 
     uint64_t neighborSum = std::accumulate(begin(neighborsCount), end(neighborsCount), 0);
-    MPI_Allreduce(MPI_IN_PLACE, &neighborSum, 1, MpiType<uint64_t>{}, MPI_SUM, MPI_COMM_WORLD);
-
     {
         std::vector<LocalIndex> neighborsRef(numParticles * ngmax);
         std::vector<unsigned> neighborsCountRef(numParticles);
@@ -469,8 +467,6 @@ void randomGaussianGrav(int thisRank, int numRanks)
 
 
         uint64_t neighborSumRef = std::accumulate(begin(neighborsCountRef), end(neighborsCountRef), uint64_t(0));
-        MPI_Allreduce(MPI_IN_PLACE, &neighborSumRef, 1, MpiType<uint64_t>{}, MPI_SUM, MPI_COMM_WORLD);
-        if (thisRank == 0) { std::cout << "neighbor sum " << neighborSum << std::endl; }
         EXPECT_EQ(neighborSum, neighborSumRef);
     }
 }

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -376,6 +376,47 @@ void randomGaussianGrav(int thisRank, int numRanks)
     auto let_lcounts = ftree.leafCountsAcc();
     auto let_layout  = domain.layout();
 
+    std::span<const SourceCenterType<T>> centers = ftree.expansionCentersAcc();
+
+    // Any leaf in the tree with particles: does it contain the same particles as in the reference set of particles?
+
+    ASSERT_EQ(let_leaves.size(), let_layout.size());
+    for (int i = 0; i < let_leaves.size() - 1; ++i)
+    {
+        if (let_layout[i + 1] > let_layout[i])
+        {
+            EXPECT_EQ(let_layout[i + 1] - let_layout[i], let_lcounts[i]);
+            auto pk1 = keys[let_layout[i]];
+            auto pk2 = keys[let_layout[i + 1] - 1];
+
+            int gi1 = std::lower_bound(gkeys.begin(), gkeys.end(), pk1) - gkeys.begin();
+            int gi2 = std::lower_bound(gkeys.begin(), gkeys.end(), pk2) - gkeys.begin();
+            EXPECT_EQ(gi2 - gi1 + 1, let_lcounts[i]);
+
+            for (int d = 0; d < let_lcounts[i]; ++d)
+            {
+                EXPECT_EQ(keys[let_layout[i] + d], gkeys[gi1 + d]);
+            }
+
+        }
+    }
+
+    // Are all local and remote mass centers correct ?
+
+    for (int i = 0; i < let_full.numNodes; ++i)
+    {
+        KeyType k1 = decodePlaceholderBit(let_full.prefixes[i]);
+        KeyType k2 = k1 + (1ul << (3 * maxTreeLevel<KeyType>{} - decodePrefixLength(let_full.prefixes[i])));
+        int gi1    = std::lower_bound(gkeys.begin(), gkeys.end(), k1) - gkeys.begin();
+        int gi2    = std::lower_bound(gkeys.begin(), gkeys.end(), k2) - gkeys.begin();
+        // leafCenter based on global
+        auto leafCenter =
+            massCenter<T>(coords.x().data(), coords.y().data(), coords.z().data(), globalMasses.data(), gi1, gi2);
+        EXPECT_NEAR(sqrt(norm2(makeVec3(leafCenter) - makeVec3(centers[i]))), 0.0, 1e-5);
+    }
+
+    // Are the MAC flags set correctly? Do nodes marked by MAC have correct particle counts?
+
     {
         KeyType focusStart = let_leaves[ftree.assignment()[thisRank].start()];
         KeyType focusEnd   = let_leaves[ftree.assignment()[thisRank].end()];
@@ -384,7 +425,6 @@ void randomGaussianGrav(int thisRank, int numRanks)
         spanSfcRange(focusStart, focusEnd, spanningKeys.data());
         spanningKeys.back() = focusEnd;
 
-        std::span<const SourceCenterType<T>> centers = ftree.expansionCentersAcc();
         std::vector<uint8_t> marks(let_full.numNodes, 0);
         for (TreeNodeIndex i = 0; i < nNodes(spanningKeys); ++i)
         {
@@ -406,28 +446,6 @@ void randomGaussianGrav(int thisRank, int numRanks)
                 LocalIndex gi1 = std::lower_bound(gkeys.begin(), gkeys.end(), let_leaves[leafIdx]) - gkeys.begin();
                 LocalIndex gi2 = std::lower_bound(gkeys.begin(), gkeys.end(), let_leaves[leafIdx + 1]) - gkeys.begin();
                 EXPECT_EQ(gi2 - gi1 + 1, let_layout[leafIdx + 1] - let_layout[leafIdx]);
-            }
-        }
-    }
-
-    // Any leaf in the tree with particles: does it contain the same particles as in the reference set of particles?
-
-    ASSERT_EQ(let_leaves.size(), let_layout.size());
-    for (int i = 0; i < let_leaves.size() - 1; ++i)
-    {
-        if (let_layout[i + 1] > let_layout[i])
-        {
-            EXPECT_EQ(let_layout[i + 1] - let_layout[i], let_lcounts[i]);
-            auto pk1 = keys[let_layout[i]];
-            auto pk2 = keys[let_layout[i + 1] - 1];
-
-            int gi1 = std::lower_bound(gkeys.begin(), gkeys.end(), pk1) - gkeys.begin();
-            int gi2 = std::lower_bound(gkeys.begin(), gkeys.end(), pk2) - gkeys.begin();
-            EXPECT_EQ(gi2 - gi1 + 1, let_lcounts[i]);
-
-            for (int d = 0; d < let_lcounts[i]; ++d)
-            {
-                EXPECT_EQ(keys[let_layout[i] + d], gkeys[gi1 + d]);
             }
         }
     }

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -331,7 +331,7 @@ TEST(FocusDomain, reapplySync)
 template<class KeyType, class T>
 void randomGaussianGrav(int thisRank, int numRanks)
 {
-    const LocalIndex numParticles    = (100000 / numRanks) * numRanks;
+    const LocalIndex numParticles    = 100000;
     unsigned         bucketSize      = numParticles / (100 * numRanks);
     unsigned         bucketSizeLocal = std::min(64u, bucketSize);
     float            theta           = 0.5;
@@ -342,7 +342,7 @@ void randomGaussianGrav(int thisRank, int numRanks)
     RandomGaussianCoordinates<T, SfcKind<KeyType>> coords(numParticles, box);
 
     std::vector<T> globalH(numParticles, 0.1);
-    adjustSmoothingLength<KeyType>(globalH.size(), 5, 10, coords.x(), coords.y(), coords.z(), globalH, box);
+    adjustSmoothingLength<KeyType>(globalH.size(), 100, 150, coords.x(), coords.y(), coords.z(), globalH, box);
 
     std::vector<T> globalMasses(numParticles, 1.0 / numParticles);
 
@@ -398,6 +398,46 @@ void randomGaussianGrav(int thisRank, int numRanks)
                 EXPECT_EQ(keys[let_layout[i] + d], gkeys[gi1 + d]);
             }
         }
+    }
+
+    int ngmax = 1; // don't store neighbors, only counts
+    std::vector<LocalIndex> neighbors(domain.nParticles() * ngmax);
+    std::vector<unsigned> neighborsCount(domain.nParticles());
+    findNeighbors(x.data(), y.data(), z.data(), h.data(), domain.startIndex(), domain.endIndex(), box,
+                  domain.octreeProperties(), ngmax, neighbors.data(), neighborsCount.data());
+
+    uint64_t neighborSum = std::accumulate(begin(neighborsCount), end(neighborsCount), 0);
+    MPI_Allreduce(MPI_IN_PLACE, &neighborSum, 1, MpiType<uint64_t>{}, MPI_SUM, MPI_COMM_WORLD);
+
+    {
+        std::vector<LocalIndex> neighborsRef(numParticles * ngmax);
+        std::vector<unsigned> neighborsCountRef(numParticles);
+
+        auto [globCsarray, globCounts] = computeOctree(gkeys, 16);
+
+        OctreeData<KeyType, CpuTag> octree;
+        octree.resize(nNodes(globCsarray));
+        updateInternalTree<KeyType>(globCsarray, octree.data());
+
+        std::vector<LocalIndex> layout(globCounts.size() + 1, 0);
+        std::inclusive_scan(globCounts.begin(), globCounts.end(), layout.begin() + 1);
+
+        std::vector<Vec3<T>> geoCenters(octree.numNodes), geoSizes(octree.numNodes);
+        nodeFpCenters<KeyType>(octree.prefixes, geoCenters.data(), geoSizes.data(), box);
+
+        auto o = octree.data();
+        OctreeNsView<T, KeyType> octreeProps{o.numLeafNodes,   o.prefixes,        o.childOffsets,
+                                             o.internalToLeaf, o.levelRange,      globCsarray.data(),
+                                             layout.data(),    geoCenters.data(), geoSizes.data()};
+
+        findNeighbors(coords.x().data(), coords.y().data(), coords.z().data(), globalH.data(), firstGlobalIdx,
+                      lastGlobalIdx, box, octreeProps, ngmax, neighborsRef.data(), neighborsCountRef.data());
+
+
+        uint64_t neighborSumRef = std::accumulate(begin(neighborsCountRef), end(neighborsCountRef), uint64_t(0));
+        MPI_Allreduce(MPI_IN_PLACE, &neighborSumRef, 1, MpiType<uint64_t>{}, MPI_SUM, MPI_COMM_WORLD);
+        if (thisRank == 0) { std::cout << "neighbor sum " << neighborSum << std::endl; }
+        EXPECT_EQ(neighborSum, neighborSumRef);
     }
 }
 

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -327,3 +327,86 @@ TEST(FocusDomain, reapplySync)
         EXPECT_EQ(numCommon, domain.nParticles());
     }
 }
+
+template<class KeyType, class T>
+void randomGaussianGrav(int thisRank, int numRanks)
+{
+    const LocalIndex numParticles    = (100000 / numRanks) * numRanks;
+    unsigned         bucketSize      = numParticles / (100 * numRanks);
+    unsigned         bucketSizeLocal = std::min(64u, bucketSize);
+    float            theta           = 0.5;
+
+    Box<T> box{-1, 1};
+
+    // common pool of coordinates, identical on all ranks
+    RandomGaussianCoordinates<T, SfcKind<KeyType>> coords(numParticles, box);
+
+    std::vector<T> globalH(numParticles, 0.1);
+    adjustSmoothingLength<KeyType>(globalH.size(), 5, 10, coords.x(), coords.y(), coords.z(), globalH, box);
+
+    std::vector<T> globalMasses(numParticles, 1.0 / numParticles);
+
+    LocalIndex firstIndex = (numParticles * thisRank) / numRanks;
+    LocalIndex lastIndex  = (numParticles * (thisRank + 1)) / numRanks;
+
+    // extract a slice of the common pool, each rank takes a different slice, but all slices together
+    // are equal to the common pool
+    std::vector<T>       x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
+    std::vector<T>       y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
+    std::vector<T>       z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
+    std::vector<T>       h(globalH.begin() + firstIndex, globalH.begin() + lastIndex);
+    std::vector<T>       m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
+    std::vector<KeyType> keys(x.size());
+
+    Domain<KeyType, T, CpuTag> domain(thisRank, numRanks, bucketSize, bucketSizeLocal, theta, box);
+
+    std::vector<T> s1, s2, s3;
+    domain.syncGrav(keys, x, y, z, h, m, std::tuple{}, std::tie(s1, s2, s3));
+    domain.exchangeHalos(std::tie(m), s1, s2);
+
+    std::span<const KeyType> gkeys(coords.particleKeys());
+    int firstGlobalIdx = std::lower_bound(gkeys.begin(), gkeys.end(), keys[domain.startIndex()]) - gkeys.begin();
+    int lastGlobalIdx  = std::upper_bound(gkeys.begin(), gkeys.end(), keys[domain.endIndex() - 1]) - gkeys.begin();
+
+    //! the focused octree, structure only
+    auto LET         = domain.focusTree();
+    auto let_full    = LET.octreeViewAcc();
+    auto let_leaves  = LET.treeLeavesAcc();
+    auto let_lcounts = LET.leafCountsAcc();
+    auto let_layout  = domain.layout();
+
+    //std::span<const SourceCenterType<T>> centers = domain.focusTree().expansionCentersAcc();
+
+    //! global ref tree at focus resolution
+    // auto [gtree, gcounts] = computeOctree<KeyType>(coords.particleKeys(), bucketSizeLocal);
+
+    ASSERT_EQ(let_leaves.size(), let_layout.size());
+    for (int i = 0; i < let_leaves.size() - 1; ++i)
+    {
+        if (let_layout[i + 1] > let_layout[i])
+        {
+            EXPECT_EQ(let_layout[i + 1] - let_layout[i], let_lcounts[i]);
+            auto pk1 = keys[let_layout[i]];
+            auto pk2 = keys[let_layout[i + 1] - 1];
+
+            int gi1 = std::lower_bound(gkeys.begin(), gkeys.end(), pk1) - gkeys.begin();
+            int gi2 = std::lower_bound(gkeys.begin(), gkeys.end(), pk2) - gkeys.begin();
+            EXPECT_EQ(gi2 - gi1 + 1, let_lcounts[i]);
+
+            for (int d = 0; d < let_lcounts[i]; ++d)
+            {
+                EXPECT_EQ(keys[let_layout[i] + d], gkeys[gi1 + d]);
+            }
+        }
+    }
+}
+
+TEST(FocusDomain, randomGaussianGrav)
+{
+    int rank = 0, nRanks = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nRanks);
+    {
+        randomGaussianGrav<uint64_t, double>(rank, nRanks);
+    }
+}

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -365,20 +365,52 @@ void randomGaussianGrav(int thisRank, int numRanks)
     domain.exchangeHalos(std::tie(m), s1, s2);
 
     std::span<const KeyType> gkeys(coords.particleKeys());
-    int firstGlobalIdx = std::lower_bound(gkeys.begin(), gkeys.end(), keys[domain.startIndex()]) - gkeys.begin();
-    int lastGlobalIdx  = std::upper_bound(gkeys.begin(), gkeys.end(), keys[domain.endIndex() - 1]) - gkeys.begin();
+    LocalIndex firstGlobalIdx = std::lower_bound(gkeys.begin(), gkeys.end(), keys[domain.startIndex()]) - gkeys.begin();
+    LocalIndex lastGlobalIdx =
+        std::upper_bound(gkeys.begin(), gkeys.end(), keys[domain.endIndex() - 1]) - gkeys.begin();
 
     //! the focused octree, structure only
-    auto LET         = domain.focusTree();
-    auto let_full    = LET.octreeViewAcc();
-    auto let_leaves  = LET.treeLeavesAcc();
-    auto let_lcounts = LET.leafCountsAcc();
+    auto ftree       = domain.focusTree();
+    auto let_full    = ftree.octreeViewAcc();
+    auto let_leaves  = ftree.treeLeavesAcc();
+    auto let_lcounts = ftree.leafCountsAcc();
     auto let_layout  = domain.layout();
 
-    //std::span<const SourceCenterType<T>> centers = domain.focusTree().expansionCentersAcc();
+    {
+        KeyType focusStart = let_leaves[ftree.assignment()[thisRank].start()];
+        KeyType focusEnd   = let_leaves[ftree.assignment()[thisRank].end()];
 
-    //! global ref tree at focus resolution
-    // auto [gtree, gcounts] = computeOctree<KeyType>(coords.particleKeys(), bucketSizeLocal);
+        std::vector<KeyType> spanningKeys(spanSfcRange(focusStart, focusEnd) + 1);
+        spanSfcRange(focusStart, focusEnd, spanningKeys.data());
+        spanningKeys.back() = focusEnd;
+
+        std::span<const SourceCenterType<T>> centers = ftree.expansionCentersAcc();
+        std::vector<uint8_t> marks(let_full.numNodes, 0);
+        for (TreeNodeIndex i = 0; i < nNodes(spanningKeys); ++i)
+        {
+            IBox target                     = sfcIBox(sfcKey(spanningKeys[i]), sfcKey(spanningKeys[i + 1]));
+            auto [targetCenter, targetSize] = centerAndSize<KeyType>(target, box);
+            unsigned maxLevel               = maxTreeLevel<KeyType>{};
+
+            markMacPerBox(targetCenter, targetSize, maxLevel, let_full.prefixes, let_full.childOffsets, centers.data(),
+                          box, focusStart, focusEnd, marks.data());
+        }
+        for (TreeNodeIndex j = 0; j < let_full.numNodes; ++j)
+        {
+            TreeNodeIndex leafIdx = let_full.internalToLeaf[j];
+            bool isLeaf           = leafIdx >= 0;
+            bool isRemote =
+                ftree.assignment()[thisRank].start() <= leafIdx && leafIdx < ftree.assignment()[thisRank].end();
+            if (isLeaf && isRemote && marks[j])
+            {
+                LocalIndex gi1 = std::lower_bound(gkeys.begin(), gkeys.end(), let_leaves[leafIdx]) - gkeys.begin();
+                LocalIndex gi2 = std::lower_bound(gkeys.begin(), gkeys.end(), let_leaves[leafIdx + 1]) - gkeys.begin();
+                EXPECT_EQ(gi2 - gi1 + 1, let_layout[leafIdx + 1] - let_layout[leafIdx]);
+            }
+        }
+    }
+
+    // Any leaf in the tree with particles: does it contain the same particles as in the reference set of particles?
 
     ASSERT_EQ(let_leaves.size(), let_layout.size());
     for (int i = 0; i < let_leaves.size() - 1; ++i)
@@ -399,6 +431,8 @@ void randomGaussianGrav(int thisRank, int numRanks)
             }
         }
     }
+
+    // Do we have all halos to compute correct neighbor counts?
 
     int ngmax = 1; // don't store neighbors, only counts
     std::vector<LocalIndex> neighbors(domain.nParticles() * ngmax);

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -331,18 +331,16 @@ TEST(FocusDomain, reapplySync)
 template<class KeyType, class T>
 void randomGaussianGrav(int thisRank, int numRanks)
 {
-    const LocalIndex numParticles    = 100000;
-    unsigned         bucketSize      = numParticles / (100 * numRanks);
-    unsigned         bucketSizeLocal = std::min(64u, bucketSize);
-    float            theta           = 0.5;
+    const LocalIndex numParticles = 100000;
+    unsigned bucketSize           = numParticles / (100 * numRanks);
+    unsigned bucketSizeLocal      = std::min(64u, bucketSize);
+    float theta                   = 0.5;
 
-    Box<T> box{-1, 1};
+    Box<T> box{-1, 1, cstone::BoundaryType::fixed}; // need to fix box to avoid domain.sync computing a tight fit
 
     // common pool of coordinates, identical on all ranks
     RandomGaussianCoordinates<T, SfcKind<KeyType>> coords(numParticles, box);
-
-    std::vector<T> globalH(numParticles, 0.1);
-    adjustSmoothingLength<KeyType>(globalH.size(), 200, 250, coords.x(), coords.y(), coords.z(), globalH, box);
+    coords.adjustH(200, 250);
 
     std::vector<T> globalMasses(numParticles, 1.0 / numParticles);
 
@@ -351,11 +349,11 @@ void randomGaussianGrav(int thisRank, int numRanks)
 
     // extract a slice of the common pool, each rank takes a different slice, but all slices together
     // are equal to the common pool
-    std::vector<T>       x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
-    std::vector<T>       y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
-    std::vector<T>       z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
-    std::vector<T>       h(globalH.begin() + firstIndex, globalH.begin() + lastIndex);
-    std::vector<T>       m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
+    std::vector<T> x(coords.x().begin() + firstIndex, coords.x().begin() + lastIndex);
+    std::vector<T> y(coords.y().begin() + firstIndex, coords.y().begin() + lastIndex);
+    std::vector<T> z(coords.z().begin() + firstIndex, coords.z().begin() + lastIndex);
+    std::vector<T> h(coords.h().begin() + firstIndex, coords.h().begin() + lastIndex);
+    std::vector<T> m(globalMasses.begin() + firstIndex, globalMasses.begin() + lastIndex);
     std::vector<KeyType> keys(x.size());
 
     Domain<KeyType, T, CpuTag> domain(thisRank, numRanks, bucketSize, bucketSizeLocal, theta, box);
@@ -397,7 +395,6 @@ void randomGaussianGrav(int thisRank, int numRanks)
             {
                 EXPECT_EQ(keys[let_layout[i] + d], gkeys[gi1 + d]);
             }
-
         }
     }
 
@@ -431,8 +428,8 @@ void randomGaussianGrav(int thisRank, int numRanks)
             auto [targetCenter, targetSize] = centerAndSize<KeyType>(target, box);
             unsigned maxLevel               = maxTreeLevel<KeyType>{};
 
-            markMacPerBox(targetCenter, targetSize, maxLevel, let_full.prefixes, let_full.childOffsets, centers.data(),
-                          box, focusStart, focusEnd, marks.data());
+            markMacPerBox(targetCenter, targetSize, maxLevel, let_full.prefixes, let_full.childOffsets,
+                          let_full.parents, centers.data(), box, focusStart, focusEnd, marks.data());
         }
         for (TreeNodeIndex j = 0; j < let_full.numNodes; ++j)
         {
@@ -475,13 +472,12 @@ void randomGaussianGrav(int thisRank, int numRanks)
         nodeFpCenters<KeyType>(octree.prefixes, geoCenters.data(), geoSizes.data(), box);
 
         auto o = octree.data();
-        OctreeNsView<T, KeyType> octreeProps{o.numLeafNodes,   o.prefixes,        o.childOffsets,
-                                             o.internalToLeaf, o.levelRange,      globCsarray.data(),
-                                             layout.data(),    geoCenters.data(), geoSizes.data()};
+        OctreeNsView<T, KeyType> octreeProps{o.numLeafNodes,    o.prefixes,     o.childOffsets,     o.parents,
+                                             o.internalToLeaf,  o.levelRange,   globCsarray.data(), layout.data(),
+                                             geoCenters.data(), geoSizes.data()};
 
-        findNeighbors(coords.x().data(), coords.y().data(), coords.z().data(), globalH.data(), firstGlobalIdx,
+        findNeighbors(coords.x().data(), coords.y().data(), coords.z().data(), coords.h().data(), firstGlobalIdx,
                       lastGlobalIdx, box, octreeProps, ngmax, neighborsRef.data(), neighborsCountRef.data());
-
 
         uint64_t neighborSumRef = std::accumulate(begin(neighborsCountRef), end(neighborsCountRef), uint64_t(0));
         EXPECT_EQ(neighborSum, neighborSumRef);
@@ -493,7 +489,6 @@ TEST(FocusDomain, randomGaussianGrav)
     int rank = 0, nRanks = 0;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nRanks);
-    {
-        randomGaussianGrav<uint64_t, double>(rank, nRanks);
-    }
+
+    randomGaussianGrav<uint64_t, double>(rank, nRanks);
 }

--- a/domain/test/integration_mpi/domain_nranks.cpp
+++ b/domain/test/integration_mpi/domain_nranks.cpp
@@ -409,10 +409,9 @@ void randomGaussianGrav(int thisRank, int numRanks)
         KeyType k2 = k1 + (1ul << (3 * maxTreeLevel<KeyType>{} - decodePrefixLength(let_full.prefixes[i])));
         int gi1    = std::lower_bound(gkeys.begin(), gkeys.end(), k1) - gkeys.begin();
         int gi2    = std::lower_bound(gkeys.begin(), gkeys.end(), k2) - gkeys.begin();
-        // leafCenter based on global
-        auto leafCenter =
+        auto globCenter =
             massCenter<T>(coords.x().data(), coords.y().data(), coords.z().data(), globalMasses.data(), gi1, gi2);
-        EXPECT_NEAR(sqrt(norm2(makeVec3(leafCenter) - makeVec3(centers[i]))), 0.0, 1e-5);
+        EXPECT_NEAR(sqrt(norm2(makeVec3(globCenter) - makeVec3(centers[i]))), 0.0, 1e-5);
     }
 
     // Are the MAC flags set correctly? Do nodes marked by MAC have correct particle counts?

--- a/ryoanji/test/interface/global_forces_gpu.cpp
+++ b/ryoanji/test/interface/global_forces_gpu.cpp
@@ -25,6 +25,7 @@
 
 #include "ryoanji/interface/global_multipole.hpp"
 #include "ryoanji/interface/multipole_holder.cuh"
+#include "ryoanji/nbody/traversal_cpu.hpp"
 
 using namespace ryoanji;
 
@@ -100,6 +101,36 @@ static int multipoleHolderTest(int thisRank, int numRanks)
     multipoleHolder.upsweep(rawPtr(d_x), rawPtr(d_y), rawPtr(d_z), rawPtr(d_m), domain.globalTree(), domain.focusTree(),
                             domain.layout().data());
 
+    std::vector<T> ax_cpu(d_x.size(), 0), ay_cpu(d_x.size(), 0), az_cpu(d_x.size(), 0);
+    {
+        auto cpToHost = []<class X>(const X* ptr, int n)
+        {
+            std::vector<X> ret(n);
+            memcpyD2H(ptr, n, ret.data());
+            return ret;
+        };
+
+        auto child          = cpToHost(octree.childOffsets, octree.numNodes);
+        auto intToLeaf      = cpToHost(octree.internalToLeaf, octree.numNodes);
+        auto centers_cpu    = cpToHost(centers.data(), centers.size());
+        auto multipoles_cpu = cpToHost(multipoleHolder.deviceMultipoles(), octree.numNodes);
+        auto layout         = cpToHost(domain.layout().data(), domain.layout().size());
+
+        auto x = toHost(d_x);
+        auto y = toHost(d_y);
+        auto z = toHost(d_z);
+        auto h = toHost(d_h);
+        auto m = toHost(d_m);
+
+        T egravTot_cpu = 0;
+        computeGravity(child.data(), intToLeaf.data(), centers_cpu.data(), multipoles_cpu.data(), layout.data(), 0,
+                       octree.numLeafNodes, x.data(), y.data(), z.data(), h.data(), m.data(), box, G, (T*)nullptr,
+                       ax_cpu.data(), ay_cpu.data(), az_cpu.data(), &egravTot_cpu, numShells);
+        ax_cpu.erase(ax_cpu.begin(), ax_cpu.begin() + domain.startIndex());
+        ay_cpu.erase(ay_cpu.begin(), ay_cpu.begin() + domain.startIndex());
+        az_cpu.erase(az_cpu.begin(), az_cpu.begin() + domain.startIndex());
+    }
+
     // Check Barnes-Hut accelerations from distributed particle set
     // against the direct-sum reference computed with the (single node) common pool
     bool                pass;
@@ -149,22 +180,30 @@ static int multipoleHolderTest(int thisRank, int numRanks)
         std::vector<T> azRef = dl(d_azref.data() + firstGlobalIdx, d_azref.data() + lastGlobalIdx);
 
         double         potentialSumRef = 0;
-        std::vector<T> errors(ax.size());
+        std::vector<T> errors(ax.size()), errors_cpu(ax.size());
         for (int i = 0; i < ax.size(); i++)
         {
             potentialSumRef += pRef[i];
-            Vec3<T> ref   = {axRef[i], ayRef[i], azRef[i]};
-            Vec3<T> probe = {ax[i], ay[i], az[i]};
-            errors[i]     = std::sqrt(norm2(ref - probe) / norm2(ref));
+            Vec3<T> ref       = {axRef[i], ayRef[i], azRef[i]};
+            Vec3<T> probe     = {ax[i], ay[i], az[i]};
+            Vec3<T> probe_cpu = {ax_cpu[i], ay_cpu[i], az_cpu[i]};
+            errors[i]         = std::sqrt(norm2(ref - probe) / norm2(ref));
+            errors_cpu[i]     = std::sqrt(norm2(ref - probe_cpu) / norm2(ref));
         }
         potentialSumRef *= 0.5 * G;
         std::sort(begin(errors), end(errors));
+        std::sort(begin(errors_cpu), end(errors_cpu));
 
         double err1pc = errors[errors.size() * 0.99];
         double errmax = errors.back();
-
         MPI_Allgather(&err1pc, 1, MPI_DOUBLE, firstPercentiles.data(), 1, MPI_DOUBLE, MPI_COMM_WORLD);
         MPI_Allgather(&errmax, 1, MPI_DOUBLE, maxErrors.data(), 1, MPI_DOUBLE, MPI_COMM_WORLD);
+
+        std::vector<double> firstPercentiles_cpu(numRanks), maxErrors_cpu(numRanks);
+        double              err1pc_cpu = errors_cpu[errors.size() * 0.99];
+        double              errmax_cpu = errors_cpu.back();
+        MPI_Allgather(&err1pc_cpu, 1, MPI_DOUBLE, firstPercentiles_cpu.data(), 1, MPI_DOUBLE, MPI_COMM_WORLD);
+        MPI_Allgather(&errmax_cpu, 1, MPI_DOUBLE, maxErrors_cpu.data(), 1, MPI_DOUBLE, MPI_COMM_WORLD);
 
         double bhPotentialGlob, potentialSumRefGlob;
         MPI_Allreduce(&bhPotential, &bhPotentialGlob, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
@@ -177,8 +216,12 @@ static int multipoleHolderTest(int thisRank, int numRanks)
         if (thisRank == 0)
         {
             for (int i = 0; i < numRanks; ++i)
+            {
                 std::cout << "rank " << i << " 1st-percentile acc error " << firstPercentiles[i] << ", max acc error "
                           << maxErrors[i] << std::endl;
+                std::cout << "rank " << i << " 1st-pct (CPU)  acc error " << firstPercentiles_cpu[i]
+                          << ", max acc error " << maxErrors_cpu[i] << std::endl;
+            }
 
             std::cout << "global reference potential " << potentialSumRefGlob << ", BH global potential "
                       << bhPotentialGlob << std::endl;

--- a/ryoanji/test/interface/global_forces_gpu.cpp
+++ b/ryoanji/test/interface/global_forces_gpu.cpp
@@ -111,6 +111,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
         };
 
         auto child          = cpToHost(octree.childOffsets, octree.numNodes);
+        auto parents        = cpToHost(octree.parents, 1 + octree.numNodes / 8);
         auto intToLeaf      = cpToHost(octree.internalToLeaf, octree.numNodes);
         auto centers_cpu    = cpToHost(centers.data(), centers.size());
         auto multipoles_cpu = cpToHost(multipoleHolder.deviceMultipoles(), octree.numNodes);
@@ -123,9 +124,9 @@ static int multipoleHolderTest(int thisRank, int numRanks)
         auto m = toHost(d_m);
 
         T egravTot_cpu = 0;
-        computeGravity(child.data(), intToLeaf.data(), centers_cpu.data(), multipoles_cpu.data(), layout.data(), 0,
-                       octree.numLeafNodes, x.data(), y.data(), z.data(), h.data(), m.data(), box, G, (T*)nullptr,
-                       ax_cpu.data(), ay_cpu.data(), az_cpu.data(), &egravTot_cpu, numShells);
+        computeGravity(child.data(), parents.data(), intToLeaf.data(), centers_cpu.data(), multipoles_cpu.data(),
+                       layout.data(), 0, octree.numLeafNodes, x.data(), y.data(), z.data(), h.data(), m.data(), box, G,
+                       (T*)nullptr, ax_cpu.data(), ay_cpu.data(), az_cpu.data(), &egravTot_cpu, numShells);
         ax_cpu.erase(ax_cpu.begin(), ax_cpu.begin() + domain.startIndex());
         ay_cpu.erase(ay_cpu.begin(), ay_cpu.begin() + domain.startIndex());
         az_cpu.erase(az_cpu.begin(), az_cpu.begin() + domain.startIndex());

--- a/ryoanji/test/interface/global_forces_gpu.cpp
+++ b/ryoanji/test/interface/global_forces_gpu.cpp
@@ -111,7 +111,7 @@ static int multipoleHolderTest(int thisRank, int numRanks)
         };
 
         auto child          = cpToHost(octree.childOffsets, octree.numNodes);
-        auto parents        = cpToHost(octree.parents, 1 + octree.numNodes / 8);
+        auto parents        = cpToHost(octree.parents, octree.numParents);
         auto intToLeaf      = cpToHost(octree.internalToLeaf, octree.numNodes);
         auto centers_cpu    = cpToHost(centers.data(), centers.size());
         auto multipoles_cpu = cpToHost(multipoleHolder.deviceMultipoles(), octree.numNodes);


### PR DESCRIPTION
There were no tests previously' for `domain.syncGrav`, only indirectly in Ryoanji through multipole upsweep and force computations.