### PR TITLE
Create continuous mixed dimension SFC

### DIFF
--- a/domain/include/cstone/sfc/hilbert.hpp
+++ b/domain/include/cstone/sfc/hilbert.hpp
@@ -179,13 +179,47 @@ iHilbert(unsigned px, unsigned py, unsigned pz, unsigned bx, unsigned by, unsign
 
     if (bits[1] > bits[2]) // 2 dims have more bits than the 3rd, add 2D levels
     {
-        const int n = bits[1] - bits[2];
-        // encode n 2D levels with 2D-Hilbert and add it to the key
-        // 2D key needs to be computed only for n bits
-        const KeyType key2D = iHilbert2D<KeyType>(sortedCoordinates[0] >> bits[2], sortedCoordinates[1] >> bits[2], n);
-        // IM: Check if we want to the 2D key together or break it from 2 bits per level to 3 bits per level
-        // key |= key2D << (3 * bits[2]);
-        // or below
+        const int n        = bits[1] - bits[2];
+        const KeyType mask = (static_cast<KeyType>(1) << bits[2]) - 1;
+
+        /* Inline version of iHilbert2D's own recursion, run on the high (2D-prefix) bits to compute
+         * key2D exactly as iHilbert2D<KeyType>(hiX, hiY, n) would. In addition, the identical
+         * swap/complement that iHilbert2D applies to (hiX, hiY) at each level is also applied here to
+         * the low (to-be-3D-encoded) bits (lowX, lowY), so that by the time we reach the 3D-Hilbert
+         * suffix, its coordinates are expressed in the orientation implied by the 2D digits - this is
+         * the forward counterpart of the rotation that decodeHilbert() undoes. z is left untouched,
+         * exactly as iHilbert2D never touches a third coordinate. */
+        KeyType hiX  = sortedCoordinates[0] >> bits[2];
+        KeyType hiY  = sortedCoordinates[1] >> bits[2];
+        KeyType lowX = sortedCoordinates[0] & mask;
+        KeyType lowY = sortedCoordinates[1] & mask;
+
+        KeyType key2D = 0;
+        for (int level = n - 1; level >= 0; --level)
+        {
+            const unsigned xi = static_cast<unsigned>((hiX >> level) & KeyType{1});
+            const unsigned yi = static_cast<unsigned>((hiY >> level) & KeyType{1});
+
+            key2D = 4 * key2D + 2 * xi + (xi ^ yi); // append two bits to key2D, same as iHilbert2D
+
+            if (yi == 0)
+            {
+                KeyType tmpHi  = hiX;
+                hiX            = hiY;
+                hiY            = tmpHi;
+                KeyType tmpLow = lowX;
+                lowX           = lowY;
+                lowY           = tmpLow;
+                if (xi == 1)
+                {
+                    hiX  = ~hiX;
+                    hiY  = ~hiY;
+                    lowX = mask - lowX;
+                    lowY = mask - lowY;
+                }
+            }
+        }
+
         for (int i{0}; i < n; ++i)
         {
             const auto processes2DKeyBitIndex      = n - 1 - i;
@@ -193,10 +227,9 @@ iHilbert(unsigned px, unsigned py, unsigned pz, unsigned bx, unsigned by, unsign
             key |= static_cast<KeyType>(static_cast<KeyType>(key2D >> (2 * processes2DKeyBitIndex)) & 3)
                    << (3 * processesCoordinateBitIndex);
         }
-        // remove n bits from sortedCoordinates[0] and sortedCoordinates[1]
-        const KeyType mask = (static_cast<KeyType>(1) << bits[2]) - 1;
-        sortedCoordinates[0] &= mask;
-        sortedCoordinates[1] &= mask;
+        // low bits are now the rotated (lowX, lowY), ready to be fed into the 3D-Hilbert suffix
+        sortedCoordinates[0] = lowX;
+        sortedCoordinates[1] = lowY;
         bits[0] -= n;
         bits[1] -= n;
         // now we have bits[0] == bits[1] == bits[2]
@@ -208,7 +241,8 @@ iHilbert(unsigned px, unsigned py, unsigned pz, unsigned bx, unsigned by, unsign
     assert(sortedCoordinates[1] < (static_cast<KeyType>(1) << bits[2]));
 
     // encode remaining bits[0] == min(bx,by,bz) 3D levels or octal digits with 3D-Hilbert and add to key
-    const KeyType key3D = iHilbert3D<KeyType>(sortedCoordinates[0], sortedCoordinates[1], sortedCoordinates[2], bits[2]);
+    const KeyType key3D =
+        iHilbert3D<KeyType>(sortedCoordinates[0], sortedCoordinates[1], sortedCoordinates[2], bits[2]);
     key |= key3D;
     // Example for (bx,by,bz) = (10,9,7): 1D,2D,2D,3D*7
 
@@ -398,9 +432,9 @@ decodeHilbert(KeyType key, unsigned bx, unsigned by, unsigned bz) noexcept
     }
     const auto shift3D     = maxTreeLevel<KeyType>{} - bits[2];
     const auto pair3D      = decodeHilbert3D<KeyType>(key << (3 * shift3D));
-    KeyType   x3d          = get<0>(pair3D) >> shift3D;
-    KeyType   y3d          = get<1>(pair3D) >> shift3D;
-    KeyType   z3d          = get<2>(pair3D) >> shift3D;
+    KeyType x3d            = get<0>(pair3D) >> shift3D;
+    KeyType y3d            = get<1>(pair3D) >> shift3D;
+    KeyType z3d            = get<2>(pair3D) >> shift3D;
     const KeyType maxCoord = (static_cast<KeyType>(1) << bits[2]) - static_cast<KeyType>(1);
 
     /* Undo the per-level swap/complement performed by the 2D-Hilbert curve, mirroring decodeHilbert2D.
@@ -414,9 +448,9 @@ decodeHilbert(KeyType key, unsigned bx, unsigned by, unsigned bz) noexcept
     const int num2DLevels = bits[1] > bits[2] ? bits[1] - bits[2] : 0;
     for (int i = 0; i < num2DLevels; ++i)
     {
-        const auto quad    = static_cast<unsigned>((key2D >> (2 * i)) & 3u);
-        const unsigned xi  = (quad >> 1) & 1u;
-        const unsigned yi  = xi ^ (quad & 1u);
+        const auto quad   = static_cast<unsigned>((key2D >> (2 * i)) & 3u);
+        const unsigned xi = (quad >> 1) & 1u;
+        const unsigned yi = xi ^ (quad & 1u);
         if (yi == 0)
         {
             KeyType tmp = x3d;

--- a/domain/include/cstone/sfc/hilbert.hpp
+++ b/domain/include/cstone/sfc/hilbert.hpp
@@ -422,8 +422,10 @@ decodeHilbert(KeyType key, unsigned bx, unsigned by, unsigned bz) noexcept
         const auto quad = static_cast<unsigned>((key2D >> (2 * i)) & 3u);
         util::tuple<KeyType, KeyType, KeyType> result;
         if (quad == 0) result      = permute0(x3d, y3d, z3d);
-        else if (quad == 1) result = permute1(x3d, y3d, z3d);
-        else if (quad == 2) result = permute2(x3d, y3d, z3d);
+        else if (quad == 1 && i % 2 == 0) result = permute1(x3d, y3d, z3d);
+        else if (quad == 1 && i % 2 == 1) result = {x3d, y3d, z3d};
+        else if (quad == 2 && i % 2 == 0) result = permute2(x3d, y3d, z3d);
+        else if (quad == 2 && i % 2 == 1) result = {x3d, y3d, z3d};
         else result                = permute3(x3d, y3d, z3d);
         x3d = get<0>(result);
         y3d = get<1>(result);

--- a/domain/include/cstone/sfc/hilbert.hpp
+++ b/domain/include/cstone/sfc/hilbert.hpp
@@ -24,8 +24,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include "cstone/util/tuple.hpp"
 #include "morton.hpp"
 
@@ -210,7 +208,7 @@ iHilbert(unsigned px, unsigned py, unsigned pz, unsigned bx, unsigned by, unsign
     assert(sortedCoordinates[1] < (static_cast<KeyType>(1) << bits[2]));
 
     // encode remaining bits[0] == min(bx,by,bz) 3D levels or octal digits with 3D-Hilbert and add to key
-    const KeyType key3D = iHilbert3D<KeyType>(sortedCoordinates[0], sortedCoordinates[1], sortedCoordinates[2]);
+    const KeyType key3D = iHilbert3D<KeyType>(sortedCoordinates[0], sortedCoordinates[1], sortedCoordinates[2], bits[2]);
     key |= key3D;
     // Example for (bx,by,bz) = (10,9,7): 1D,2D,2D,3D*7
 
@@ -382,11 +380,10 @@ decodeHilbert(KeyType key, unsigned bx, unsigned by, unsigned bz) noexcept
         }
         key &= (static_cast<KeyType>(1) << (3 * bits[1])) - 1;
     }
+    KeyType key2D{};
     if (bits[1] > bits[2]) // 2 dims have more bits than the 3rd, add 2D levels
     {
         const int n = bits[1] - bits[2];
-        // const auto key2D  = key >> (3 * bits[2]);
-        KeyType key2D{};
         for (int i{}; i < n; ++i)
         {
             const auto processes2DKeyBitIndex      = n - 1 - i;
@@ -399,11 +396,43 @@ decodeHilbert(KeyType key, unsigned bx, unsigned by, unsigned bz) noexcept
         coordinates[1] |= (get<1>(pair2D) & ((static_cast<KeyType>(1) << n) - 1)) << bits[2];
         key &= (static_cast<KeyType>(1) << (3 * bits[2])) - 1;
     }
+    const auto shift3D     = maxTreeLevel<KeyType>{} - bits[2];
+    const auto pair3D      = decodeHilbert3D<KeyType>(key << (3 * shift3D));
+    KeyType   x3d          = get<0>(pair3D) >> shift3D;
+    KeyType   y3d          = get<1>(pair3D) >> shift3D;
+    KeyType   z3d          = get<2>(pair3D) >> shift3D;
+    const KeyType maxCoord = (static_cast<KeyType>(1) << bits[2]) - static_cast<KeyType>(1);
 
-    const auto pair3D = decodeHilbert3D<KeyType>(key);
-    coordinates[0] |= get<0>(pair3D);
-    coordinates[1] |= get<1>(pair3D);
-    coordinates[2] |= get<2>(pair3D);
+    auto permute0 = [](KeyType x, KeyType y, KeyType z) {
+        return util::tuple<KeyType, KeyType, KeyType>{y, x, z};
+    };
+    auto permute1 = [](KeyType x, KeyType y, KeyType z) {
+        return util::tuple<KeyType, KeyType, KeyType>{x, z, y};
+    };
+    auto permute2 = [](KeyType x, KeyType y, KeyType z) {
+        return util::tuple<KeyType, KeyType, KeyType>{x, z, y};
+    };
+    auto permute3 = [maxCoord](KeyType x, KeyType y, KeyType z) {
+        return util::tuple<KeyType, KeyType, KeyType>{maxCoord - y, maxCoord - x, z};
+    };
+
+    const int num2DLevels = bits[1] > bits[2] ? bits[1] - bits[2] : 0;
+    for (int i = 0; i < num2DLevels; ++i)
+    {
+        const auto quad = static_cast<unsigned>((key2D >> (2 * i)) & 3u);
+        util::tuple<KeyType, KeyType, KeyType> result;
+        if (quad == 0) result      = permute0(x3d, y3d, z3d);
+        else if (quad == 1) result = permute1(x3d, y3d, z3d);
+        else if (quad == 2) result = permute2(x3d, y3d, z3d);
+        else result                = permute3(x3d, y3d, z3d);
+        x3d = get<0>(result);
+        y3d = get<1>(result);
+        z3d = get<2>(result);
+    }
+
+    coordinates[0] |= x3d;
+    coordinates[1] |= y3d;
+    coordinates[2] |= z3d;
 
     KeyType returnCoordinates[3]      = {0, 0, 0};
     returnCoordinates[permutation[0]] = coordinates[0];

--- a/domain/include/cstone/sfc/hilbert.hpp
+++ b/domain/include/cstone/sfc/hilbert.hpp
@@ -403,33 +403,31 @@ decodeHilbert(KeyType key, unsigned bx, unsigned by, unsigned bz) noexcept
     KeyType   z3d          = get<2>(pair3D) >> shift3D;
     const KeyType maxCoord = (static_cast<KeyType>(1) << bits[2]) - static_cast<KeyType>(1);
 
-    auto permute0 = [](KeyType x, KeyType y, KeyType z) {
-        return util::tuple<KeyType, KeyType, KeyType>{y, x, z};
-    };
-    auto permute1 = [](KeyType x, KeyType y, KeyType z) {
-        return util::tuple<KeyType, KeyType, KeyType>{x, z, y};
-    };
-    auto permute2 = [](KeyType x, KeyType y, KeyType z) {
-        return util::tuple<KeyType, KeyType, KeyType>{x, z, y};
-    };
-    auto permute3 = [maxCoord](KeyType x, KeyType y, KeyType z) {
-        return util::tuple<KeyType, KeyType, KeyType>{maxCoord - y, maxCoord - x, z};
-    };
-
+    /* Undo the per-level swap/complement performed by the 2D-Hilbert curve, mirroring decodeHilbert2D.
+     * iHilbert2D appends 2 bits per level: high bit = xi, low bit = xi ^ yi (see the `2*xi + (xi^yi)`
+     * term in iHilbert2D). decodeHilbert2D recovers (xi, yi) from those two bits (sa = xi, sa^sb = yi)
+     * and, whenever yi == 0, swaps its running (x, y) accumulator and, if xi == 1, complements it.
+     * The same (xi, yi) pair also determines which orientation the 3D sub-cube was reached in, so the
+     * identical swap/complement must be undone here on (x3d, y3d) - z3d is untouched, exactly as z is
+     * left untouched by iHilbert2D. Levels are processed from i = 0 (finest, adjacent to the 3D suffix)
+     * out to the coarsest 2D level, i.e. the reverse order in which iHilbert encoded them. */
     const int num2DLevels = bits[1] > bits[2] ? bits[1] - bits[2] : 0;
     for (int i = 0; i < num2DLevels; ++i)
     {
-        const auto quad = static_cast<unsigned>((key2D >> (2 * i)) & 3u);
-        util::tuple<KeyType, KeyType, KeyType> result;
-        if (quad == 0) result      = permute0(x3d, y3d, z3d);
-        else if (quad == 1 && i % 2 == 0) result = permute1(x3d, y3d, z3d);
-        else if (quad == 1 && i % 2 == 1) result = {x3d, y3d, z3d};
-        else if (quad == 2 && i % 2 == 0) result = permute2(x3d, y3d, z3d);
-        else if (quad == 2 && i % 2 == 1) result = {x3d, y3d, z3d};
-        else result                = permute3(x3d, y3d, z3d);
-        x3d = get<0>(result);
-        y3d = get<1>(result);
-        z3d = get<2>(result);
+        const auto quad    = static_cast<unsigned>((key2D >> (2 * i)) & 3u);
+        const unsigned xi  = (quad >> 1) & 1u;
+        const unsigned yi  = xi ^ (quad & 1u);
+        if (yi == 0)
+        {
+            KeyType tmp = x3d;
+            x3d         = y3d;
+            y3d         = tmp;
+            if (xi == 1)
+            {
+                x3d = maxCoord - x3d;
+                y3d = maxCoord - y3d;
+            }
+        }
     }
 
     coordinates[0] |= x3d;

--- a/domain/include/cstone/sfc/hilbert.hpp
+++ b/domain/include/cstone/sfc/hilbert.hpp
@@ -182,38 +182,32 @@ iHilbert(unsigned px, unsigned py, unsigned pz, unsigned bx, unsigned by, unsign
         const int n        = bits[1] - bits[2];
         const KeyType mask = (static_cast<KeyType>(1) << bits[2]) - 1;
 
-        /* Inline version of iHilbert2D's own recursion, run on the high (2D-prefix) bits to compute
-         * key2D exactly as iHilbert2D<KeyType>(hiX, hiY, n) would. In addition, the identical
-         * swap/complement that iHilbert2D applies to (hiX, hiY) at each level is also applied here to
-         * the low (to-be-3D-encoded) bits (lowX, lowY), so that by the time we reach the 3D-Hilbert
-         * suffix, its coordinates are expressed in the orientation implied by the 2D digits - this is
-         * the forward counterpart of the rotation that decodeHilbert() undoes. z is left untouched,
-         * exactly as iHilbert2D never touches a third coordinate. */
-        KeyType hiX  = sortedCoordinates[0] >> bits[2];
-        KeyType hiY  = sortedCoordinates[1] >> bits[2];
+        /* key2D is computed by the real iHilbert2D, exactly as before. Each of its 2-bit digits is
+         * `2*xi + (xi^yi)` (see iHilbert2D), i.e. it already encodes (xi, xi^yi) for that level, so
+         * (xi, yi) can be recovered directly from key2D's own bits without duplicating iHilbert2D's
+         * recursion. Using that, apply the identical swap/complement that iHilbert2D performs on
+         * (hiX, hiY) internally to the low (to-be-3D-encoded) bits (lowX, lowY) instead, so that by the
+         * time we reach the 3D-Hilbert suffix, its coordinates are expressed in the orientation implied
+         * by the 2D digits - this is the forward counterpart of the rotation that decodeHilbert() undoes.
+         * z is left untouched, exactly as iHilbert2D never touches a third coordinate. Levels are
+         * processed from n-1 (coarsest, decided first by iHilbert2D) down to 0 (finest, adjacent to the
+         * 3D suffix), matching iHilbert2D's own descent order. */
+        const KeyType key2D = iHilbert2D<KeyType>(sortedCoordinates[0] >> bits[2], sortedCoordinates[1] >> bits[2], n);
+
         KeyType lowX = sortedCoordinates[0] & mask;
         KeyType lowY = sortedCoordinates[1] & mask;
-
-        KeyType key2D = 0;
         for (int level = n - 1; level >= 0; --level)
         {
-            const unsigned xi = static_cast<unsigned>((hiX >> level) & KeyType{1});
-            const unsigned yi = static_cast<unsigned>((hiY >> level) & KeyType{1});
-
-            key2D = 4 * key2D + 2 * xi + (xi ^ yi); // append two bits to key2D, same as iHilbert2D
-
+            const auto quad   = static_cast<unsigned>((key2D >> (2 * level)) & 3u);
+            const unsigned xi = (quad >> 1) & 1u;
+            const unsigned yi = xi ^ (quad & 1u);
             if (yi == 0)
             {
-                KeyType tmpHi  = hiX;
-                hiX            = hiY;
-                hiY            = tmpHi;
-                KeyType tmpLow = lowX;
-                lowX           = lowY;
-                lowY           = tmpLow;
+                KeyType tmp = lowX;
+                lowX        = lowY;
+                lowY        = tmp;
                 if (xi == 1)
                 {
-                    hiX  = ~hiX;
-                    hiY  = ~hiY;
                     lowX = mask - lowX;
                     lowY = mask - lowY;
                 }

--- a/domain/python/cstone_sfc_bindings.cpp
+++ b/domain/python/cstone_sfc_bindings.cpp
@@ -112,9 +112,9 @@ NB_MODULE(cstone_sfc, m)
         "maxTreeLevel",
         [](const std::string& keyType) -> unsigned
         {
-            return dispatchKeyType(keyType, []<class KeyType>() -> unsigned {
-                return static_cast<unsigned>(cstone::maxTreeLevel<cstone::HilbertKey<KeyType>>{});
-            });
+            return dispatchKeyType(
+                keyType, []<class KeyType>() -> unsigned
+                { return static_cast<unsigned>(cstone::maxTreeLevel<cstone::HilbertKey<KeyType>>{}); });
         },
         nb::arg("key_type") = "uint64_t",
         "Max octree depth supported by the selected key type ('uint64_t' or 'unsigned')");
@@ -125,10 +125,12 @@ NB_MODULE(cstone_sfc, m)
         {
             validateBox(boxLimits);
             const auto box = makeBox(boxLimits);
-            return dispatchKeyType(keyType, [&box]<class KeyType>() -> std::array<unsigned, 3> {
-                const auto bits = box.getBoxDimBits(cstone::maxTreeLevel<KeyType>{});
-                return {bits[0], bits[1], bits[2]};
-            });
+            return dispatchKeyType(keyType,
+                                   [&box]<class KeyType>() -> std::array<unsigned, 3>
+                                   {
+                                       const auto bits = box.getBoxDimBits(cstone::maxTreeLevel<KeyType>{});
+                                       return {bits[0], bits[1], bits[2]};
+                                   });
         },
         nb::arg("box_limits"), nb::arg("key_type") = "uint64_t",
         "Return (bx, by, bz) for a physical box [xmin, xmax, ymin, ymax, zmin, zmax]");
@@ -138,10 +140,12 @@ NB_MODULE(cstone_sfc, m)
         [](unsigned px, unsigned py, unsigned pz, unsigned bx, unsigned by, unsigned bz, const std::string& keyType)
         {
             const cstone::AxesBits axesBits{bx, by, bz};
-            return dispatchKeyType(keyType, [&, bx, by, bz]<class KeyType>() -> std::uint64_t {
-                validateBits<KeyType>(axesBits);
-                return std::uint64_t(cstone::iHilbert<KeyType>(px, py, pz, bx, by, bz));
-            });
+            return dispatchKeyType(keyType,
+                                   [&, bx, by, bz]<class KeyType>() -> std::uint64_t
+                                   {
+                                       validateBits<KeyType>(axesBits);
+                                       return std::uint64_t(cstone::iHilbert<KeyType>(px, py, pz, bx, by, bz));
+                                   });
         },
         nb::arg("px"), nb::arg("py"), nb::arg("pz"), nb::arg("bx"), nb::arg("by"), nb::arg("bz"),
         nb::arg("key_type") = "uint64_t",
@@ -152,12 +156,14 @@ NB_MODULE(cstone_sfc, m)
         [](std::uint64_t key, unsigned bx, unsigned by, unsigned bz, const std::string& keyType)
         {
             const cstone::AxesBits axesBits{bx, by, bz};
-            return dispatchKeyType(keyType, [&, key, bx, by, bz]<class KeyType>() -> std::array<unsigned, 3> {
-                validateBits<KeyType>(axesBits);
-                validateKeyValue<KeyType>(key);
-                auto [px, py, pz] = cstone::decodeHilbert<KeyType>(KeyType(key), bx, by, bz);
-                return {px, py, pz};
-            });
+            return dispatchKeyType(keyType,
+                                   [&, key, bx, by, bz]<class KeyType>() -> std::array<unsigned, 3>
+                                   {
+                                       validateBits<KeyType>(axesBits);
+                                       validateKeyValue<KeyType>(key);
+                                       auto [px, py, pz] = cstone::decodeHilbert<KeyType>(KeyType(key), bx, by, bz);
+                                       return {px, py, pz};
+                                   });
         },
         nb::arg("key"), nb::arg("bx"), nb::arg("by"), nb::arg("bz"), nb::arg("key_type") = "uint64_t",
         "Decode a mixed-dimension Hilbert key into (px, py, pz) for the selected key type");
@@ -167,16 +173,19 @@ NB_MODULE(cstone_sfc, m)
         [](std::uint64_t key, unsigned level, unsigned bx, unsigned by, unsigned bz, const std::string& keyType)
         {
             const cstone::AxesBits axesBits{bx, by, bz};
-            return dispatchKeyType(keyType, [&, key, level, bx, by, bz]<class KeyType>() -> std::array<int, 6> {
-                validateBits<KeyType>(axesBits);
-                if (level > cstone::maxTreeLevel<KeyType>{})
+            return dispatchKeyType(
+                keyType,
+                [&, key, level, bx, by, bz]<class KeyType>() -> std::array<int, 6>
                 {
-                    throw std::invalid_argument("level must be <= maxTreeLevel for the selected key_type");
-                }
-                validateKeyValue<KeyType>(key);
-                auto ibox = cstone::hilbertIBox<KeyType>(KeyType(key), level, bx, by, bz);
-                return {ibox.xmin(), ibox.xmax(), ibox.ymin(), ibox.ymax(), ibox.zmin(), ibox.zmax()};
-            });
+                    validateBits<KeyType>(axesBits);
+                    if (level > cstone::maxTreeLevel<KeyType>{})
+                    {
+                        throw std::invalid_argument("level must be <= maxTreeLevel for the selected key_type");
+                    }
+                    validateKeyValue<KeyType>(key);
+                    auto ibox = cstone::hilbertIBox<KeyType>(KeyType(key), level, bx, by, bz);
+                    return {ibox.xmin(), ibox.xmax(), ibox.ymin(), ibox.ymax(), ibox.zmin(), ibox.zmax()};
+                });
         },
         nb::arg("key"), nb::arg("level"), nb::arg("bx"), nb::arg("by"), nb::arg("bz"), nb::arg("key_type") = "uint64_t",
         "Return MixD integer box [xmin, xmax, ymin, ymax, zmin, zmax] for key and level-from-right");
@@ -189,10 +198,12 @@ NB_MODULE(cstone_sfc, m)
             validateBox(boxLimits);
             const auto ibox = makeIBox(iboxLimits);
             const auto box  = makeBox(boxLimits);
-            return dispatchKeyType(keyType, [&ibox, &box]<class KeyType>() {
-                auto [center, size] = cstone::centerAndSize<KeyType>(ibox, box);
-                return std::make_pair(toStdArray(center), toStdArray(size));
-            });
+            return dispatchKeyType(keyType,
+                                   [&ibox, &box]<class KeyType>()
+                                   {
+                                       auto [center, size] = cstone::centerAndSize<KeyType>(ibox, box);
+                                       return std::make_pair(toStdArray(center), toStdArray(size));
+                                   });
         },
         nb::arg("ibox_limits"), nb::arg("box_limits"), nb::arg("key_type") = "uint64_t",
         "Compute center and half-size from integer box and physical box");

