### PR TITLE
GPU version of id tagging utils function 

### DIFF
--- a/main/src/io/id_tag_utils.cpp
+++ b/main/src/io/id_tag_utils.cpp
@@ -41,19 +41,6 @@
 namespace sphexa
 {
 
-uint64_t applyTaggingMask(uint64_t groupId, uint64_t id)
-{
-    if (groupId >= maxNumGroupIds)
-        throw std::runtime_error("Tagging group id larger than max value (" + std::to_string(maxNumGroupIds) + ")\n");
-
-    // Clear previous tagging bits if any
-    uint64_t taggedId = id & ~taggingCheckMask;
-
-    taggedId |= ((groupId + 1) << taggingMaskStartingBit);
-
-    return taggedId;
-}
-
 void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                   std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups)
 {

--- a/main/src/io/id_tag_utils.cu
+++ b/main/src/io/id_tag_utils.cu
@@ -46,6 +46,93 @@
 namespace sphexa
 {
 
+struct FindAndTagIdsInList
+{
+    FindAndTagIdsInList(const thrust::device_vector<uint64_t>& selectedIds, const thrust::device_vector<unsigned>& selectedIdsGroups)
+        : selectedIdsSize(selectedIds.size())
+        , selectedIdsPtr(thrust::raw_pointer_cast(selectedIds.data()))
+        , selectedIdsGroupsPtr(thrust::raw_pointer_cast(selectedIdsGroups.data()))
+    {}
+
+    HOST_DEVICE_FUN uint64_t operator()(uint64_t id) const
+    {
+        // Since ids may be already tagged we need to unmask them in the search
+        uint64_t untaggedId = id & ~taggingCheckMask;
+        for(std::size_t i = 0; i < selectedIdsSize; ++i)
+        {
+            if (selectedIdsPtr[i] == untaggedId)
+            {
+                return applyTaggingMask(selectedIdsGroupsPtr[i], id);
+            }
+        }
+        return id;
+    }
+
+    uint64_t selectedIdsSize;
+    const uint64_t* selectedIdsPtr;
+    const unsigned* selectedIdsGroupsPtr;
+};
+
+struct FindAndTagInSphere
+{
+    FindAndTagInSphere(const thrust::device_vector<IdSelectionSphere>& selSpheres, const thrust::device_vector<unsigned>& sphereGroupIds)
+        : numSpheres(selSpheres.size())
+        , selSpheresPtr(thrust::raw_pointer_cast(selSpheres.data()))
+        , sphereGroupIdsPtr(thrust::raw_pointer_cast(sphereGroupIds.data()))
+    {}
+
+    HOST_DEVICE_FUN uint64_t operator()(const thrust::tuple<uint64_t, CoordinateType, CoordinateType, CoordinateType>& particleData) const
+    {
+        uint64_t currentId = get<0>(particleData);
+        const cstone::Vec3<CoordinateType> currentPosition{get<1>(particleData), get<2>(particleData), get<3>(particleData)};
+        for (unsigned groupIndex = 0; groupIndex < numSpheres; ++groupIndex)
+        {
+            const auto     sphere          = selSpheresPtr[groupIndex];
+            const auto     squareRadius    = sphere[3] * sphere[3];
+            const auto     sphereCenter    = util::makeVec3(sphere);
+            auto           squaredDistance = util::norm2(currentPosition - sphereCenter);
+            if (squaredDistance < squareRadius)
+            {
+                currentId = applyTaggingMask(sphereGroupIdsPtr[groupIndex], currentId);
+            }
+        }
+        return currentId;
+    }
+
+    uint64_t numSpheres;
+    const IdSelectionSphere* selSpheresPtr;
+    const unsigned* sphereGroupIdsPtr;
+};
+
+void tagIdsInListGPU(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
+                     std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups)
+{
+    if (selectedIds.size() != selectedIdsGroups.size())
+        throw std::runtime_error("Number of selected ids and number of group ids must be the same\n");
+
+    thrust::device_vector<uint64_t> selectedIdsDev(selectedIds.begin(), selectedIds.end());
+    thrust::device_vector<unsigned> selectedIdsGroupsDev(selectedIdsGroups.begin(), selectedIdsGroups.end());
+    FindAndTagIdsInList findAndTagIdsInList(selectedIdsDev, selectedIdsGroupsDev);
+    thrust::transform(thrust::device, ids.data() + firstIndex, ids.data() + lastIndex, ids.data() + firstIndex, findAndTagIdsInList);
+}
+
+void tagIdsInSphereGPU(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
+                       std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
+                       std::span<const IdSelectionSphere> selSpheres, std::span<const unsigned> sphereGroupIds)
+{
+    if (selSpheres.size() != sphereGroupIds.size())
+        throw std::runtime_error("Number of spherical volumes and number of group ids must be the same\n");
+
+    auto first = thrust::make_zip_iterator(thrust::make_tuple(ids.data() + firstIndex, x.data() + firstIndex,
+                                                        y.data() + firstIndex,  z.data() + firstIndex));
+    auto last  = thrust::make_zip_iterator(thrust::make_tuple(ids.data() + lastIndex,  x.data() + lastIndex,
+                                                        y.data() + lastIndex,  z.data() + lastIndex));
+    thrust::device_vector<IdSelectionSphere> selSpheresDev(selSpheres.begin(), selSpheres.end());
+    thrust::device_vector<unsigned> sphereGroupIdsDev(sphereGroupIds.begin(), sphereGroupIds.end());
+    FindAndTagInSphere findAndTagInSphere(selSpheresDev, sphereGroupIdsDev);
+    thrust::transform(thrust::device, first, last, ids.data() + firstIndex, findAndTagInSphere);
+}
+
 template<class LocalIndexP, template<class> class DeviceVector>
 extern void findTaggedIdsGPU(std::span<const uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                              DeviceVector<LocalIndexP>& taggedIdsIndexes)

--- a/main/src/io/id_tag_utils.hpp
+++ b/main/src/io/id_tag_utils.hpp
@@ -33,6 +33,8 @@
 #pragma once
 
 #include <span>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "cstone/tree/definitions.h"
@@ -71,7 +73,22 @@ struct IsMasked
  * @param[in] id            input id
  * @return                  tagged id
  */
-uint64_t applyTaggingMask(uint64_t groupId, uint64_t id);
+HOST_DEVICE_FUN inline uint64_t applyTaggingMask(uint64_t groupId, uint64_t id)
+{
+    // TODO: implement check for device code as well
+    #if !defined(__CUDACC__) && !defined(__HIPCC__)
+    if (groupId >= maxNumGroupIds)
+        fprintf(stderr, "Tagging group id larger than max value ( %s\n)", std::to_string(maxNumGroupIds).c_str());
+    #endif
+
+    // Clear previous tagging bits if any
+    uint64_t taggedId = id & ~taggingCheckMask;
+
+    taggedId |= ((groupId + 1) << taggingMaskStartingBit);
+
+    return taggedId;
+}
+
 
 /*! @brief Tagged id (in first:last range) identification, CPU version
  *
@@ -111,6 +128,17 @@ using IdSelectionSphere = cstone::Vec4<CoordinateType>;
 void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
                   std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups);
 
+/*! @brief Id tagging (in first:last range) from list, GPU version
+ *
+ * @param[inout] ids               id list
+ * @param[in]    firstIndex        first id index
+ * @param[in]    lastIndex         last (excluded) id index
+ * @param[in]    selectedIds       ids to be tagged (no duplications allowed)
+ * @param[in]    selectedIdsGroups group id for each selected id
+ */
+void tagIdsInListGPU(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t lastIndex,
+                     std::span<const uint64_t> selectedIds, std::span<const unsigned> selectedIdsGroups);
+
 /*! @brief Id tagging (in first:last range) in spherical volume
  *
  * @param[out] ids               id list
@@ -125,4 +153,20 @@ void tagIdsInList(std::span<uint64_t> ids, std::size_t firstIndex, std::size_t l
 void tagIdsInSphere(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
                     std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
                     std::span<const IdSelectionSphere> selSphereData, std::span<const unsigned> sphereGroupIds);
+
+/*! @brief Id tagging (in first:last range) in spherical volume, GPU version
+ *
+ * @param[out] ids               id list
+ * @param[in]  x                 x coordinates
+ * @param[in]  y                 y coordinates
+ * @param[in]  z                 z coordinates
+ * @param[in]  firstIndex        first id index
+ * @param[in]  lastIndex         last (excluded) id index
+ * @param[in]  selSphereData     set of spherical volume definitions
+ * @param[in]  sphereGroupIds    group id for each spherical volume definition
+ */
+void tagIdsInSphereGPU(std::span<uint64_t> ids, std::span<const CoordinateType> x, std::span<const CoordinateType> y,
+                       std::span<const CoordinateType> z, std::size_t firstIndex, std::size_t lastIndex,
+                       std::span<const IdSelectionSphere> selSphereData, std::span<const unsigned> sphereGroupIds);
+
 } // namespace sphexa

--- a/main/test/io/id_tag_utils.cpp
+++ b/main/test/io/id_tag_utils.cpp
@@ -34,34 +34,9 @@
 #include <numeric>
 #include <vector>
 
+#include "id_tag_utils.hpp"
 #include "gtest/gtest.h"
 #include "io/id_tag_utils.hpp"
-
-void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x, std::vector<sphexa::CoordinateType>& y,
-                              std::vector<sphexa::CoordinateType>& z, std::size_t numParticles)
-{
-    x.resize(numParticles);
-    y.resize(numParticles);
-    z.resize(numParticles);
-
-    unsigned int gridSize = std::cbrt(numParticles);
-    double       step     = 2.0 / (gridSize - 1);
-    unsigned int index    = 0;
-    for (unsigned int i = 0; i < gridSize; ++i)
-    {
-        for (unsigned int j = 0; j < gridSize; ++j)
-        {
-            for (unsigned int k = 0; k < gridSize; ++k)
-            {
-                if (index >= numParticles) break;
-                x[index] = -1.0 + i * step;
-                y[index] = -1.0 + j * step;
-                z[index] = -1.0 + k * step;
-                ++index;
-            }
-        }
-    }
-}
 
 TEST(IO, applyTaggingMaskZero)
 {

--- a/main/test/io/id_tag_utils.hpp
+++ b/main/test/io/id_tag_utils.hpp
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * SPH-EXA
+ * Copyright (c) 2024 CSCS, ETH Zurich, University of Basel, University of Zurich
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*! @file
+ * @brief Utility functions for id tagging related functionality unit tests
+ *
+ * @author Christopher Bignamini <christopher.bignamini@gmail.com>
+ * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ */
+
+#include <vector>
+
+#include "io/id_tag_utils.hpp"
+
+void makeParticleDistribution(std::vector<sphexa::CoordinateType>& x, std::vector<sphexa::CoordinateType>& y,
+                              std::vector<sphexa::CoordinateType>& z, std::size_t numParticles)
+{
+    x.resize(numParticles);
+    y.resize(numParticles);
+    z.resize(numParticles);
+
+    unsigned int gridSize = std::cbrt(numParticles);
+    double       step     = 2.0 / (gridSize - 1);
+    unsigned int index    = 0;
+    for (unsigned int i = 0; i < gridSize; ++i)
+    {
+        for (unsigned int j = 0; j < gridSize; ++j)
+        {
+            for (unsigned int k = 0; k < gridSize; ++k)
+            {
+                if (index >= numParticles) break;
+                x[index] = -1.0 + i * step;
+                y[index] = -1.0 + j * step;
+                z[index] = -1.0 + k * step;
+                ++index;
+            }
+        }
+    }
+}

--- a/main/test/io/id_tag_utils_gpu.cu
+++ b/main/test/io/id_tag_utils_gpu.cu
@@ -35,10 +35,222 @@
 
 #include <thrust/device_vector.h>
 
+#include "id_tag_utils.hpp"
 #include "cstone/cuda/device_vector.h"
 #include "cstone/cuda/cuda_utils.cuh"
 #include "gtest/gtest.h"
 #include "io/id_tag_utils.hpp"
+
+TEST(IO, tagIdInListGPU)
+{
+    std::vector<uint64_t> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t>   selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<unsigned>   selectedIdsGroups(selectedIds.size(), 0);
+    std::vector<uint64_t>   tagIdsRef = ids;
+    tagIdsRef[0]                      = 18014398509481984ULL;
+    tagIdsRef[1]                      = 18014398509481985ULL;
+    tagIdsRef[2]                      = 18014398509481986ULL;
+    tagIdsRef[3]                      = 18014398509481987ULL;
+    tagIdsRef[6]                      = 18014398509481990ULL;
+    tagIdsRef[11]                     = 18014398509481995ULL;
+    tagIdsRef[13]                     = 18014398509481997ULL;
+    tagIdsRef[23]                     = 18014398509482007ULL;
+    tagIdsRef[71]                     = 18014398509482055ULL;
+    tagIdsRef[83]                     = 18014398509482067ULL;
+    tagIdsRef[91]                     = 18014398509482075ULL;
+    tagIdsRef[95]                     = 18014398509482079ULL;
+    tagIdsRef[99]                     = 18014398509482083ULL;
+
+    cstone::DeviceVector<uint64_t> idsDev(ids);
+    sphexa::tagIdsInListGPU(std::span<uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(),
+                            std::span<const uint64_t>(selectedIds),
+                            std::span<const unsigned>(selectedIdsGroups));
+
+    EXPECT_EQ(toHost(idsDev), tagIdsRef);
+}
+
+TEST(IO, tagIdInListMultipleGroupsGPU)
+{
+    std::vector<uint64_t> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t>   selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<unsigned>   selectedIdsGroups{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2};
+    std::vector<uint64_t>   tagIdsRef = ids;
+    tagIdsRef[0]                      = 18014398509481984ULL;
+    tagIdsRef[1]                      = 18014398509481985ULL;
+    tagIdsRef[2]                      = 18014398509481986ULL;
+    tagIdsRef[3]                      = 18014398509481987ULL;
+    tagIdsRef[6]                      = 36028797018963974ULL;
+    tagIdsRef[11]                     = 36028797018963979ULL;
+    tagIdsRef[13]                     = 36028797018963981ULL;
+    tagIdsRef[23]                     = 36028797018963991ULL;
+    tagIdsRef[71]                     = 54043195528446023ULL;
+    tagIdsRef[83]                     = 54043195528446035ULL;
+    tagIdsRef[91]                     = 54043195528446043ULL;
+    tagIdsRef[95]                     = 54043195528446047ULL;
+    tagIdsRef[99]                     = 54043195528446051ULL;
+
+    cstone::DeviceVector<uint64_t> idsDev(ids);
+    sphexa::tagIdsInListGPU(std::span<uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), 0, idsDev.size(),
+                            std::span<const uint64_t>(selectedIds),
+                            std::span<const unsigned>(selectedIdsGroups));
+
+    EXPECT_EQ(toHost(idsDev), tagIdsRef);
+}
+
+TEST(IO, tagIdInListWithRangeGPU)
+{
+    uint32_t              first = 3;
+    uint32_t              last  = 10;
+    std::vector<uint64_t> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<unsigned> selectedIdsGroups(selectedIds.size(), 0);
+    std::vector<uint64_t>   tagIdsRef = ids;
+    tagIdsRef[3]                      = 18014398509481987ULL;
+    tagIdsRef[6]                      = 18014398509481990ULL;
+
+    cstone::DeviceVector<uint64_t> idsDev(ids);
+    sphexa::tagIdsInListGPU(std::span<uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last,
+                            std::span<const uint64_t>(selectedIds),
+                            std::span<const unsigned>(selectedIdsGroups));
+    EXPECT_EQ(toHost(idsDev), tagIdsRef);
+}
+
+TEST(IO, tagIdInListWithRangeMultipleGroupsGPU)
+{
+    uint32_t              first = 3;
+    uint32_t              last  = 94;
+    std::vector<uint64_t> ids(100);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t> selectedIds{0, 1, 2, 3, 6, 11, 13, 23, 71, 83, 91, 95, 99};
+    std::vector<unsigned> selectedIdsGroups{0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2};
+    std::vector<uint64_t>   tagIdsRef = ids;
+    tagIdsRef[3]                      = 18014398509481987ULL;
+    tagIdsRef[6]                      = 36028797018963974ULL;
+    tagIdsRef[11]                     = 36028797018963979ULL;
+    tagIdsRef[13]                     = 36028797018963981ULL;
+    tagIdsRef[23]                     = 36028797018963991ULL;
+    tagIdsRef[71]                     = 54043195528446023ULL;
+    tagIdsRef[83]                     = 54043195528446035ULL;
+    tagIdsRef[91]                     = 54043195528446043ULL;
+
+    cstone::DeviceVector<uint64_t> idsDev(ids);
+    sphexa::tagIdsInListGPU(std::span<uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()), first, last,
+                            std::span<const uint64_t>(selectedIds),
+                            std::span<const unsigned>(selectedIdsGroups));
+
+    EXPECT_EQ(toHost(idsDev), tagIdsRef);
+}
+
+TEST(IO, tagIdInSphereGPU)
+{
+    std::vector<uint64_t> ids(1000);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t> tagIdsRef = ids;
+
+    // Particle distribution creation
+    std::vector<sphexa::CoordinateType> x, y, z;
+    makeParticleDistribution(x, y, z, 1000);
+
+    // Selection sphere definition
+    sphexa::IdSelectionSphere              selSphereData{0.0, 0.0, 0.0, 0.25};
+    std::vector<sphexa::IdSelectionSphere> selSphereDataVec{selSphereData};
+
+    tagIdsRef[444] = 18014398509482428ULL;
+    tagIdsRef[445] = 18014398509482429ULL;
+    tagIdsRef[454] = 18014398509482438ULL;
+    tagIdsRef[455] = 18014398509482439ULL;
+    tagIdsRef[544] = 18014398509482528ULL;
+    tagIdsRef[545] = 18014398509482529ULL;
+    tagIdsRef[554] = 18014398509482538ULL;
+    tagIdsRef[555] = 18014398509482539ULL;
+
+    cstone::DeviceVector<uint64_t> idsDev(ids);
+    cstone::DeviceVector<sphexa::CoordinateType> xDev(x);
+    cstone::DeviceVector<sphexa::CoordinateType> yDev(y);
+    cstone::DeviceVector<sphexa::CoordinateType> zDev(z);
+    sphexa::tagIdsInSphereGPU(std::span<uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(xDev.data()), xDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(yDev.data()), yDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(zDev.data()), zDev.size()),
+                              0, idsDev.size(), std::span<const sphexa::IdSelectionSphere>(selSphereDataVec),
+                              std::span<const unsigned>(std::vector<unsigned>{0}));
+    EXPECT_EQ(toHost(idsDev), tagIdsRef);
+}
+
+TEST(IO, tagIdInSphereWithRangeGPU)
+{
+    std::vector<uint64_t> ids(1000);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t> tagIdsRef = ids;
+    uint32_t              first     = 400;
+    uint32_t              last      = 500;
+
+    // Particle distribution creation
+    std::vector<sphexa::CoordinateType> x, y, z;
+    makeParticleDistribution(x, y, z, 1000);
+
+    // Selection sphere definition
+    sphexa::IdSelectionSphere              selSphereData{0.0, 0.0, 0.0, 0.25};
+    std::vector<sphexa::IdSelectionSphere> selSphereDataVec{selSphereData};
+
+    tagIdsRef[444] = 18014398509482428ULL;
+    tagIdsRef[445] = 18014398509482429ULL;
+    tagIdsRef[454] = 18014398509482438ULL;
+    tagIdsRef[455] = 18014398509482439ULL;
+    cstone::DeviceVector<uint64_t> idsDev(ids);
+    cstone::DeviceVector<sphexa::CoordinateType> xDev(x);
+    cstone::DeviceVector<sphexa::CoordinateType> yDev(y);
+    cstone::DeviceVector<sphexa::CoordinateType> zDev(z);
+    sphexa::tagIdsInSphereGPU(std::span<uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(xDev.data()), xDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(yDev.data()), yDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(zDev.data()), zDev.size()),
+                              first, last, std::span<const sphexa::IdSelectionSphere>(selSphereDataVec),
+                              std::span<const unsigned>(std::vector<unsigned>{0}));
+    EXPECT_EQ(toHost(idsDev), tagIdsRef);
+}
+
+TEST(IO, tagIdInMultipleSpheresGPU)
+{
+    std::vector<uint64_t> ids(1000);
+    std::iota(ids.begin(), ids.end(), 0);
+    std::vector<uint64_t> tagIdsRef = ids;
+
+    // Particle distribution creation
+    std::vector<sphexa::CoordinateType> x, y, z;
+    makeParticleDistribution(x, y, z, 1000);
+
+    // Selection spheres definition: second sphere overlaps with first one
+    std::vector<sphexa::IdSelectionSphere> selSphereDataVec{sphexa::IdSelectionSphere{0.0, 0.0, 0.0, 0.25},
+                                                            sphexa::IdSelectionSphere{0.1, 0.1, 0.1, 0.25}};
+
+    tagIdsRef[444] = 18014398509482428ULL;
+    tagIdsRef[445] = 18014398509482429ULL;
+    tagIdsRef[454] = 18014398509482438ULL;
+    tagIdsRef[455] = 36028797018964423ULL;
+    tagIdsRef[544] = 18014398509482528ULL;
+    tagIdsRef[545] = 36028797018964513ULL;
+    tagIdsRef[554] = 36028797018964522ULL;
+    tagIdsRef[555] = 36028797018964523ULL;
+    tagIdsRef[556] = 36028797018964524ULL;
+    tagIdsRef[565] = 36028797018964533ULL;
+    tagIdsRef[655] = 36028797018964623ULL;
+
+    cstone::DeviceVector<uint64_t> idsDev(ids);
+    cstone::DeviceVector<sphexa::CoordinateType> xDev(x);
+    cstone::DeviceVector<sphexa::CoordinateType> yDev(y);
+    cstone::DeviceVector<sphexa::CoordinateType> zDev(z);
+    sphexa::tagIdsInSphereGPU(std::span<uint64_t>(thrust::raw_pointer_cast(idsDev.data()), idsDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(xDev.data()), xDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(yDev.data()), yDev.size()),
+                              std::span<const sphexa::CoordinateType>(thrust::raw_pointer_cast(zDev.data()), zDev.size()),
+                              0, idsDev.size(), std::span<const sphexa::IdSelectionSphere>(selSphereDataVec),
+                              std::span<const unsigned>(std::vector<unsigned>{0, 1}));
+    EXPECT_EQ(toHost(idsDev), tagIdsRef);
+}
 
 TEST(IO, taggedIdIdentificationGPU)
 {


### PR DESCRIPTION
Given the new ParticleData field storage strategy (either exclusively on the host or on the device), the functions introduced in this PR implement ID tagging directly on the device, thereby avoiding any data transfer to the host.