### PR TITLE
add missing thrust tuple includes

### DIFF
--- a/domain/include/cstone/primitives/primitives_gpu.cu
+++ b/domain/include/cstone/primitives/primitives_gpu.cu
@@ -22,6 +22,7 @@
 #include <thrust/reduce.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/tuple.h>
 
 #include "cstone/cuda/cub.hpp"
 #include "cstone/cuda/errorcheck.cuh"

--- a/main/src/observables/gpu_reductions.cu
+++ b/main/src/observables/gpu_reductions.cu
@@ -32,6 +32,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/transform_reduce.h>
+#include <thrust/tuple.h>
 
 #include "gpu_reductions.h"
 


### PR DESCRIPTION
Some missing thrust includes in GPU translation units that pop up with CUDA 13.3