### PR TITLE
Grackle propagator and eos_cooling compilation error fix

### DIFF
--- a/main/src/propagator/std_hydro_grackle.hpp
+++ b/main/src/propagator/std_hydro_grackle.hpp
@@ -209,21 +209,11 @@ public:
         computeTimestep(first, last, d, minDtCooling);
         timer.step("Timestep");
 
-        // TODO: this is needed to avoid the deep copy of du in CPU case.
-        if constexpr (IsDeviceVector<std::decay_t<decltype(d.du)>>::value)
-        {
-            auto du = toHost(d.du);
-            cooling_data.cool_particles(T(d.minDt), rho.data(), u.data(),
-                                        cstone::getPointers(get<CoolingFields>(simData.chem), 0), du.data(), first,
-                                        last);
-            d.du = std::move(du);
-        }
-        else
-        {
-            cooling_data.cool_particles(T(d.minDt), rho.data(), u.data(),
-                                        cstone::getPointers(get<CoolingFields>(simData.chem), 0), d.du.data(), first,
-                                        last);
-        }
+        auto du = toHost(d.du);
+        cooling_data.cool_particles(T(d.minDt), rho.data(), u.data(),
+                                    cstone::getPointers(get<CoolingFields>(simData.chem), 0), du.data(), first, last);
+
+        d.du = std::move(du);
         timer.step("GRACKLE chemistry and cooling");
 
         computePositions(groups_.view(), d, domain.box(), d.minDt, {float(d.minDt_m1)});

--- a/main/src/propagator/std_hydro_grackle.hpp
+++ b/main/src/propagator/std_hydro_grackle.hpp
@@ -209,11 +209,21 @@ public:
         computeTimestep(first, last, d, minDtCooling);
         timer.step("Timestep");
 
-        auto du = toHost(d.du);
-        cooling_data.cool_particles(T(d.minDt), rho.data(), u.data(),
-                                    cstone::getPointers(get<CoolingFields>(simData.chem), 0), du.data(), first, last);
-
-        d.du = std::move(du);
+        // TODO: this is needed to avoid the deep copy of du in CPU case.
+        if constexpr (IsDeviceVector<std::decay_t<decltype(d.du)>>::value)
+        {
+            auto du = toHost(d.du);
+            cooling_data.cool_particles(T(d.minDt), rho.data(), u.data(),
+                                        cstone::getPointers(get<CoolingFields>(simData.chem), 0), du.data(), first,
+                                        last);
+            d.du = std::move(du);
+        }
+        else
+        {
+            cooling_data.cool_particles(T(d.minDt), rho.data(), u.data(),
+                                        cstone::getPointers(get<CoolingFields>(simData.chem), 0), d.du.data(), first,
+                                        last);
+        }
         timer.step("GRACKLE chemistry and cooling");
 
         computePositions(groups_.view(), d, domain.box(), d.minDt, {float(d.minDt_m1)});

--- a/main/src/propagator/std_hydro_grackle.hpp
+++ b/main/src/propagator/std_hydro_grackle.hpp
@@ -202,14 +202,14 @@ public:
         size_t first = domain.startIndex();
         size_t last  = domain.endIndex();
 
-        const auto&& rho = toHost(d.rho);
-        const auto&& u   = toHost(d.u);
+        auto&& rho = toHost(d.rho);
+        auto&& u   = toHost(d.u);
 
         auto minDtCooling = cooling::coolingTimestep(first, last, rho.data(), u.data(), cooling_data, simData.chem);
         computeTimestep(first, last, d, minDtCooling);
         timer.step("Timestep");
 
-        auto&& du = toHost(d.du);
+        auto du = toHost(d.du);
         cooling_data.cool_particles(T(d.minDt), rho.data(), u.data(),
                                     cstone::getPointers(get<CoolingFields>(simData.chem), 0), du.data(), first, last);
 

--- a/physics/cooling/include/cooling/eos_cooling.hpp
+++ b/physics/cooling/include/cooling/eos_cooling.hpp
@@ -26,8 +26,8 @@ void eos_cooling(size_t startIndex, size_t endIndex, HydroData& d, ChemData& che
     using T              = typename HydroData::HydroType;
     const auto chemistry = cstone::getPointers(get<CoolingFields>(chem), 0);
 
-    const auto&& rho = toHost(d.rho);
-    const auto&& u   = toHost(d.u);
+    auto&& rho = toHost(d.rho);
+    auto&& u   = toHost(d.u);
 
     std::vector<T> p(rho.size()), c(rho.size());
     cooler.computePressures(rho.data(), u.data(), chemistry, p.data(), startIndex, endIndex);


### PR DESCRIPTION
The const keywords in the integrate method of HydroGrackleProp and cooling/eos_cooling.hpp, such as 
`const auto&& rho = toHost(d.rho);`
`const auto&& u   = toHost(d.u);`
generate rvalue/lvalue binding errors at compile time and the 
`auto&& du = toHost(d.du);`
line in the integrate method a template argument deduction error. This second error should be fixable by changing the signature of cool_particles which, however, makes sense in terms of const correctness.   