### PR TITLE
Update ascent_adaptor.h

### DIFF
--- a/main/src/ascent_adaptor.h
+++ b/main/src/ascent_adaptor.h
@@ -88,7 +88,8 @@ void Initialize([[maybe_unused]] DataType& d, [[maybe_unused]] long startIndex)
     scenes["s1/renders/r1/image_prefix"] = output_path + "density.%05d";
     scenes["s1/renders/r1/image_width"] = 1920;
     scenes["s1/renders/r1/image_height"] = 1080;
-
+    scenes["s1/renders/r1/tiled_rendering"] = "false";
+    
     scenes["s1/renders/r1/camera/look_at"].set({0.5, 0.125, 0.125});
     scenes["s1/renders/r1/camera/position"].set({0.5, 0.125, 3.0});
     scenes["s1/renders/r1/camera/up"].set({0.0, 1.0, 0.0});


### PR DESCRIPTION
turn tiled rendering off (the default is on) to render high resolution images. see details at https://github.com/Alpine-DAV/ascent/issues/1681