--- a/domain/test/unit/sfc/mixed_hilbert.cpp
+++ b/domain/test/unit/sfc/mixed_hilbert.cpp
@@ -33,14 +33,16 @@ TEST(MixedHilbertBox, x10y9z9)
     for (int i = 0; i < numKeys; ++i)
     {
         auto hilbertMixDKey = iHilbert<unsigned>(x_le_511[i], y[i], z[i], bx, by, bz);
-        auto hilbertKey     = iHilbert3D<unsigned>(x_le_511[i], y[i], z[i]);
+        auto hilbertKey     = iHilbert3D<unsigned>(x_le_511[i], y[i], z[i], std::min({bx, by, bz}));
         EXPECT_EQ(hilbertMixDKey, hilbertKey);
     };
 
     for (int i = 0; i < numKeys; ++i)
     {
-        auto hilbertMixDKey      = iHilbert<unsigned>(x_ge_512[i], y[i], z[i], bx, by, bz);
-        auto hilbertKey_px_m_512 = iHilbert3D<unsigned>(x_ge_512[i] - 512, y[i], z[i]);
+        auto hilbertMixDKey = iHilbert<unsigned>(x_ge_512[i], y[i], z[i], bx, by, bz);
+        // min(bx, by, bz) = 9, so the 3D-Hilbert suffix is computed with 9 bits per dimension which is enough for
+        // (x_ge_512[i] - 512) as well
+        auto hilbertKey_px_m_512 = iHilbert3D<unsigned>(x_ge_512[i] - 512, y[i], z[i], std::min({bx, by, bz}));
         EXPECT_EQ(hilbertMixDKey, (1 << 27) + hilbertKey_px_m_512);
     };
 }
