### PR TITLE
Missing particle coordinate memory pre-allocation in grid case added

### DIFF
--- a/main/src/init/sedov_init.hpp
+++ b/main/src/init/sedov_init.hpp
@@ -126,7 +126,7 @@ public:
 
         T              r = settings_.at("r1");
         cstone::Box<T> globalBox(-r, r, cstone::BoundaryType::periodic);
-        std::vector<T> x, y, z;
+        std::vector<T> x(last - first), y(last - first), z(last - first);
         regularGrid(r, cubeSide, first, last, x, y, z);
         d.x = x; // uploads to GPU if active
         d.y = y;


### PR DESCRIPTION
Before merging #568 the vectors storing the coordinates in the grid case where resized by the call to d.resize(last - first) and then passed to regularGrid with the right size. We forgot to do the same with the local vectors. 