### PR TITLE
Explicitly write step attribute value provided by rank 0

### DIFF
--- a/domain/include/cstone/primitives/mpi_wrappers.hpp
+++ b/domain/include/cstone/primitives/mpi_wrappers.hpp
@@ -28,7 +28,7 @@ namespace detail
 // nvcc doesn't allow making this constexpr with OpenMPI, as the type macros contain a static_cast<void*>
 static MPI_Datatype typeIDs[] = {MPI_DOUBLE, MPI_FLOAT, MPI_CHAR, MPI_SIGNED_CHAR, MPI_UNSIGNED_CHAR,
                                  MPI_SHORT, MPI_UNSIGNED_SHORT, MPI_INT, MPI_UNSIGNED, MPI_LONG,
-                                 MPI_UNSIGNED_LONG, MPI_LONG_LONG, MPI_UNSIGNED_LONG_LONG};
+                                 MPI_UNSIGNED_LONG, MPI_LONG_LONG, MPI_UNSIGNED_LONG_LONG, MPI_DATATYPE_NULL};
 // clang-format on
 } // namespace detail
 

--- a/main/src/io/ifile_io.hpp
+++ b/main/src/io/ifile_io.hpp
@@ -57,8 +57,9 @@ public:
 
     virtual ~IFileWriter() = default;
 
-    virtual void     addStep(size_t firstIndex, size_t lastIndex, std::string path) = 0;
-    virtual int64_t  stepAttributeSize(const std::string& /*key*/) { return 0; }
+    virtual void    addStep(size_t firstIndex, size_t lastIndex, std::string path) = 0;
+    virtual int64_t stepAttributeSize(const std::string& /*key*/) { return 0; }
+    //! @brief Writes a step attribute. If called from multiple ranks, the value of rank 0 will be written
     virtual void     stepAttribute(const std::string& key, FieldType val, int64_t size) = 0;
     virtual void     stepAttribute(const std::string& key, const std::string& val)      = 0;
     virtual void     fileAttribute(const std::string& key, FieldType val, int64_t size) = 0;

--- a/main/src/io/ifile_io.hpp
+++ b/main/src/io/ifile_io.hpp
@@ -59,7 +59,11 @@ public:
 
     virtual void    addStep(size_t firstIndex, size_t lastIndex, std::string path) = 0;
     virtual int64_t stepAttributeSize(const std::string& /*key*/) { return 0; }
-    //! @brief Writes a step attribute. If called from multiple ranks, the value of rank 0 will be written
+    //! @brief Writes a step attribute.
+    //! If called from multiple ranks, the value of rank 0 will be written. The call is collective in that
+    //! case, and all participating ranks must provide the same @p size and a @p FieldType holding the
+    //! same underlying attribute type. Supplying mismatched sizes or types across ranks may cause the
+    //! underlying collective communication to hang or fail.
     virtual void     stepAttribute(const std::string& key, FieldType val, int64_t size) = 0;
     virtual void     stepAttribute(const std::string& key, const std::string& val)      = 0;
     virtual void     fileAttribute(const std::string& key, FieldType val, int64_t size) = 0;

--- a/main/src/io/ifile_io_hdf5.cpp
+++ b/main/src/io/ifile_io_hdf5.cpp
@@ -103,7 +103,10 @@ public:
                 // so we explicitly broadcast the value of rank 0 to all ranks
                 using Type = std::decay_t<decltype(*argp)>;
                 std::vector<Type> arg(size);
-                std::copy(argp, argp + size, arg.data());
+                if (size > 0 && rank_ == 0)
+                {
+                    std::copy(argp, argp + size, arg.data());
+                }
                 MPI_Bcast(arg.data(), size, MpiType<Type>{}, 0, comm_);
                 fileutils::H5WriteStepAttribT(h5File_, key.c_str(), arg.data(), size);
             },

--- a/main/src/io/ifile_io_hdf5.cpp
+++ b/main/src/io/ifile_io_hdf5.cpp
@@ -98,8 +98,14 @@ public:
     void stepAttribute(const std::string& key, FieldType val, int64_t size) override
     {
         std::visit(
-            [this, &key, size](auto arg) { //
-                fileutils::H5WriteStepAttribT(h5File_, key.c_str(), arg, size);
+            [this, &key, size](auto argp) { //
+                // if val differs between rank it's a data race, if we only call on rank 0 it hangs
+                // so we explicitly broadcast the value of rank 0 to all ranks
+                using Type = std::decay_t<decltype(*argp)>;
+                std::vector<Type> arg(size);
+                std::copy(argp, argp + size, arg.data());
+                MPI_Bcast(arg.data(), size, MpiType<Type>{}, 0, comm_);
+                fileutils::H5WriteStepAttribT(h5File_, key.c_str(), arg.data(), size);
             },
             val);
     }
@@ -208,7 +214,14 @@ public:
 
     void stepAttribute(const std::string& key, FieldType val, int64_t size) override
     {
-        if (rank_ == 0) { Base::stepAttribute(key, val, size); }
+        if (rank_ == 0)
+        {
+            std::visit(
+                [this, &key, size](auto arg) { //
+                    fileutils::H5WriteStepAttribT(h5File_, key.c_str(), arg, size);
+                },
+                val);
+        }
     }
 
     void stepAttribute(const std::string& key, const std::string& val) override


### PR DESCRIPTION
When opening a file for parallel writes during checkpointing, `stepAttribute` nevertheless has to be called on all ranks,
even though calling with different attribute values constitutes a data race.

As a work-around, I broadcast the attribute of rank 0 to all other ranks to support the case
where only rank 0 has a valid attribute value.