@@ -75,45 +77,64 @@ TEST(MixedHilbertBox, x10y10z9)
     std::generate(begin(y_ge_512), end(y_ge_512), getRandYge512);
     std::generate(begin(z), end(z), getRandZ);
 
+    // quadrant (0,0): the single 2D-level digit is 0, and since yi == 0 the low bits (which feed the
+    // 3D-Hilbert suffix) get swapped - see the inline recursion in iHilbert() - so x and y trade places
     for (int i = 0; i < numKeys; ++i)
     {
         auto hilbertMixDKey = iHilbert<unsigned>(x_le_511[i], y_le_511[i], z[i], bx, by, bz);
-        auto hilbertKey     = iHilbert3D<unsigned>(x_le_511[i], y_le_511[i], z[i]);
+        auto hilbertKey     = iHilbert3D<unsigned>(y_le_511[i], x_le_511[i], z[i], bz);
 
         EXPECT_EQ(hilbertMixDKey, hilbertKey);
     };
 
+    // quadrant (0,1): digit 1, yi == 1, so no swap/complement of the low bits
     for (int i = 0; i < numKeys; ++i)
     {
         auto hilbertMixDKey      = iHilbert<unsigned>(x_le_511[i], y_ge_512[i], z[i], bx, by, bz);
-        auto hilbertKey_py_m_512 = iHilbert3D<unsigned>(x_le_511[i], y_ge_512[i] - 512, z[i]);
+        auto hilbertKey_py_m_512 = iHilbert3D<unsigned>(x_le_511[i], y_ge_512[i] - 512, z[i], bz);
 
         EXPECT_EQ(hilbertMixDKey, (1 << 27) + hilbertKey_py_m_512);
     };
 
+    // quadrant (1,1): digit 2, yi == 1, so no swap/complement of the low bits
     for (int i = 0; i < numKeys; ++i)
     {
         auto hilbertMixDKey      = iHilbert<unsigned>(x_ge_512[i], y_ge_512[i], z[i], bx, by, bz);
-        auto hilbertKey_py_m_512 = iHilbert3D<unsigned>(x_ge_512[i] - 512, y_ge_512[i] - 512, z[i]);
+        auto hilbertKey_py_m_512 = iHilbert3D<unsigned>(x_ge_512[i] - 512, y_ge_512[i] - 512, z[i], bz);
 
         EXPECT_EQ(hilbertMixDKey, (2 << 27) + hilbertKey_py_m_512);
     };
 
+    // quadrant (1,0): digit 3, yi == 0 and xi == 1, so the low bits get swapped *and* complemented
+    // (mask = 511 for bz = 9 bits)
     for (int i = 0; i < numKeys; ++i)
     {
-        auto hilbertMixDKey      = iHilbert<unsigned>(x_ge_512[i], y_ge_512[i], z[i], bx, by, bz);
-        auto hilbertKey_py_m_512 = iHilbert3D<unsigned>(x_ge_512[i] - 512, y_ge_512[i] - 512, z[i]);
+        auto hilbertMixDKey = iHilbert<unsigned>(x_ge_512[i], y_le_511[i], z[i], bx, by, bz);
+        auto hilbertKey_rot = iHilbert3D<unsigned>(511 - y_le_511[i], 1023 - x_ge_512[i], z[i], bz);
 
-        EXPECT_EQ(hilbertMixDKey, (2 << 27) + hilbertKey_py_m_512);
+        EXPECT_EQ(hilbertMixDKey, (3 << 27) + hilbertKey_rot);
     };
 
     // clang-format off
-    // iHilbert(px in [0:512], py in [0:512], pz, bx, by, bz)       == iHilbert3D(px, py, pz) >> 3
-    // iHilbert(px in [0:512], py in [512:1024], pz, bx, by, bz)    == 01000000000 (=8^9) + (iHilbert3D(px, py - 512, pz) >> 3)
-    // iHilbert(px in [512:1024], py in [512:1024], pz, bx, by, bz) == 02000000000 (=8^9) + (iHilbert3D(px - 512, py - 512, pz) >> 3)
-    // IM: Can't understand below since inputs to the functions are the same as the 2nd case
-    // iHilbert(px in [0:512], py in [512:1024], pz, bx, by, bz)    == 03000000000 (=8^9) + (iHilbert3D(px, py - 512, pz) >> 3)
+    // iHilbert(px in [0:512], py in [0:512], pz, bx, by, bz)       == iHilbert3D(py, px, pz, bz)              (x,y swapped)
+    // iHilbert(px in [0:512], py in [512:1024], pz, bx, by, bz)    == 01000000000 (=8^9) + iHilbert3D(px, py - 512, pz, bz)
+    // iHilbert(px in [512:1024], py in [512:1024], pz, bx, by, bz) == 02000000000 (=8^9) + iHilbert3D(px - 512, py - 512, pz, bz)
+    // iHilbert(px in [512:1024], py in [0:512], pz, bx, by, bz)    == 03000000000 (=8^9) + iHilbert3D(511 - py, 1023 - px, pz, bz)
     // clang-format on
+
+    // round-trip sanity check across all 4 quadrants, independent of the hand-derived formulas above
+    for (int i = 0; i < numKeys; ++i)
+    {
+        for (auto [xv, yv] : {std::pair{x_le_511[i], y_le_511[i]}, std::pair{x_le_511[i], y_ge_512[i]},
+                              std::pair{x_ge_512[i], y_ge_512[i]}, std::pair{x_ge_512[i], y_le_511[i]}})
+        {
+            auto key          = iHilbert<unsigned>(xv, yv, z[i], bx, by, bz);
+            auto [xr, yr, zr] = decodeHilbert<unsigned>(key, bx, by, bz);
+            EXPECT_EQ(xv, xr);
+            EXPECT_EQ(yv, yr);
+            EXPECT_EQ(z[i], zr);
+        }
+    }
 }
 
 //! @brief tests numKeys random 3D points for encoding/decoding consistency
@@ -194,4 +215,3 @@ TEST(MixedHilbertEncoding, validMixDKey)
     EXPECT_FALSE(isValidHilbertMixDKey(decodePlaceholderBit(KeyType(01147)), l, l - 1, l - 2));
     EXPECT_FALSE(isValidHilbertMixDKey(decodePlaceholderBit(KeyType(01237)), l, l - 1, l - 2));
 }
-

--- a/domain/test/unit/traversal/collisions_a2a.cpp
+++ b/domain/test/unit/traversal/collisions_a2a.cpp
@@ -95,7 +95,7 @@ public:
 
         const auto axesBits       = box.getBoxDimBits(maxTreeLevel<KeyType>{});
         std::vector<KeyType> keys = makeRandomGaussianKeys<KeyType>(numParticles, 42, axesBits);
-        auto [tree, counts] = computeOctree<KeyType>(keys, 4);
+        auto [tree, counts]       = computeOctree<KeyType>(keys, 4);
 
         OctreeData<KeyType, execution::Cpu> octree;
         octree.resize(nNodes(tree));

--- a/domain/test/unit/traversal/traversal.cpp
+++ b/domain/test/unit/traversal/traversal.cpp
@@ -136,8 +136,8 @@ void dualTraversalNeighbors()
 
     auto crossFocusSurfacePairs = [focusStart, focusEnd, &tree = octree, &box](TreeNodeIndex a, TreeNodeIndex b)
     {
-        auto [ka1, ka2] = decodePlaceholderBit2K(tree.prefixes[a]);
-        auto [kb1, kb2] = decodePlaceholderBit2K(tree.prefixes[b]);
+        auto [ka1, ka2]    = decodePlaceholderBit2K(tree.prefixes[a]);
+        auto [kb1, kb2]    = decodePlaceholderBit2K(tree.prefixes[b]);
         bool aFocusOverlap = overlapTwoRanges(focusStart, focusEnd, ka1, ka2);
         bool bInFocus      = containedIn(kb1, kb2, focusStart, focusEnd);
         if (!aFocusOverlap || bInFocus) { return false; }


### PR DESCRIPTION
The current mixed dimension SFC is not continuous in space. There can be jumps from node to node of the tree longer than the minimum distance between two nodes across the whole tree as shown in the plot below that plots the centers of a range of nodes as well as their connections between them based on their ascending order.
<img width="1253" height="1044" alt="image" src="https://github.com/user-attachments/assets/1149a1b9-9af8-4450-ba9d-50972e696be6" />

With the proposed change we rotate the coordinates in the encoding and the key bits in the decoding of the MixD Hilbert key in the same way the `iHilbert2D` function encodes a 2D key. This is essential to "rotate" the generated 3D Hilbert SFC in such way that we manage to get a continuous curve. See image below:
<img width="1253" height="1044" alt="image" src="https://github.com/user-attachments/assets/17aefa6b-3aa2-408f-a1ad-4bd997fe8947" />
The comparison of the changes in this PR (annotated below as `MixD`) to the current `develop` for the `Kelvin Helmholtz` test case on 16 GPUs is shown below:
```
Run:     kelvin_r16_c1_s200_n100_gpu
MixD    numHalos sum : 1,931,764,058
Develop numHalos sum : 1,941,453,448
Ratio   MixD / Dev   : 0.995009
MixD    numHalos max : 919,654
Develop numHalos max : 920,310
MaxRatio MixD / Dev  : 0.999287

=== Timing Comparison: MixD vs develop  [KELVIN / GPU]  (summed over all steps) ===
─────────────────────────────────────────────────────────────────────────────────────────────────
Category                                          MixD (s)  Develop (s)     Diff (s)     Diff (%)
─────────────────────────────────────────────────────────────────────────────────────────────────
domain::sync                                         8.035        8.429       -0.394         -4.7
computeGroups                                        0.384        0.376       +0.009         +2.3
updateSmoothingLengthIterative                       7.942        7.930       +0.012         +0.1
FindNeighbors                                        8.050        8.069       -0.018         -0.2
XMass                                                2.919        2.920       -0.001         -0.0
mpi::synchronizeHalos                                3.736        3.899       -0.163         -4.2
Generalized Volume Elements                          2.841        2.840       +0.000         +0.0
IadVelocityDivCurlGradh                             15.462       15.351       +0.112         +0.7
EquationOfState                                      0.034        0.033       +0.001         +2.2
AVswitches                                           7.499        7.471       +0.027         +0.4
MomentumAndEnergy                                   16.237       16.220       +0.017         +0.1
Timestep                                             1.222        1.181       +0.040         +3.4
UpdateQuantities                                     0.115        0.114       +0.001         +0.9
Total time reported                                 83.474       84.294       -0.819         -1.0
─────────────────────────────────────────────────────────────────────────────────────────────────
```
The continuous curve has as a result the (minimal) decrease in the number of halos as particles that are close in space are more likely to be in adjacent tree nodes.